### PR TITLE
Issue #78: Add dependencies for mapbox

### DIFF
--- a/web/themes/custom/hatter/hatter.libraries.yml
+++ b/web/themes/custom/hatter/hatter.libraries.yml
@@ -15,4 +15,7 @@ mapbox:
   js:
     https://api.tiles.mapbox.com/mapbox-gl-js/v0.26.0/mapbox-gl.js: { type: external, minified: false }
     js/map.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
 


### PR DESCRIPTION
# Description
Resolves #78.  The map on the homepage is failing to display for anonymous users, throwing error `Uncaught ReferenceError: jQuery is not defined` in `map.js`. 
This PR adds dependencies for `mapbox` to resolve.

# To test
- `drush cr`
- Observe the map displays while logged out