### PR TITLE
Hide header button until we have something to do with it.

### DIFF
--- a/web/themes/custom/hatter/templates/block/block--system-branding-block.html.twig
+++ b/web/themes/custom/hatter/templates/block/block--system-branding-block.html.twig
@@ -27,7 +27,7 @@
             <h1 class="event__title">{{ site_name }}</h1>
           {% endif %}
           <h2 class="event__subtitle">{{ site_slogan }}</h2>
-          <a href="#" class="event__button button--primary">Register</a>
+          {# <a href="#" class="event__button button--primary">Register</a> #}
         </div>
       </div>
     </div>


### PR DESCRIPTION
The "Register" button in the header didn't go anywhere. Let's hide this until we can make it useful.