### PR TITLE
Add composer-install-elsewhere to the Pantheon deployment

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -53,7 +53,7 @@
     <!-- Target: deploy -->
     <target name="deploy" description="Deploy the code to Pantheon.">
         <phingcall target="madcamp-init-artifact-repository" />
-        <phingcall target="madcamp-copy-files-to-artifact" />
+        <phingcall target="madcamp-compose-artifact-files" />
         <phingcall target="madcamp-commit-artifact-changes" />
     </target>
 

--- a/build/madcamp.xml
+++ b/build/madcamp.xml
@@ -11,83 +11,46 @@
 
 
   <target name="madcamp-init-artifact-repository">
-    <fail unless="pantheon.repo" />
-    <fail unless="pantheon.branch" />
-    <fail unless="pantheon.dest" />
+      <phing target="init-repository" phingfile="vendor/palantirnet/the-build/tasks/lib/repositories.xml" inheritAll="false" dir=".">
+          <property name="repo.dir" value="${pantheon.repo.dir}" />
+          <property name="repo.source" value="${pantheon.repo.source}" />
+      </phing>
 
-    <phing target="init-repository" phingfile="vendor/palantirnet/the-build/tasks/lib/repositories.xml" inheritAll="false" dir=".">
-      <property name="repo.dir" value="${pantheon.dest}" />
-      <property name="repo.source" value="${pantheon.repo}" />
-    </phing>
-
-    <phing target="init-branch" phingfile="vendor/palantirnet/the-build/tasks/lib/repositories.xml" inheritAll="false" dir=".">
-      <property name="repo.dir" value="${pantheon.dest}" />
-      <property name="repo.branch" value="${pantheon.branch}" />
-    </phing>
+      <phing target="init-branch" phingfile="vendor/palantirnet/the-build/tasks/lib/repositories.xml" inheritAll="false" dir=".">
+          <property name="repo.dir" value="${pantheon.repo.dir}" />
+          <property name="repo.branch" value="${pantheon.repo.branch}" />
+      </phing>
   </target>
 
 
   <!-- @see the-build/tasks/lib/artifacts.xml:run-composer-elsewhere -->
-  <target name="madcamp-copy-files-to-artifact">
-    <fail unless="pantheon.dest" />
-    <fail unless="pantheon.source" />
+  <target name="madcamp-compose-artifact-files">
+      <phing target="run-composer-elsewhere" phingfile="vendor/palantirnet/the-build/tasks/lib/artifacts.xml" inheritAll="false" dir=".">
+          <property name="install_dir" value="${pantheon.repo.dir}" />
+          <property name="build.dir" value="${build.dir}" />
+          <property name="drupal.root" value="${pantheon.repo.dir}" />
+          <property name="drupal.sites_subdir" value="${drupal.sites_subdir}" />
 
-    <!-- Remove all the existing files so that we can install cleanly. -->
-    <delete includeemptydirs="true">
-      <fileset dir="${pantheon.dest}" excludes=".git,.git/**" />
-    </delete>
-
-    <!--
-        also, we need to manually copy the custom code into the artifact.
-        doing it based on what is checked in to git prevents us from
-        accidentally adding local files or settings.php in to the
-        build repository.
-
-        AND, drupal has applied permissions to the sites directory that
-        prevent us from writing to it, so we need to squash them.
-    <exec command="chmod 777 www/sites/default" dir="${build.dir}" />
-        -->
-
-    <tempfile property="tmpfile" destdir="${build.dir}/artifacts" />
-    <exec command="git ls-files" dir="${build.dir}/${pantheon.source}" output="${tmpfile}" />
-
-    <copy todir="${pantheon.dest}" overwrite="true" haltonerror="true">
-      <filelist dir="${build.dir}/${pantheon.source}" listfile="${tmpfile}" />
-    </copy>
-
-    <delete file="${tmpfile}" />
-
-    <!--
-        having git repositories in the vendor dir messes up the build
-        artifact, since the entire vendor dir gets checked in to the
-        artifact and git will automatically try to do submodules for git
-        directories like this. so we strip them.
-        -->
-    <delete includeemptydirs="true">
-      <fileset dir="${pantheon.dest}" defaultexcludes="false">
-        <include name="*/**/.git/**" />
-        <include name="*/**/.git" />
-      </fileset>
-    </delete>
+          <property name="drupal.root_name" value="" />
+          <property name="install_conf_dir" value="${install_dir}/private" />
+      </phing>
   </target>
 
 
   <target name="madcamp-commit-artifact-changes">
