### PR TITLE
Links the styleguide to the theme

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,16 +4,35 @@
 
 
     <import file="vendor/palantirnet/the-build/tasks/boilerplate.xml" />
+    <import file="build/styleguide.xml" />
 
 
     <!-- Make these commands available by default. -->
     <import file="vendor/palantirnet/the-build/tasks/drupal.xml" />
     <import file="vendor/palantirnet/the-build/tasks/acquia.xml" />
 
-
     <!-- Default target: build -->
     <target name="build" description="Build the application.">
         <phingcall target="drupal-build" />
+        <resolvepath propertyName="styleguide.dir.absolute_path" file="${styleguide.dir}" />
+
+        <resolvepath propertyname="styleguide_code" file="${styleguide.dir}/source/code" />
+
+        <!-- Define custom theme -->
+        <resolvepath propertyname="custom_theme" file="${drupal.root}/themes/custom/hatter" />
+        <phingcall target="styleguide-link">
+            <property name="css_source" value="${styleguide_code}/css" />
+            <property name="css_dest" value="${custom_theme}/css" />
+
+            <property name="svg_source" value="${styleguide_code}/_views/includes/svg" />
+            <property name="svg_dest" value="${custom_theme}/svg" />
+
+            <property name="js_source" value="${styleguide_code}/js" />
+            <property name="js_dest" value="${custom_theme}/js" />
+
+            <property name="imgs_source" value="${styleguide_code}/imgs" />
+            <property name="imgs_dest" value="${custom_theme}/imgs" />
+        </phingcall>
     </target>
 
 

