### PR TITLE
Mobile menu

### DIFF
--- a/web/themes/custom/hatter/hatter.info.yml
+++ b/web/themes/custom/hatter/hatter.info.yml
@@ -2,9 +2,10 @@ name: Hatter
 description: Now with more madness!
 type: theme
 core: 8.x
-base theme: stable
+base theme: classy
 libraries:
   - hatter/global-css
+  - hatter/global-js
   - hatter/fonts
 regions:
   page_top: 'Page top'

--- a/web/themes/custom/hatter/hatter.libraries.yml
+++ b/web/themes/custom/hatter/hatter.libraries.yml
@@ -4,6 +4,12 @@ global-css:
       css/print.css:
         media: print
       css/styles.css: {}
+global-js:
+  js:
+    js/site.js: {}
+  dependencies:
+    - core/jquery
+    - core/drupal
 fonts:
   css:
     theme:

--- a/web/themes/custom/hatter/templates/block/block--system-menu-block.html.twig
+++ b/web/themes/custom/hatter/templates/block/block--system-menu-block.html.twig
@@ -1,0 +1,56 @@
+{#
+/**
+ * @file
+ * Theme override for a menu block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: HTML attributes for the containing element.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: HTML attributes for the title element.
+ * - content_attributes: HTML attributes for the content element.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * Headings should be used on navigation menus that consistently appear on
+ * multiple pages. When this menu block's label is configured to not be
+ * displayed, it is automatically made invisible using the 'visually-hidden' CSS
+ * class, which still keeps it visible for screen-readers and assistive
+ * technology. Headings allow screen-reader and keyboard only users to navigate
+ * to or skip the links.
+ * See http://juicystudio.com/article/screen-readers-display-none.php and
+ * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
+ */
+#}
+{%
+  set classes = [
+    'block',
+    'block-menu',
+    'navigation',
+    'menu--' ~ derivative_plugin_id|clean_class,
+  ]
+%}
+{% set heading_id = attributes.id ~ '-menu'|clean_id %}
+<nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass(classes)|without('role', 'aria-labelledby') }}>
+  {# Label. If not displayed, we still provide it for screen readers. #}
+  {% if not configuration.label_display %}
+    {% set title_attributes = title_attributes.addClass('visually-hidden') %}
+  {% endif %}
+  {{ title_prefix }}
+  <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
+  {{ title_suffix }}
+
+  {# Menu. #}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</nav>

--- a/web/themes/custom/hatter/templates/block/block--system-menu-block.html.twig
+++ b/web/themes/custom/hatter/templates/block/block--system-menu-block.html.twig
@@ -33,24 +33,25 @@
 #}
 {%
   set classes = [
-    'block',
-    'block-menu',
-    'navigation',
-    'menu--' ~ derivative_plugin_id|clean_class,
+    'site-header__nav',
   ]
 %}
 {% set heading_id = attributes.id ~ '-menu'|clean_id %}
 <nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass(classes)|without('role', 'aria-labelledby') }}>
-  {# Label. If not displayed, we still provide it for screen readers. #}
-  {% if not configuration.label_display %}
-    {% set title_attributes = title_attributes.addClass('visually-hidden') %}
-  {% endif %}
-  {{ title_prefix }}
-  <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
-  {{ title_suffix }}
+  <div class="container">
+    <div class="l-1up">
+      {# Label. If not displayed, we still provide it for screen readers. #}
+      {% if not configuration.label_display %}
+        {% set title_attributes = title_attributes.addClass('visually-hidden') %}
+      {% endif %}
+      {{ title_prefix }}
+      <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
+      {{ title_suffix }}
 
-  {# Menu. #}
-  {% block content %}
-    {{ content }}
-  {% endblock %}
+      {# Menu. #}
+      {% block content %}
+        {{ content }}
+      {% endblock %}
+    </div>
+  </div>
 </nav>

--- a/web/themes/custom/hatter/templates/navigation/menu--main.html.twig
+++ b/web/themes/custom/hatter/templates/navigation/menu--main.html.twig
@@ -18,6 +18,8 @@
  *   - in_active_trail: TRUE if the link is in the active trail.
  */
 #}
+<button class="primary-nav__trigger">{% include active_theme_path() ~ '/svg/menu.svg' %} Menu</button>
+
 {% import _self as menus %}
 
 {#
@@ -31,28 +33,29 @@
   {% if items %}
     {# Add classes to the UL #}
     {%
-      set classes = [
-        'primary-nav__list',
-      ]
+    set classes = [
+    'primary-nav__list',
+    ]
     %}
     {% if menu_level == 0 %}
-      <ul{{ attributes.addClass(classes) }}>
+<ul{{ attributes.addClass(classes) }}>
     {% else %}
-      <ul{{ attributes.addClass(classes) }}>
-    {% endif %}
-    {% for item in items %}
-      {%
-        set item_classes = [
-          'primary-nav__item',
-        ]
-      %}
-      <li{{ item.attributes.addClass(item_classes) }}>
-        {{ link(item.title, item.url) }}
-        {% if item.below %}
-          {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+    <button class="primary-nav__sublist--trigger"><span class="element-invisible">Open Menu</span>{% include active_theme_path() ~ '/svg/arrow.svg' %}</button>
+    <ul{{ attributes.addClass(classes) }}>
         {% endif %}
-      </li>
-    {% endfor %}
+        {% for item in items %}
+            {%
+            set item_classes = [
+            'primary-nav__item',
+            ]
+            %}
+            <li{{ item.attributes.addClass(item_classes) }}>
+                {{ link(item.title, item.url) }}
+                {% if item.below %}
+                    {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+                {% endif %}
+            </li>
+        {% endfor %}
     </ul>
-  {% endif %}
-{% endmacro %}
+    {% endif %}
+    {% endmacro %}

--- a/web/themes/custom/hatter/templates/page/page.html.twig
+++ b/web/themes/custom/hatter/templates/page/page.html.twig
@@ -50,7 +50,7 @@
 
 {% if page.header|render|trim is not empty  %}
   <header class="site-header">
-    <div class="container">{{ page.header }}</div>
+    {{ page.header }}
   </header>
 {% endif %}
 


### PR DESCRIPTION
This hooks up a single level mobile menu per the style guide. The style guide also includes (and we will need) child menus, but I'm too new to D8 to hook that up yet.

Marking as WIP, but until we have child pages, this is also ready for review.

To test, reduce the width of your browser window until the hamburger menu appears. Clicking on it will expose the full menu.