-    <fail unless="pantheon.dest" />
-    <fail unless="pantheon.tag_prefix" />
-    <fail unless="pantheon.branch" />
+      <phing target="commit" phingfile="vendor/palantirnet/the-build/tasks/lib/repositories.xml" inheritAll="false" dir=".">
+          <property name="build.dir" value="${build.dir}" />
+          <property name="repo.dir" value="${pantheon.repo.dir}" />
+          <property name="tag_prefix" value="${pantheon.repo.tag_prefix}" />
+          <property name="message" value="Drupal artifact." />
+      </phing>
 
-    <phing target="commit" phingfile="vendor/palantirnet/the-build/tasks/lib/repositories.xml" inheritAll="false" dir=".">
-      <property name="build.dir" value="${build.dir}" />
-      <property name="repo.dir" value="${pantheon.dest}" />
-      <property name="tag_prefix" value="${pantheon.tag_prefix}" />
-      <property name="message" value="Drupal artifact." />
-    </phing>
-
-    <phing target="push" phingfile="vendor/palantirnet/the-build/tasks/lib/repositories.xml" inheritAll="false" dir=".">
-      <property name="repo.dir" value="${pantheon.dest}" />
-      <property name="repo.branch" value="${pantheon.branch}" />
-    </phing>
+<!--
+      <phing target="push" phingfile="vendor/palantirnet/the-build/tasks/lib/repositories.xml" inheritAll="false" dir=".">
+          <property name="repo.dir" value="pantheon.repo.dir" />
+          <property name="repo.branch" value="pantheon.repo.branch" />
+      </phing>
+      -->
   </target>
 
 

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "drupal/linkicon": "^1.4",
         "drupal/mailchimp": "^1.2",
         "drupal/paragraphs": "^8.1",
-        "palantirnet/the-build": "dev-master"
+        "palantirnet/the-build": "dev-composer-install-elsewhere-flexibility"
     },
     "require-dev": {
         "behat/behat": "^3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "ac2b44a73f7bbb2fbb9463dbfa1b1f08",
-    "content-hash": "2f11bd43e7fa8653fd6a417639d956fb",
+    "hash": "68aa5e07521e26739a786ab118f55287",
+    "content-hash": "684a96411bb1e624087a4a91e2e4f204",
     "packages": [
         {
             "name": "codegyre/robo",
@@ -1147,6 +1147,42 @@
             }
         },
         {
+            "name": "drupal/coder",
+            "version": "8.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/klausi/coder.git",
+                "reference": "6d717e1a5a5dd592ebbeaafad11746849fb52532"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/klausi/coder/zipball/6d717e1a5a5dd592ebbeaafad11746849fb52532",
+                "reference": "6d717e1a5a5dd592ebbeaafad11746849fb52532",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": ">=2.5.1",
+                "symfony/yaml": ">=2.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=3.7"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Coder is a library to review Drupal code.",
+            "homepage": "https://www.drupal.org/project/coder",
+            "keywords": [
+                "code review",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2016-07-05 20:48:03"
+        },
+        {
             "name": "drupal/config_installer",
             "version": "8.1.3",
             "source": {
@@ -1780,7 +1816,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://ftp.drupal.org/files/projects/mailchimp-8.x-1.2.zip",
-                "reference": null,
+                "reference": "8.x-1.2",
                 "shasum": "01ffed8a4a1b9ecf0c4967afd74e3d7196ecfb72"
             },
             "require": {
@@ -2718,23 +2754,82 @@
             "time": "2016-04-19 13:41:41"
         },
         {
-            "name": "palantirnet/the-build",
-            "version": "dev-master",
+            "name": "nilportugues/php_todo",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "git@github.com:palantirnet/the-build.git",
-                "reference": "de0590b7d6b5a6e2b7d517d11a61921762d66cd2"
+                "url": "https://github.com/nilportugues/php_todo_finder.git",
+                "reference": "134ab0645771310f19758d641e8018cd845f0cdd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/palantirnet/the-build/zipball/de0590b7d6b5a6e2b7d517d11a61921762d66cd2",
-                "reference": "de0590b7d6b5a6e2b7d517d11a61921762d66cd2",
+                "url": "https://api.github.com/repos/nilportugues/php_todo_finder/zipball/134ab0645771310f19758d641e8018cd845f0cdd",
+                "reference": "134ab0645771310f19758d641e8018cd845f0cdd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "symfony/console": "~2.2",
+                "symfony/yaml": "^2.7"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "1.4.2"
+            },
+            "bin": [
+                "bin/php_todo"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "NilPortugues\\TodoFinder\\": "src/TodoFinder/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nil Portugués Calderó",
+                    "email": "contact@nilportugues.com",
+                    "role": "Project Lead Developer"
+                }
+            ],
+            "description": "Looks into the code using a user-defined list of to-do phrases and stops commit if the total amount increased or is above a threshold.",
+            "homepage": "http://nilportugues.com",
+            "keywords": [
+                "HOOK",
+                "checker",
+                "fixer",
+                "forbidden",
+                "function",
+                "functions",
+                "git",
+                "php"
+            ],
+            "time": "2015-11-10 00:04:39"
+        },
+        {
+            "name": "palantirnet/the-build",
+            "version": "dev-composer-install-elsewhere-flexibility",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:palantirnet/the-build.git",
+                "reference": "acdb1e126d0f55cdf3a6f5899b8ed12e7e2836a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/palantirnet/the-build/zipball/acdb1e126d0f55cdf3a6f5899b8ed12e7e2836a3",
+                "reference": "acdb1e126d0f55cdf3a6f5899b8ed12e7e2836a3",
                 "shasum": ""
             },
             "require": {
                 "continuousphp/phing-drush-task": "dev-master",
+                "drupal/coder": "^8.2",
+                "nilportugues/php_todo": "^1.0",
                 "pear/versioncontrol_git": "@dev",
-                "phing/phing": "^2.14"
+                "phing/phing": "^2.14",
+                "phpmd/phpmd": "^2.4"
             },
             "type": "library",
             "license": [
@@ -2748,10 +2843,10 @@
             ],
             "description": "Drupal build tasks for our projects.",
             "support": {
-                "source": "https://github.com/palantirnet/the-build/tree/master",
+                "source": "https://github.com/palantirnet/the-build/tree/composer-install-elsewhere-flexibility",
                 "issues": "https://github.com/palantirnet/the-build/issues"
             },
-            "time": "2016-12-12 18:00:44"
+            "time": "2016-12-21 05:14:53"
         },
         {
             "name": "paragonie/random_compat",
@@ -2800,6 +2895,46 @@
                 "random"
             ],
             "time": "2016-03-18 20:34:03"