--- a/build/styleguide.xml
+++ b/build/styleguide.xml
@@ -1,0 +1,270 @@
+<project name="Styleguide" default="styleguide-generate">
+    <!--
+      Include this file in your build.xml with:
+        <import file="vendor/palantirnet/the-build/tasks/styleguide.xml" />
+      -->
+
+    <fail unless="projectname" />
+    <fail unless="build.dir" />
+    <fail unless="build.env" />
+
+
+    <!--
+        Target: configure
+
+        Interactive configuration to set the styleguide build properties.
+        -->
+    <target name="styleguide-configure" description="Configure the styleguide build.">
+        <phing phingfile="${phing.dir.boilerplate}/configure.xml" inheritAll="false" dir="${build.dir}">
+            <property name="build.env" value="${build.env}" />
+            <property name="build.dir" value="${build.dir}" />
+
+            <property name="prompt.styleguide.dir" value="Styleguide directory, relative to the project root." />
+            <property name="default.styleguide.dir" value="styleguide" />
+
+            <property name="prompt.styleguide.repo" value="Git repository for the rendered styleguide" />
+            <property name="default.styleguide.repo" value="git@github.com:palantirnet/${projectname}.git" />
+
+            <property name="prompt.styleguide.branch" value="Branch of the git repository to use" />
+            <property name="default.styleguide.branch" value="gh-pages" />
+
+            <property name="prompt.styleguide.env" value="Environment to use when rendering sass and sculpin (dev, prod)" />
+            <property name="default.styleguide.env" value="dev" />
+
+            <property name="update" value="styleguide.dir,styleguide.repo,styleguide.branch,styleguide.env" />
+        </phing>
+    </target>
+
+
+    <!--
+        Target: styleguide-build
+
+        Generate and deploy the prod styleguide CSS and HTML.
+        -->
+    <target name="styleguide-build" description="Build and deploy the current styleguide.">
+        <!-- Always render for prod when doing a build. -->
+        <property name="styleguide.env" value="prod" override="true" />
+        <property name="styleguide.output_dir" value="${build.dir}/styleguide/output_${styleguide.env}" override="true" />
+
+        <phingcall target="styleguide-build-init" />
+        <phingcall target="styleguide-generate" />
+        <phingcall target="styleguide-build-deploy" />
+    </target>
+
+
+    <!--
+        Target: styleguide-generate
+
+        Can be run any time, for any environment. Defaults to generating "dev"
+        CSS and HTML.
+        -->
+    <target name="styleguide-generate">
+        <fail unless="styleguide.dir" />
+        <resolvepath propertyName="styleguide.dir.absolute_path" file="${styleguide.dir}" />
+        <property name="styleguide.env" value="dev" />
+
+        <exec command="vendor/bin/sculpin generate --project-dir=${styleguide.dir.absolute_path} --env=${styleguide.env}" checkreturn="true" />
+        <echo>Regenerated HTML.</echo>
+    </target>
+
+
+    <!--
+        Target: styleguide-build-init
+
+        Should only be run when building the styleguide for deployment. Note
+        that in this case, ${styleguide.env} == "prod", but ${build.env} might
+        be anything.
+        -->
+    <target name="styleguide-build-init">
+        <fail unless="styleguide.output_dir" />
+        <fail unless="styleguide.repo" />
+        <fail unless="styleguide.branch" />
+
+        <resolvepath propertyName="repo.dir" file="${styleguide.output_dir}" />
+
+        <if>
+            <not><equals arg1="${styleguide.env}" arg2="prod" /></not>
+            <then>
+                <fail msg="styleguide-build-init should only be run when building a prod styleguide artifact." />
+            </then>
+        </if>
+
+        <phing phingfile="${phing.dir.boilerplate}/lib/repositories.xml" target="init-repository" inheritAll="false" dir=".">
+            <property name="repo.dir" value="${repo.dir}" />
+            <property name="repo.source" value="${styleguide.repo}" />
+        </phing>
+
+        <phing phingfile="${phing.dir.boilerplate}/lib/repositories.xml" target="init-branch" inheritAll="false" dir=".">
+            <property name="repo.dir" value="${repo.dir}" />
+            <property name="repo.branch" value="${styleguide.branch}" />
+        </phing>
+    </target>
+
+
+    <!--
+        Target: styleguide-build-deploy
+
+        Commit and push current changes to the rendered styleguide. Should only
+        be run when building the styleguide for deployment.
+        -->
+    <target name="styleguide-build-deploy">
+        <fail unless="styleguide.env" />
+        <fail unless="styleguide.output_dir" />
+        <fail unless="styleguide.branch" />
+
+        <if>
+            <not><equals arg1="${styleguide.env}" arg2="prod" /></not>
+            <then>
+                <fail msg="styleguide-build-deploy should only be run when building a prod styleguide artifact." />
+            </then>
+        </if>
+
+        <phing target="commit" phingfile="${phing.dir.boilerplate}/lib/repositories.xml" inheritAll="false" dir=".">
+            <property name="build.dir" value="${build.dir}" />
+            <property name="repo.dir" value="${styleguide.output_dir}" />
+            <property name="message" value="Styleguide artifact." />
+        </phing>
+
+        <phing target="push" phingfile="${phing.dir.boilerplate}/lib/repositories.xml" inheritAll="false" dir=".">
+            <property name="repo.dir" value="${styleguide.output_dir}" />
+            <property name="repo.branch" value="${styleguide.branch}" />
+            <property name="push" value="${push}" />
+        </phing>
+    </target>
+
+
+    <!--
+        Target: styleguide-test
+        -->
+    <target name="styleguide-test" description="Run linters on the styleguide.">
+        <fail unless="styleguide.dir" />
+        <resolvepath propertyName="styleguide.dir.absolute_path" file="${styleguide.dir}" />
+        <property name="test.output_dir" value="/dev/null" />
+
+        <exec command="bundle exec scss-lint" dir="${styleguide.dir.absolute_path}" outputProperty="scss_lint.output" returnProperty="scss_lint.return" />
+
+        <!-- If an output dir was provided, dump the linter output there. -->
+        <if>
+            <available file="${test.output_dir}" type="dir" />
+            <then>
+                <mkdir dir="${test.output_dir}/scss-lint" />
+                <echo msg="${scss_lint.output}" file="${test.output_dir}/scss-lint/output.txt" />
+            </then>
+        </if>
+
+        <!-- Show the linter output and throw an error if linting didn't pass. -->
+        <if>
+            <not><equals arg1="${scss_lint.return}" arg2="0" /></not>
+            <then>
+                <fail msg="${scss_lint.output}" status="${scss_lint.return}" />
+            </then>
+        </if>
+    </target>
+
+
+    <!--
+        Target: fed-init
+
+        Install styleguide development dependencies. This is the same thing as
+        Butler's fed-init.sh, but not a shell script.
+        -->
+    <target name="fed-init" description="Install the Butler toolset in the styleguide.">
+        <fail unless="styleguide.dir" />
+        <resolvepath propertyName="styleguide.dir.absolute_path" file="${styleguide.dir}" />
+
+        <!-- Let's just put these default npm packages right here. -->
+        <property name="styleguide.npm_dependencies" value="browser-sync compass-options gulp gulp-autoprefixer gulp-changed gulp-compass gulp-cssmin gulp-imagemin gulp-inject gulp-jscs gulp-jscs-stylish gulp-jshint gulp-rename gulp-scss-lint gulp-sitespeedio gulp-uglify jshint-checkstyle-file-reporter" />
+
+        <!-- If there are bundler dependencies, install them. -->
+        <if>
+            <available file="${styleguide.dir.absolute_path}/Gemfile" type="file" />
+            <then>
+                <echo>Installing bundler dependencies.</echo>
+
+                <phingcall target="styleguide-check-commandline-dependency">
+                    <property name="dependency" value="bundle" />
+                </phingcall>
+
+                <exec command="bundle install" dir="${styleguide.dir.absolute_path}" checkreturn="true" outputProperty="bundle_install_output" />
+                <echo level="verbose">${bundle_install_output}</echo>
+            </then>
+        </if>
+
+        <!-- If there is a Gulpfile, install the npm dependencies. -->
+        <if>
+            <available file="${styleguide.dir.absolute_path}/Gulpfile.js" type="file" />
+            <then>
+                <echo>Installing npm dependencies.</echo>
+
+                <phingcall target="styleguide-check-commandline-dependency">
+                    <property name="dependency" value="npm" />
+                </phingcall>
+
+                <if>
+                    <available file="${styleguide.dir.absolute_path}/package.json" type="file" />
+                    <then>
+                        <exec command="npm install" dir="${styleguide.dir.absolute_path}" checkreturn="true" outputProperty="npm_install_output" />
+                        <echo level="verbose">${npm_install_output}</echo>
+                    </then>
+                    <else>
+                        <exec command="npm install --save-dev ${styleguide.npm_dependencies}" dir="${styleguide.dir.absolute_path}" checkreturn="true" outputProperty="npm_install_output" />
+                        <echo level="verbose">${npm_install_output}</echo>
+                        <echo level="warning">A `package.json` file for npm has been created. You should commit this to your repository, like, now.</echo>
+                    </else>
+                </if>
+            </then>
+        </if>
+    </target>
+
+
+    <!--
+        Target: styleguide-check-commandline-dependency
+
+        Verify that a CLI program (e.g. bundle, npm) is available.
+        -->
+    <target name="styleguide-check-commandline-dependency">
+        <fail unless="dependency" />
+
+        <exec command="command -v ${dependency}" returnProperty="has_dependency" />
+
+        <if>
+            <not><equals arg1="${has_dependency}" arg2="0" /></not>
+            <then>
+                <fail message="Missing command line dependency `${dependency}`." />
+            </then>
+        </if>
+    </target>
+
+
+    <!--
+        Target: styleguide-link-css
+
+        Link the styleguide css into the theme.
+        -->
+    <target name="styleguide-link">
+        <phing phingfile="${phing.dir.boilerplate}/lib/artifacts.xml" target="include-resource" inheritAll="false" dir=".">
+            <property name="artifact_mode" value="${build.artifact_mode}" />
+            <property name="resource_source" value="${css_source}" />
+            <property name="resource_dest" value="${css_dest}" />
+        </phing>
+
+        <phing phingfile="${phing.dir.boilerplate}/lib/artifacts.xml" target="include-resource" inheritAll="false" dir=".">
+            <property name="artifact_mode" value="${build.artifact_mode}" />
+            <property name="resource_source" value="${svg_source}" />
+            <property name="resource_dest" value="${svg_dest}" />
+        </phing>
+
+        <phing phingfile="${phing.dir.boilerplate}/lib/artifacts.xml" target="include-resource" inheritAll="false" dir=".">
+            <property name="artifact_mode" value="${build.artifact_mode}" />
+            <property name="resource_source" value="${js_source}" />
+            <property name="resource_dest" value="${js_dest}" />
+        </phing>
+
+        <phing phingfile="${phing.dir.boilerplate}/lib/artifacts.xml" target="include-resource" inheritAll="false" dir=".">
+            <property name="artifact_mode" value="${build.artifact_mode}" />
+            <property name="resource_source" value="${imgs_source}" />
+            <property name="resource_dest" value="${imgs_dest}" />
+        </phing>
+    </target>
+
+</project>

--- a/conf/build.default.properties
+++ b/conf/build.default.properties
@@ -14,3 +14,8 @@ drupal.settings.file_private_path=
 drupal.site_name=midcamp
 drupal.twig.debug=
 drupal.uri=http://midcamp.local
+
+styleguide.dir=styleguide
+styleguide.repo=git@github.com:midcamp/midcamp.git
+styleguide.branch=gh-pages
+styleguide.env=dev


### PR DESCRIPTION
This should now copy css, images and whatnot from the styleguide into the hatter theme when `vendor/bin/phing build` is run.