### PR TITLE
change base theme to classy and add tab block to content region

### DIFF
--- a/conf/drupal/config/block.block.hatter_content.yml
+++ b/conf/drupal/config/block.block.hatter_content.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_content
 theme: hatter
 region: content
-weight: 0
+weight: -5
 provider: null
 plugin: system_main_block
 settings:

--- a/conf/drupal/config/block.block.hatter_help.yml
+++ b/conf/drupal/config/block.block.hatter_help.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_help
 theme: hatter
 region: content
-weight: -7
+weight: -9
 provider: null
 plugin: help_block
 settings:

--- a/conf/drupal/config/block.block.hatter_local_actions.yml
+++ b/conf/drupal/config/block.block.hatter_local_actions.yml
@@ -9,7 +9,7 @@ _core:
 id: hatter_local_actions
 theme: hatter
 region: content
-weight: -7
+weight: -6
 provider: null
 plugin: local_actions_block
 settings:

--- a/conf/drupal/config/block.block.tabs.yml
+++ b/conf/drupal/config/block.block.tabs.yml
@@ -1,0 +1,20 @@
+uuid: c8afcf7d-9bca-4b86-a48e-d21f1fc8ec78
+langcode: en
+status: true
+dependencies:
+  theme:
+    - hatter
+id: tabs
+theme: hatter
+region: content
+weight: -8
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: Tabs
+  provider: core
+  label_display: '0'
+  primary: true
+  secondary: true
+visibility: {  }

--- a/conf/drupal/config/block.block.views_block__event_news_block_1.yml
+++ b/conf/drupal/config/block.block.views_block__event_news_block_1.yml
@@ -11,7 +11,7 @@ dependencies:
 id: views_block__event_news_block_1
 theme: hatter
 region: content
-weight: 1
+weight: -4
 provider: null
 plugin: 'views_block:event_news-block_1'
 settings:

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -57,7 +57,6 @@ module:
   user: 0
   views_ui: 0
   viewsreference: 0
-  workbench_tabs: 0
   workflows: 0
   menu_link_content: 1
   pathauto: 1

--- a/web/themes/custom/hatter/hatter.info.yml
+++ b/web/themes/custom/hatter/hatter.info.yml
@@ -2,7 +2,7 @@ name: Hatter
 description: Now with more madness!
 type: theme
 core: 8.x
-base theme: stable
+base theme: classy
 libraries:
   - hatter/global-css
   - hatter/fonts


### PR DESCRIPTION
Add tabs back to content region and switch to classy as base theme so we don't have to style every damn ui piece. Also uninstalled workbench tabs to remove tab duplication in the admin theme.