### PR TITLE
Fix error w/ yaml parsing in libraries 

### DIFF
--- a/web/themes/custom/hatter/hatter.libraries.yml
+++ b/web/themes/custom/hatter/hatter.libraries.yml
@@ -1,11 +1,11 @@
 global-css:
   css:
     theme:
+      css/print.css:
+        media: print
       css/styles.css: {}
-      css/print.css: { media:print }
-
 global-js:
-  js:
-    js/script.js: {}
   dependencies:
     - core/jquery
+  js:
+    js/script.js: {}


### PR DESCRIPTION
Solves a problem caused by yaml syntax.

``` ID         :  65                                                                                                                                                             
 Date       :  02/Apr 16:06                                                                                                                                                   
 Type       :  php                                                                                                                                                            
 Severity   :  error                                                                                                                                                          
 Message    :  Drupal\Core\Asset\Exception\InvalidLibraryFileException: Invalid library definition in themes/custom/hatter/hatter.libraries.yml: yaml_parse(): scanning error 
               encountered during parsing: found unexpected ':' (line 5, column 29), context while scanning a plain scalar (line 5, column 24) in                             
               Drupal\Core\Asset\LibraryDiscoveryParser->parseLibraryInfo() (line 305 of /var/www/midcamp.local/web/core/lib/Drupal/Core/Asset/LibraryDiscoveryParser.php).   

```

(also linted the file)