### PR TITLE
Internal pages

### DIFF
--- a/conf/drupal/config/block.block.hatter_branding.yml
+++ b/conf/drupal/config/block.block.hatter_branding.yml
@@ -22,4 +22,9 @@ settings:
   use_site_logo: true
   use_site_name: true
   use_site_slogan: true
-visibility: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: '<front>'
+    negate: false
+    context_mapping: {  }

--- a/web/themes/custom/hatter/templates/block/block--hatter-account-menu.html.twig
+++ b/web/themes/custom/hatter/templates/block/block--hatter-account-menu.html.twig
@@ -34,26 +34,25 @@
 <section class="top-header__wrapper">
     <div class="top-header">
         <div class="container">
-            <div class="l-1up">
-                <nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass(classes)|without('role', 'aria-labelledby') }}>
-                    <div class="container">
-                        <div class="l-1up">
-                            {# Label. If not displayed, we still provide it for screen readers. #}
-                            {% if not configuration.label_display %}
-                                {% set title_attributes = title_attributes.addClass('visually-hidden') %}
-                            {% endif %}
-                            {{ title_prefix }}
-                            <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
-                            {{ title_suffix }}
+                <div class="l-2up--1 camp-dates">
+                    <a href="/">MidCamp 2018</a> March 8-11, 2018 &mdash; Chicago, IL
+                </div>
+                <div class="l-2up--2 user-menu">
+                    <nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass(classes)|without('role', 'aria-labelledby') }}>
+                        {# Label. If not displayed, we still provide it for screen readers. #}
+                        {% if not configuration.label_display %}
+                            {% set title_attributes = title_attributes.addClass('visually-hidden') %}
+                        {% endif %}
+                        {{ title_prefix }}
+                        <h2{{ title_attributes.setAttribute('id', heading_id) }}>{{ configuration.label }}</h2>
+                        {{ title_suffix }}
 
-                            {# Menu. #}
-                            {% block content %}
-                                {{ content }}
-                            {% endblock %}
-                        </div>
-                    </div>
-                </nav>
-            </div>
+                        {# Menu. #}
+                        {% block content %}
+                            {{ content }}
+                        {% endblock %}
+                    </nav>
+                </div>
         </div>
     </div>
 </section>

--- a/web/themes/custom/hatter/templates/layout/html.html.twig
+++ b/web/themes/custom/hatter/templates/layout/html.html.twig
@@ -23,6 +23,15 @@
  * @see template_preprocess_html()
  */
 #}
+{%
+set body_classes = [
+logged_in ? 'user-logged-in',
+not root_path ? 'path-frontpage' : 'path-' ~ root_path|clean_class,
+node_type ? 'page-node-type-' ~ node_type|clean_class,
+db_offline ? 'db-offline',
+]
+%}
+
 <!DOCTYPE html>
 <html{{ html_attributes }}>
   <head>
@@ -31,8 +40,8 @@
     <css-placeholder token="{{ placeholder_token|raw }}">
     <js-placeholder token="{{ placeholder_token|raw }}">
   </head>
-  <body{{ attributes }}>
-    {#
+  <body{{ attributes.addClass(body_classes) }}>
+  {#
       Keyboard navigation/accessibility link to main content section in
       page.html.twig.
     #}

--- a/web/themes/custom/hatter/templates/layout/html.html.twig
+++ b/web/themes/custom/hatter/templates/layout/html.html.twig
@@ -26,6 +26,7 @@
 {%
 set body_classes = [
 logged_in ? 'user-logged-in',
+is_admin ? 'admin',
 not root_path ? 'path-frontpage' : 'path-' ~ root_path|clean_class,
 node_type ? 'page-node-type-' ~ node_type|clean_class,
 db_offline ? 'db-offline',

--- a/web/themes/custom/hatter/templates/navigation/menu--main.html.twig
+++ b/web/themes/custom/hatter/templates/navigation/menu--main.html.twig
@@ -43,7 +43,8 @@
   {% for item in items %}
     {% set classes = [
         menu_level == 0 ? 'primary-nav__item' : 'primary-nav__sublist-item',
-        item.below ? 'has-children'
+        item.below ? 'has-children',
+        'item--' ~ item.title|clean_class,
     ] %}
     <li{{ item.attributes.addClass(classes) }}>
         {{ link(item.title, item.url) }}

--- a/web/themes/custom/hatter/templates/page/page--front.html.twig
+++ b/web/themes/custom/hatter/templates/page/page--front.html.twig
@@ -50,7 +50,7 @@
 
 {% if page.header|render|trim is not empty  %}
   <header class="site-header">
-    <div class="container">{{ page.header }}</div>
+    {{ page.header }}
   </header>
 {% endif %}
 


### PR DESCRIPTION
We all love the hatter, but once off the home page, we need to not scroll down a whole screen to see content.
- **this depends on the latest hatter css**
- adds classing to the body tag for admin role and whether we are on the front page
- adds camp dates to the left side of the mobile menu
- fixes markup around the header bits on the front page

To test:
- go to any page besides the home page and verify the giant hatter/pic is gone
- add menu links to the main menu (Log in - /user/login; Log out - /user/logout) and verify they only show when the mobile hamburger menu is active