+        },
+        {
+            "name": "pdepend/pdepend",
+            "version": "2.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pdepend/pdepend.git",
+                "reference": "b086687f3a01dc6bb92d633aef071d2c5dd0db06"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/b086687f3a01dc6bb92d633aef071d2c5dd0db06",
+                "reference": "b086687f3a01dc6bb92d633aef071d2c5dd0db06",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.7",
+                "symfony/config": "^2.3.0|^3",
+                "symfony/dependency-injection": "^2.3.0|^3",
+                "symfony/filesystem": "^2.3.0|^3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.4.0,<4.8",
+                "squizlabs/php_codesniffer": "^2.0.0"
+            },
+            "bin": [
+                "src/bin/pdepend"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PDepend\\": "src/main/php/PDepend"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Official version of pdepend to be handled with Composer",
+            "time": "2016-03-10 15:15:04"
         },
         {
             "name": "pear/archive_tar",
@@ -3289,6 +3424,71 @@
             "time": "2015-02-03 12:10:50"
         },
         {
+            "name": "phpmd/phpmd",
+            "version": "2.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpmd/phpmd.git",
+                "reference": "2b9c2417a18696dfb578b38c116cd0ddc19b256e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/2b9c2417a18696dfb578b38c116cd0ddc19b256e",
+                "reference": "2b9c2417a18696dfb578b38c116cd0ddc19b256e",
+                "shasum": ""
+            },
+            "require": {
+                "pdepend/pdepend": "^2.0.4",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0",
+                "squizlabs/php_codesniffer": "^2.0"
+            },
+            "bin": [
+                "src/bin/phpmd"
+            ],
+            "type": "project",
+            "autoload": {
+                "psr-0": {
+                    "PHPMD\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Manuel Pichler",
+                    "email": "github@manuel-pichler.de",
+                    "homepage": "https://github.com/manuelpichler",
+                    "role": "Project Founder"
+                },
+                {
+                    "name": "Other contributors",
+                    "homepage": "https://github.com/phpmd/phpmd/graphs/contributors",
+                    "role": "Contributors"
+                },
+                {
+                    "name": "Marc Würth",
+                    "email": "ravage@bluewin.ch",
+                    "homepage": "https://github.com/ravage84",
+                    "role": "Project Maintainer"
+                }
+            ],
+            "description": "PHPMD is a spin-off project of PHP Depend and aims to be a PHP equivalent of the well known Java tool PMD.",
+            "homepage": "http://phpmd.org/",
+            "keywords": [
+                "mess detection",
+                "mess detector",
+                "pdepend",
+                "phpmd",
+                "pmd"
+            ],
+            "time": "2016-04-04 11:52:04"
+        },
+        {
             "name": "psr/http-message",
             "version": "1.0.1",
             "source": {
@@ -3447,6 +3647,84 @@
                 "shell"
             ],
             "time": "2016-03-09 05:03:14"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "2.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "4edb770cb853def6e60c93abb088ad5ac2010c83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4edb770cb853def6e60c93abb088ad5ac2010c83",
+                "reference": "4edb770cb853def6e60c93abb088ad5ac2010c83",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "scripts/phpcs",
+                "scripts/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "CodeSniffer.php",
+                    "CodeSniffer/CLI.php",
+                    "CodeSniffer/Exception.php",
+                    "CodeSniffer/File.php",
+                    "CodeSniffer/Fixer.php",
+                    "CodeSniffer/Report.php",
+                    "CodeSniffer/Reporting.php",
+                    "CodeSniffer/Sniff.php",
+                    "CodeSniffer/Tokens.php",
+                    "CodeSniffer/Reports/",
+                    "CodeSniffer/Tokenizers/",
+                    "CodeSniffer/DocGenerators/",
+                    "CodeSniffer/Standards/AbstractPatternSniff.php",
+                    "CodeSniffer/Standards/AbstractScopeSniff.php",
+                    "CodeSniffer/Standards/AbstractVariableSniff.php",
+                    "CodeSniffer/Standards/IncorrectPatternException.php",
+                    "CodeSniffer/Standards/Generic/Sniffs/",
+                    "CodeSniffer/Standards/MySource/Sniffs/",
+                    "CodeSniffer/Standards/PEAR/Sniffs/",
+                    "CodeSniffer/Standards/PSR1/Sniffs/",
+                    "CodeSniffer/Standards/PSR2/Sniffs/",
+                    "CodeSniffer/Standards/Squiz/Sniffs/",
+                    "CodeSniffer/Standards/Zend/Sniffs/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2016-07-13 23:29:13"
         },
         {
             "name": "stack/builder",
@@ -6404,42 +6682,6 @@
             "time": "2012-11-09 16:45:28"
         },
         {
-            "name": "drupal/coder",
-            "version": "8.2.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/klausi/coder.git",
-                "reference": "6d717e1a5a5dd592ebbeaafad11746849fb52532"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/klausi/coder/zipball/6d717e1a5a5dd592ebbeaafad11746849fb52532",
-                "reference": "6d717e1a5a5dd592ebbeaafad11746849fb52532",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0",
-                "squizlabs/php_codesniffer": ">=2.5.1",
-                "symfony/yaml": ">=2.0.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": ">=3.7"
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "description": "Coder is a library to review Drupal code.",
-            "homepage": "https://www.drupal.org/project/coder",
-            "keywords": [
-                "code review",
-                "phpcs",
-                "standards"
-            ],
-            "time": "2016-07-05 20:48:03"
-        },
-        {
             "name": "drupal/console",
             "version": "0.11.3",
             "source": {
@@ -7297,111 +7539,6 @@
             "time": "2016-12-01 19:32:09"
         },
         {
-            "name": "pdepend/pdepend",
-            "version": "2.2.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pdepend/pdepend.git",
-                "reference": "b086687f3a01dc6bb92d633aef071d2c5dd0db06"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/b086687f3a01dc6bb92d633aef071d2c5dd0db06",
-                "reference": "b086687f3a01dc6bb92d633aef071d2c5dd0db06",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.7",
-                "symfony/config": "^2.3.0|^3",
-                "symfony/dependency-injection": "^2.3.0|^3",
-                "symfony/filesystem": "^2.3.0|^3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.4.0,<4.8",
-                "squizlabs/php_codesniffer": "^2.0.0"
-            },
-            "bin": [
-                "src/bin/pdepend"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "PDepend\\": "src/main/php/PDepend"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Official version of pdepend to be handled with Composer",
-            "time": "2016-03-10 15:15:04"
-        },
-        {
-            "name": "phpmd/phpmd",
-            "version": "2.4.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpmd/phpmd.git",
-                "reference": "2b9c2417a18696dfb578b38c116cd0ddc19b256e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/2b9c2417a18696dfb578b38c116cd0ddc19b256e",
-                "reference": "2b9c2417a18696dfb578b38c116cd0ddc19b256e",
-                "shasum": ""
-            },
-            "require": {
-                "pdepend/pdepend": "^2.0.4",
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.0",
-                "squizlabs/php_codesniffer": "^2.0"
-            },
-            "bin": [
-                "src/bin/phpmd"
-            ],
-            "type": "project",
-            "autoload": {
-                "psr-0": {
-                    "PHPMD\\": "src/main/php"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Manuel Pichler",
-                    "email": "github@manuel-pichler.de",
-                    "homepage": "https://github.com/manuelpichler",
-                    "role": "Project Founder"
-                },
-                {
-                    "name": "Other contributors",
-                    "homepage": "https://github.com/phpmd/phpmd/graphs/contributors",
-                    "role": "Contributors"
-                },
-                {
-                    "name": "Marc Würth",
-                    "email": "ravage@bluewin.ch",
-                    "homepage": "https://github.com/ravage84",
-                    "role": "Project Maintainer"
-                }
-            ],
-            "description": "PHPMD is a spin-off project of PHP Depend and aims to be a PHP equivalent of the well known Java tool PMD.",
-            "homepage": "http://phpmd.org/",
-            "keywords": [
-                "mess detection",
-                "mess detector",
-                "pdepend",
-                "phpmd",
-                "pmd"
-            ],
-            "time": "2016-04-04 11:52:04"
-        },
-        {
             "name": "phpseclib/phpseclib",
             "version": "2.0.3",
             "source": {
@@ -7935,84 +8072,6 @@
                 "phra"
             ],
             "time": "2015-10-13 18:44:15"
-        },
-        {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.6.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "4edb770cb853def6e60c93abb088ad5ac2010c83"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/4edb770cb853def6e60c93abb088ad5ac2010c83",
-                "reference": "4edb770cb853def6e60c93abb088ad5ac2010c83",
-                "shasum": ""
-            },
-            "require": {
-                "ext-simplexml": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Greg Sherwood",
-                    "role": "lead"
-                }
-            ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
-            "keywords": [
-                "phpcs",
-                "standards"
-            ],
-            "time": "2016-07-13 23:29:13"
         },
         {
             "name": "stecman/symfony-console-completion",

--- a/conf/build.default.properties
+++ b/conf/build.default.properties
@@ -20,8 +20,9 @@ styleguide.repo=git@github.com:midcamp/midcamp.git
 styleguide.branch=gh-pages
 styleguide.env=dev
 
-pantheon.repo=ssh://codeserver.dev.d8923e06-a25b-4b96-8256-edd4f0bc8e28@codeserver.dev.d8923e06-a25b-4b96-8256-edd4f0bc8e28.drush.in:2222/~/repository.git
-pantheon.branch=master
-pantheon.tag_prefix=release-
-pantheon.dest=artifacts/pantheon
-pantheon.source=artifacts/pantheon
+pantheon.repo.source=ssh://codeserver.dev.d8923e06-a25b-4b96-8256-edd4f0bc8e28@codeserver.dev.d8923e06-a25b-4b96-8256-edd4f0bc8e28.drush.in:2222/~/repository.git
+pantheon.repo.branch=master
+pantheon.repo.tag_prefix=release-
+pantheon.repo.dir=artifacts/pantheon
+
+pantheon.drupal.config_sync_directory=private/conf


### PR DESCRIPTION
This PR is against the `deploy-to-pantheon` branch from PR #32.

Depends on this PR: https://github.com/palantirnet/the-build/pull/44 (the branch is included in this work).

To test:

* `composer install`
* `vendor/bin/phing deploy -Dbuild.env=default -Dpush=n`

The one thing that's probably going to be weird about this is that I've put the conf directory within Pantheon's `private` directory. This means your `settings.php` will have to reference it in that location:

```php
$config_directories[CONFIG_SYNC_DIRECTORY] = 'private/conf/drupal/config';
```

You can set this via the `drupal.config_sync_directory` phing property as well -- normally on our sites this value is `../conf/drupal/config`, which means our usual `settings.php` files will say:

```php
$config_directories[CONFIG_SYNC_DIRECTORY] = '../conf/drupal/config';
```
