### PR TITLE
Featured speakers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "drupal/contact_formatter": "^1.0",
         "drupal/core": "^8.4",
         "drupal/devel": "^1.0@beta",
+        "drupal/entityqueue": "^1.0@alpha",
         "drupal/field_group": "^1.3",
         "drupal/geocoder_geofield": "^2.0@alpha",
         "drupal/geolocation": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "prefer-stable": true,
     "preferred-install": "dist",
     "config": {
-        "sort-packages": "true"
+        "sort-packages": true
     },
     "repositories": {
         "hatter-styleguide": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ac81ac7f206de026f53e6921dd76698",
+    "content-hash": "6db87c676ff66b1de4c7976250ed6c05",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1380,11 +1380,7 @@
                 },
                 "drupal": {
                     "version": "8.x-1.0",
-                    "datestamp": "1470411844",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
+                    "datestamp": "1470411844"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -1392,6 +1388,10 @@
                 "GPL-2.0+"
             ],
             "authors": [
+                {
+                    "name": "Caffeinated",
+                    "homepage": "https://www.drupal.org/user/2507260"
+                },
                 {
                     "name": "albertski",
                     "homepage": "https://www.drupal.org/user/1327432"
@@ -1403,10 +1403,6 @@
                 {
                     "name": "mikeacklin",
                     "homepage": "https://www.drupal.org/user/1198900"
-                },
-                {
-                    "name": "thejimbirch",
-                    "homepage": "https://www.drupal.org/user/2507260"
                 }
             ],
             "description": "Field Formatter for Contact Forms",
@@ -1839,6 +1835,65 @@
             "homepage": "https://www.drupal.org/project/entity_reference_revisions",
             "support": {
                 "source": "http://cgit.drupalcode.org/entity_reference_revisions"
+            }
+        },
+        {
+            "name": "drupal/entityqueue",
+            "version": "1.0.0-alpha7",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/entityqueue",
+                "reference": "8.x-1.0-alpha7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/entityqueue-8.x-1.0-alpha7.zip",
+                "reference": "8.x-1.0-alpha7",
+                "shasum": "d3cf4c655c2af08b2018af8675db54319fce29d8"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0-alpha7",
+                    "datestamp": "1506839344",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "amateescu",
+                    "homepage": "https://www.drupal.org/user/729614"
+                },
+                {
+                    "name": "jojonaloha",
+                    "homepage": "https://www.drupal.org/user/1579186"
+                },
+                {
+                    "name": "quicksketch",
+                    "homepage": "https://www.drupal.org/user/35821"
+                },
+                {
+                    "name": "tim.plunkett",
+                    "homepage": "https://www.drupal.org/user/241634"
+                }
+            ],
+            "description": "Allows users to collect entities in arbitrarily ordered lists.",
+            "homepage": "https://www.drupal.org/project/entityqueue",
+            "support": {
+                "source": "http://cgit.drupalcode.org/entityqueue"
             }
         },
         {
@@ -2405,12 +2460,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.4+4-dev",
-                    "datestamp": "1491577384",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Dev releases are not covered by Drupal security advisories."
-                    }
+                    "version": "8.x-1.4+2-dev",
+                    "datestamp": "1480435083"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -8081,24 +8132,23 @@
         },
         {
             "name": "drush/drush",
-            "version": "8.1.15",
+            "version": "8.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drush-ops/drush.git",
-                "reference": "f78b619806a9bc7c3d167fa425e8757eb046bb87"
+                "reference": "bbaff2dc725a5f3eb22006c5de3dc92a2de54b08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drush-ops/drush/zipball/f78b619806a9bc7c3d167fa425e8757eb046bb87",
-                "reference": "f78b619806a9bc7c3d167fa425e8757eb046bb87",
+                "url": "https://api.github.com/repos/drush-ops/drush/zipball/bbaff2dc725a5f3eb22006c5de3dc92a2de54b08",
+                "reference": "bbaff2dc725a5f3eb22006c5de3dc92a2de54b08",
                 "shasum": ""
             },
             "require": {
-                "consolidation/annotated-command": "~2",
+                "consolidation/annotated-command": "^2.8.1",
                 "consolidation/output-formatters": "~3",
-                "pear/console_table": "~1.3.0",
+                "pear/console_table": "~1.3.1",
                 "php": ">=5.4.5",
-                "phpdocumentor/reflection-docblock": "^2.0",
                 "psr/log": "~1.0",
                 "psy/psysh": "~0.6",
                 "symfony/console": "~2.7|^3",
@@ -8141,7 +8191,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "GPL-2.0+"
+                "GPL-2.0-or-later"
             ],
             "authors": [
                 {
@@ -8187,7 +8237,7 @@
             ],
             "description": "Drush is a command line shell and scripting interface for Drupal, a veritable Swiss Army knife designed to make life easier for those of us who spend some of our working hours hacking away at the command prompt.",
             "homepage": "http://www.drush.org",
-            "time": "2017-10-10T02:05:46+00:00"
+            "time": "2018-02-06T21:18:48+00:00"
         },
         {
             "name": "fabpot/goutte",
@@ -8636,55 +8686,6 @@
                 "console"
             ],
             "time": "2018-01-25T20:47:17+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
-                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "dflydev/markdown": "~1.0",
-                "erusev/parsedown": "~1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "phpDocumentor": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
-                }
-            ],
-            "time": "2016-01-25T08:17:30+00:00"
         },
         {
             "name": "phpmd/phpmd",
@@ -9641,6 +9642,7 @@
     "stability-flags": {
         "drupal/address": 20,
         "drupal/devel": 10,
+        "drupal/entityqueue": 15,
         "drupal/geocoder_geofield": 15,
         "drupal/libraries": 20,
         "drupal/name": 10,

--- a/conf/drupal/config/block.block.views_block__speakers_block_1.yml
+++ b/conf/drupal/config/block.block.views_block__speakers_block_1.yml
@@ -1,0 +1,30 @@
+uuid: 64acb4fb-8a70-4c49-8bbe-b04b02b67603
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.speakers
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: views_block__speakers_block_1
+theme: hatter
+region: content
+weight: 0
+provider: null
+plugin: 'views_block:speakers-block_1'
+settings:
+  id: 'views_block:speakers-block_1'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility:
+  request_path:
+    id: request_path
+    pages: '<front>'
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/core.base_field_override.node.training.promote.yml
+++ b/conf/drupal/config/core.base_field_override.node.training.promote.yml
@@ -1,0 +1,22 @@
+uuid: 91f5bea0-8119-4422-a6b9-1a1d8be8f9ee
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.training
+id: node.training.promote
+field_name: promote
+entity_type: node
+bundle: training
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/drupal/config/core.entity_form_display.node.training.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.training.default.yml
@@ -1,0 +1,78 @@
+uuid: 57af259f-373b-4632-9111-8416241f6d7c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.training.body
+    - field.field.node.training.field_accepted_confirmed
+    - field.field.node.training.field_event
+    - field.field.node.training.field_meta_tags
+    - field.field.node.training.field_people
+    - field.field.node.training.field_registration_link
+    - field.field.node.training.field_track
+    - node.type.training
+  module:
+    - link
+    - text
+id: node.training.default
+targetEntityType: node
+bundle: training
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 3
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+    region: content
+  field_people:
+    weight: 2
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete_tags
+    region: content
+  field_registration_link:
+    weight: 4
+    settings:
+      placeholder_url: 'Eventbrite Link'
+      placeholder_title: 'Register Today'
+    third_party_settings: {  }
+    type: link_default
+    region: content
+  field_track:
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  url_redirects:
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  created: true
+  field_accepted_confirmed: true
+  field_event: true
+  field_meta_tags: true
+  path: true
+  promote: true
+  publish_on: true
+  status: true
+  sticky: true
+  uid: true
+  unpublish_on: true

--- a/conf/drupal/config/core.entity_view_display.node.training.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.training.default.yml
@@ -1,0 +1,62 @@
+uuid: 757a5966-c74a-4294-9427-01ac1069dddb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.training.body
+    - field.field.node.training.field_accepted_confirmed
+    - field.field.node.training.field_event
+    - field.field.node.training.field_meta_tags
+    - field.field.node.training.field_people
+    - field.field.node.training.field_registration_link
+    - field.field.node.training.field_track
+    - node.type.training
+  module:
+    - link
+    - text
+    - user
+id: node.training.default
+targetEntityType: node
+bundle: training
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_people:
+    weight: 0
+    label: above
+    settings:
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_registration_link:
+    weight: 3
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    type: link
+    region: content
+  field_track:
+    weight: 2
+    label: inline
+    settings:
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+hidden:
+  field_accepted_confirmed: true
+  field_event: true
+  field_meta_tags: true
+  links: true

--- a/conf/drupal/config/core.entity_view_display.node.training.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.training.teaser.yml
@@ -1,0 +1,28 @@
+uuid: d12eed40-c8c7-4ac1-a3bd-92ca108b1c2e
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.training.body
+    - node.type.training
+  module:
+    - text
+    - user
+id: node.training.teaser
+targetEntityType: node
+bundle: training
+mode: teaser
+content:
+  body:
+    label: hidden
+    type: text_summary_or_trimmed
+    weight: 101
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    region: content
+hidden: {  }

--- a/conf/drupal/config/core.entity_view_display.user.user.featured_speaker.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.featured_speaker.yml
@@ -78,7 +78,7 @@ content:
     weight: 0
     settings:
       image_style: featured_speaker
-      image_link: ''
+      image_link: content
     third_party_settings: {  }
     label: hidden
     region: content

--- a/conf/drupal/config/core.entity_view_display.user.user.featured_speaker.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.featured_speaker.yml
@@ -16,7 +16,7 @@ dependencies:
     - field.field.user.user.field_tracks
     - field.field.user.user.field_twitter
     - field.field.user.user.user_picture
-    - image.style.medium
+    - image.style.featured_speaker
   module:
     - image
     - link
@@ -77,7 +77,7 @@ content:
     type: image
     weight: 0
     settings:
-      image_style: medium
+      image_style: featured_speaker
       image_link: ''
     third_party_settings: {  }
     label: hidden

--- a/conf/drupal/config/core.entity_view_display.user.user.featured_speaker.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.featured_speaker.yml
@@ -78,7 +78,7 @@ content:
     weight: 0
     settings:
       image_style: featured_speaker
-      image_link: content
+      image_link: ''
     third_party_settings: {  }
     label: hidden
     region: content

--- a/conf/drupal/config/core.entity_view_display.user.user.featured_speaker.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.featured_speaker.yml
@@ -1,0 +1,93 @@
+uuid: 71b18d93-7df5-4b12-8b6f-2b1bf9056c31
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.user.featured_speaker
+    - field.field.user.user.field_bio
+    - field.field.user.user.field_company_url
+    - field.field.user.user.field_do_profile
+    - field.field.user.user.field_eventbrite_email
+    - field.field.user.user.field_mailing_list
+    - field.field.user.user.field_name
+    - field.field.user.user.field_organization
+    - field.field.user.user.field_site
+    - field.field.user.user.field_title
+    - field.field.user.user.field_tracks
+    - field.field.user.user.field_twitter
+    - field.field.user.user.user_picture
+    - image.style.medium
+  module:
+    - image
+    - link
+    - name
+    - user
+_core:
+  default_config_hash: L2mtwGWH_7wDRCMIR4r_Iu_jmvQ10DV1L8ht8iNZ5qY
+id: user.user.featured_speaker
+targetEntityType: user
+bundle: user
+mode: featured_speaker
+content:
+  field_company_url:
+    type: link
+    weight: 4
+    region: content
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: true
+      url_plain: true
+      target: _blank
+      rel: '0'
+    third_party_settings: {  }
+  field_name:
+    weight: 1
+    label: hidden
+    settings:
+      format: default
+      markup: false
+      output: default
+      multiple: default
+      multiple_delimiter: ', '
+      multiple_and: text
+      multiple_delimiter_precedes_last: never
+      multiple_el_al_min: '3'
+      multiple_el_al_first: '1'
+    third_party_settings: {  }
+    type: name_default
+    region: content
+  field_organization:
+    weight: 3
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_title:
+    weight: 2
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  user_picture:
+    type: image
+    weight: 0
+    settings:
+      image_style: medium
+      image_link: ''
+    third_party_settings: {  }
+    label: hidden
+    region: content
+hidden:
+  field_bio: true
+  field_do_profile: true
+  field_eventbrite_email: true
+  field_mailing_list: true
+  field_site: true
+  field_tracks: true
+  field_twitter: true
+  member_for: true

--- a/conf/drupal/config/core.entity_view_mode.user.featured_speaker.yml
+++ b/conf/drupal/config/core.entity_view_mode.user.featured_speaker.yml
@@ -1,0 +1,10 @@
+uuid: e2fd89d5-ad02-41fc-a6ba-4a9658d7d4b6
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: user.featured_speaker
+label: 'Featured Speaker'
+targetEntityType: user
+cache: true

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -22,6 +22,7 @@ module:
   dynamic_page_cache: 0
   editor: 0
   entity_reference_revisions: 0
+  entityqueue: 0
   field: 0
   field_group: 0
   field_ui: 0

--- a/conf/drupal/config/entityqueue.entity_queue.featured_speakers.yml
+++ b/conf/drupal/config/entityqueue.entity_queue.featured_speakers.yml
@@ -1,0 +1,23 @@
+uuid: 66dd18bb-1ec5-4dd0-8059-35e5728ad395
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: featured_speakers
+label: 'Featured Speakers'
+handler: simple
+handler_configuration: {  }
+entity_settings:
+  target_type: user
+  handler: views
+  handler_settings:
+    view:
+      view_name: speakers
+      display_name: entity_reference_1
+      arguments: {  }
+queue_settings:
+  min_size: 1
+  max_size: 3
+  act_as_queue: false
+  reverse_in_admin: false

--- a/conf/drupal/config/field.field.node.training.body.yml
+++ b/conf/drupal/config/field.field.node.training.body.yml
@@ -1,0 +1,22 @@
+uuid: b77ff849-37da-4208-8122-70cb9660a6bf
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.training
+  module:
+    - text
+id: node.training.body
+field_name: body
+entity_type: node
+bundle: training
+label: 'Describe your Training'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+field_type: text_with_summary

--- a/conf/drupal/config/field.field.node.training.field_accepted_confirmed.yml
+++ b/conf/drupal/config/field.field.node.training.field_accepted_confirmed.yml
@@ -1,0 +1,23 @@
+uuid: d1731da2-52a8-4180-9874-4b05fd519feb
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_accepted_confirmed
+    - node.type.training
+id: node.training.field_accepted_confirmed
+field_name: field_accepted_confirmed
+entity_type: node
+bundle: training
+label: 'Accepted and confirmed'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes'
+  off_label: 'No'
+field_type: boolean

--- a/conf/drupal/config/field.field.node.training.field_event.yml
+++ b/conf/drupal/config/field.field.node.training.field_event.yml
@@ -1,0 +1,33 @@
+uuid: 7925ed59-1e3c-458a-8973-3e8fb20b3902
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event
+    - node.type.training
+    - taxonomy.vocabulary.event
+  content:
+    - 'taxonomy_term:event:58ab979d-12f0-4b19-ab75-5625aa986afb'
+id: node.training.field_event
+field_name: field_event
+entity_type: node
+bundle: training
+label: Event
+description: 'The event you are proposing this training for.'
+required: false
+translatable: true
+default_value:
+  -
+    target_uuid: 58ab979d-12f0-4b19-ab75-5625aa986afb
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      event: event
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/drupal/config/field.field.node.training.field_meta_tags.yml
+++ b/conf/drupal/config/field.field.node.training.field_meta_tags.yml
@@ -1,0 +1,23 @@
+uuid: 257994ec-d803-40d3-895f-0485dcbf9219
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.training
+  module:
+    - metatag
+id: node.training.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: training
+label: 'Meta tags'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 'a:0:{}'
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/conf/drupal/config/field.field.node.training.field_people.yml
+++ b/conf/drupal/config/field.field.node.training.field_people.yml
@@ -1,0 +1,28 @@
+uuid: 57cb4e16-9032-4ce6-97df-507989bfa689
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_people
+    - node.type.training
+id: node.training.field_people
+field_name: field_people
+entity_type: node
+bundle: training
+label: Trainers
+description: 'The people who will lead this training. This must be a user on the site. '
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:user'
+  handler_settings:
+    include_anonymous: false
+    filter:
+      type: _none
+    target_bundles: null
+    sort:
+      field: _none
+    auto_create: false
+field_type: entity_reference

--- a/conf/drupal/config/field.field.node.training.field_registration_link.yml
+++ b/conf/drupal/config/field.field.node.training.field_registration_link.yml
@@ -1,0 +1,24 @@
+uuid: c0265506-c2a8-48dc-91d9-7168c208cd73
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_registration_link
+    - node.type.training
+  module:
+    - link
+id: node.training.field_registration_link
+field_name: field_registration_link
+entity_type: node
+bundle: training
+label: 'Registration Link'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 17
+  title: 1
+  title_predefined: ''
+field_type: link

--- a/conf/drupal/config/field.field.node.training.field_track.yml
+++ b/conf/drupal/config/field.field.node.training.field_track.yml
@@ -1,0 +1,29 @@
+uuid: 26d1558b-6469-4fa3-b889-1faf6377df02
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_track
+    - node.type.training
+    - taxonomy.vocabulary.session_tracks
+id: node.training.field_track
+field_name: field_track
+entity_type: node
+bundle: training
+label: Track
+description: 'We recommend that you focus your session’s intended audience, but realize that not every topic will fit neatly into one of these categories. For example, a presentation on Multilingual could be primarily Site Building, Content Admin, or Back-End, depending on the focus of the talk. For full track descriptions, please review the <a href="/topic-tracks">track descriptions</a>.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      session_tracks: session_tracks
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/drupal/config/field.storage.node.field_registration_link.yml
+++ b/conf/drupal/config/field.storage.node.field_registration_link.yml
@@ -1,0 +1,19 @@
+uuid: a7a02682-4c6c-4d15-953d-0385e48e1d42
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_registration_link
+field_name: field_registration_link
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/image.style.featured_speaker.yml
+++ b/conf/drupal/config/image.style.featured_speaker.yml
@@ -1,0 +1,14 @@
+uuid: f3a954c9-67e4-4c4c-85f6-18c56f4d015b
+langcode: en
+status: true
+dependencies: {  }
+name: featured_speaker
+label: 'Featured Speaker'
+effects:
+  7de9b193-8880-4d9b-aa42-1857433da4df:
+    uuid: 7de9b193-8880-4d9b-aa42-1857433da4df
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 400
+      height: 400

--- a/conf/drupal/config/node.type.training.yml
+++ b/conf/drupal/config/node.type.training.yml
@@ -1,0 +1,29 @@
+uuid: a46636d0-5a7c-4d75-99e5-319fcb5b2e08
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+    - scheduler
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
+name: 'Training Proposal'
+type: training
+description: 'Use <em>training</em> for individual trainings with registration links.'
+help: ''
+new_revision: false
+preview_mode: 0
+display_submitted: false

--- a/conf/drupal/config/pathauto.pattern.content.yml
+++ b/conf/drupal/config/pathauto.pattern.content.yml
@@ -9,7 +9,7 @@ label: Content
 type: 'canonical_entities:node'
 pattern: '[node:content-type]/[node:title]'
 selection_criteria:
-  6c35ddc6-57db-42a0-a6f0-f69ab91b8771:
+  4737754a-5efa-4674-b1c6-2e61db1cec8c:
     id: node_type
     bundles:
       article: article
@@ -20,7 +20,7 @@ selection_criteria:
     negate: false
     context_mapping:
       node: node
-    uuid: 6c35ddc6-57db-42a0-a6f0-f69ab91b8771
+    uuid: 4737754a-5efa-4674-b1c6-2e61db1cec8c
 selection_logic: and
-weight: -9
+weight: -7
 relationships: {  }

--- a/conf/drupal/config/pathauto.pattern.events.yml
+++ b/conf/drupal/config/pathauto.pattern.events.yml
@@ -19,5 +19,5 @@ selection_criteria:
       taxonomy_term: taxonomy_term
     uuid: b927e73e-693b-4e83-9948-308047e4014e
 selection_logic: and
-weight: -8
+weight: -6
 relationships: {  }

--- a/conf/drupal/config/pathauto.pattern.sponsor_packages.yml
+++ b/conf/drupal/config/pathauto.pattern.sponsor_packages.yml
@@ -19,5 +19,5 @@ selection_criteria:
       taxonomy_term: taxonomy_term
     uuid: e2625ac6-345e-491d-a480-1c0c4d09722a
 selection_logic: and
-weight: -7
+weight: -5
 relationships: {  }

--- a/conf/drupal/config/pathauto.pattern.training.yml
+++ b/conf/drupal/config/pathauto.pattern.training.yml
@@ -1,22 +1,22 @@
-uuid: 678b54a8-5ba1-4b06-8718-7f2672ab8adb
+uuid: 95d746b6-d193-446b-9971-60a894a9972e
 langcode: en
 status: true
 dependencies:
   module:
     - node
-id: topics
-label: Topics
+id: training
+label: Training
 type: 'canonical_entities:node'
-pattern: 'topic/[node:title]'
+pattern: 'training/[node:title]'
 selection_criteria:
-  9335d045-390f-40c7-84d4-7fcfaf29f957:
+  4e5fb38c-7e35-4551-8183-e08585edba93:
     id: node_type
     bundles:
       topic: topic
     negate: false
     context_mapping:
       node: node
-    uuid: 9335d045-390f-40c7-84d4-7fcfaf29f957
+    uuid: 4e5fb38c-7e35-4551-8183-e08585edba93
 selection_logic: and
-weight: -8
+weight: -9
 relationships: {  }

--- a/conf/drupal/config/pathauto.pattern.user.yml
+++ b/conf/drupal/config/pathauto.pattern.user.yml
@@ -10,5 +10,5 @@ type: 'canonical_entities:user'
 pattern: 'user/[user:display-name]'
 selection_criteria: {  }
 selection_logic: and
-weight: -5
+weight: -4
 relationships: {  }

--- a/conf/drupal/config/views.view.speakers.yml
+++ b/conf/drupal/config/views.view.speakers.yml
@@ -1,0 +1,383 @@
+uuid: 5ac7b69e-9a75-47f1-a46f-cd4b849eaafa
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.user.featured_speaker
+    - field.storage.user.field_organization
+    - field.storage.user.field_title
+    - field.storage.user.user_picture
+    - image.style.medium
+    - user.role.speaker
+  module:
+    - image
+    - user
+id: speakers
+label: Speakers
+module: views
+description: ''
+tag: ''
+base_table: users_field_data
+base_field: uid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access user profiles'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 3
+          offset: 0
+      style:
+        type: default
+        options:
+          row_class: l-3up
+          default_row_class: false
+          uses_fields: false
+      row:
+        type: 'entity:user'
+        options:
+          relationship: none
+          view_mode: featured_speaker
+      fields:
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          entity_type: user
+          entity_field: name
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        user_picture:
+          id: user_picture
+          table: user__user_picture
+          field: user_picture
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image
+          settings:
+            image_style: medium
+            image_link: content
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_title:
+          id: field_title
+          table: user__field_title
+          field: field_title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_organization:
+          id: field_organization
+          table: user__field_organization
+          field: field_organization
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        roles_target_id:
+          id: roles_target_id
+          table: user__roles
+          field: roles_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            speaker: speaker
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          entity_type: user
+          plugin_id: user_roles
+      sorts: {  }
+      title: 'Featured Speakers'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags:
+        - 'config:field.storage.user.field_organization'
+        - 'config:field.storage.user.field_title'
+        - 'config:field.storage.user.user_picture'
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: Block
+    position: 1
+    display_options:
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags:
+        - 'config:field.storage.user.field_organization'
+        - 'config:field.storage.user.field_title'
+        - 'config:field.storage.user.user_picture'

--- a/conf/drupal/config/views.view.speakers.yml
+++ b/conf/drupal/config/views.view.speakers.yml
@@ -4,13 +4,17 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.user.featured_speaker
+    - entityqueue.entity_queue.featured_speakers
+    - field.storage.user.field_name
     - field.storage.user.field_organization
     - field.storage.user.field_title
     - field.storage.user.user_picture
     - image.style.medium
     - user.role.speaker
   module:
+    - entityqueue
     - image
+    - name
     - user
 id: speakers
 label: Speakers
@@ -371,6 +375,104 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
+      filters:
+        roles_target_id:
+          id: roles_target_id
+          table: user__roles
+          field: roles_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            speaker: speaker
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          entity_type: user
+          plugin_id: user_roles
+        entityqueue_relationship:
+          id: entityqueue_relationship
+          table: users_field_data
+          field: entityqueue_relationship
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: user
+          plugin_id: entity_queue_in_queue
+      defaults:
+        filters: false
+        filter_groups: false
+        relationships: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      relationships:
+        entityqueue_relationship:
+          id: entityqueue_relationship
+          table: users_field_data
+          field: entityqueue_relationship
+          relationship: none
+          group_type: group
+          admin_label: 'User queue'
+          required: true
+          limit_queue: featured_speakers
+          entity_type: user
+          plugin_id: entity_queue
     cache_metadata:
       max-age: -1
       contexts:
@@ -378,6 +480,346 @@ display:
         - 'languages:language_interface'
         - user.permissions
       tags:
+        - 'config:entityqueue.entity_queue.featured_speakers'
+        - 'config:field.storage.user.field_organization'
+        - 'config:field.storage.user.field_title'
+        - 'config:field.storage.user.user_picture'
+        - entity_field_info
+        - views_data
+  entity_reference_1:
+    display_plugin: entity_reference
+    id: entity_reference_1
+    display_title: 'Entity Reference'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            name: name
+            field_name: field_name
+            user_picture: '0'
+            field_title: '0'
+            field_organization: '0'
+      fields:
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          entity_type: user
+          entity_field: name
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        user_picture:
+          id: user_picture
+          table: user__user_picture
+          field: user_picture
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image
+          settings:
+            image_style: medium
+            image_link: content
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_title:
+          id: field_title
+          table: user__field_title
+          field: field_title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_organization:
+          id: field_organization
+          table: user__field_organization
+          field: field_organization
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_name:
+          id: field_name
+          table: user__field_name
+          field: field_name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: title
+          type: name_default
+          settings:
+            format: default
+            markup: false
+            output: default
+            multiple: default
+            multiple_delimiter: ', '
+            multiple_and: text
+            multiple_delimiter_precedes_last: never
+            multiple_el_al_min: '3'
+            multiple_el_al_first: '1'
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      defaults:
+        fields: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags:
+        - 'config:field.storage.user.field_name'
         - 'config:field.storage.user.field_organization'
         - 'config:field.storage.user.field_title'
         - 'config:field.storage.user.user_picture'

--- a/conf/drupal/config/views.view.training.yml
+++ b/conf/drupal/config/views.view.training.yml
@@ -1,0 +1,714 @@
+uuid: 39a2294d-5961-4835-96c2-72fb81cc919d
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.storage.node.body
+    - field.storage.node.field_registration_link
+    - field.storage.node.field_track
+    - node.type.topic
+    - node.type.training
+    - taxonomy.vocabulary.topic_type
+  content:
+    - 'taxonomy_term:topic_type:39f8a394-f9fc-45ae-85a2-46aabfd3212f'
+  module:
+    - link
+    - node
+    - taxonomy
+    - text
+    - user
+id: training
+label: 'Training Day'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: ‹‹
+            next: ››
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      style:
+        type: default
+        options:
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            topic: topic
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          group: 1
+        field_topic_type_target_id:
+          id: field_topic_type_target_id
+          table: node__field_topic_type
+          field: field_topic_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            14: 14
+          group: 1
+          exposed: false
+          expose:
+            operator_id: field_topic_type_target_id_op
+            label: 'Topic Type'
+            description: ''
+            use_operator: false
+            operator: field_topic_type_target_id_op
+            identifier: field_topic_type_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              speaker: '0'
+              content_editor: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: topic_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      sorts: {  }
+      title: 'Submitted Sessions'
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: "<p>MidCamp is looking for folks just like you to speak to our Drupal audience! Experienced speakers are always welcome, but camp is also a great place to start for first-time speakers. From the opening of session submission through the beginning of camp, we'll have communication to assist speakers (new and old) in creating engaging and informative sessions.</p>\n<p>Sessions submission will close January 26, 2018. <a href=\"/node/add/topic\">Submit your session today!</a></p>"
+            format: basic_html
+          plugin_id: text
+      footer: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'No sessions submitted yet. What are you waiting for?'
+            format: basic_html
+          plugin_id: text
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_2:
+    display_plugin: page
+    id: page_2
+    display_title: 'Training Day'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      path: training
+      title: 'Full Day Training Sessions'
+      defaults:
+        title: false
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+        header: false
+        empty: false
+        sorts: false
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: schedule__teaser
+          default_row_class: true
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      fields:
+        field_track:
+          id: field_track
+          table: node__field_track
+          field: field_track
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: div
+          element_class: schedule__track
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h4
+          element_class: schedule__title
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        body:
+          id: body
+          table: node__body
+          field: body
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_summary_or_trimmed
+          settings:
+            trim_length: 300
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_registration_link:
+          id: field_registration_link
+          table: node__field_registration_link
+          field: field_registration_link
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '<a class="button" href={{ field_registration_link__uri }}>Register Today</a>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: 80
+            url_only: false
+            url_plain: false
+            rel: '0'
+            target: '0'
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            training: training
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: "<p>MidCamp will offer professional full day training on Thursday, March 8th to anyone interested in gaining additional hands-on knowledge on a variety of hot Drupal topics by world-class Drupal trainers.\n\n<p>Trainings are not included in the cost of a MidCamp registration. We recommend registering in advance as trainings tend to sell out. Lunch will be served and coffee will be available. \n\n<p>Registration 8 am. Trainings 9 am - 5 pm."
+            format: basic_html
+          plugin_id: text
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'Session selection and confirmation is still underway. Check back again soon.'
+            format: basic_html
+          plugin_id: text
+      sorts:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'
+        - 'config:field.storage.node.field_registration_link'
+        - 'config:field.storage.node.field_track'

--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -52,8 +52,5 @@ function hatter_preprocess_user(&$vars) {
     if ($url->count() > 0) {
       $vars['url'] = $user->get('field_company_url')->first()->getUrl();
     }
-
-    // Link to the user entity.
-    $vars['user_link'] = $user->url();
   }
 }

--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -5,6 +5,31 @@
  * Functions to support theming in the hatter theme.
  */
 
+/**
+ * Implements THEME_theme_suggestions_HOOK_alter() for taxonomy terms.
+ */
 function hatter_theme_suggestions_taxonomy_term_alter(&$suggestions, $vars, $hook) {
   $suggestions[] = 'taxonomy_term__' . $vars['elements']['#view_mode'];
 }
+
+/**
+ * Implements THEME_theme_suggestions_HOOK_alter() for fields.
+ */
+function hatter_theme_suggestions_field_alter(&$suggestions, $vars, $hook) {
+  // Add field template suggestions for user view modes.
+  if ($vars['element']['#bundle'] == 'user' && $vars['element']['#view_mode'] == 'featured_speaker') {
+    $suggestions[] = 'field__' . $vars['element']['#bundle'] . '__' .
+                      $vars['element']['#field_name'] . '__' .
+                      $vars['element']['#view_mode'];
+
+  }
+}
+
+/**
+ * Implements THEME_theme_suggestions_HOOK_alter() for user entities.
+ */
+function hatter_theme_suggestions_user_alter(&$suggestions, $vars, $hook) {
+  // Add template suggestions for User entity view modes.
+  $suggestions[] = 'user__' . $vars['elements']['#view_mode'];
+}
+

--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -33,3 +33,24 @@ function hatter_theme_suggestions_user_alter(&$suggestions, $vars, $hook) {
   $suggestions[] = 'user__' . $vars['elements']['#view_mode'];
 }
 
+/**
+ * Implements THEME_preprocess_user().
+ */
+function hatter_preprocess_user(&$vars) {
+  $user = $vars['user'];
+
+  if ($vars['elements']['#view_mode'] == 'featured_speaker') {
+    $job_title = $user->get('field_title');
+    $company = $user->get('field_organization');
+
+    // Only show the ampersand when both fields have value.
+    if ($job_title->count() > 0 && $company->count() > 0) {
+      $vars['amp'] = TRUE;
+    }
+
+    $url = $user->get('field_company_url');
+    if ($url->count() > 0) {
+      $vars['url'] = $user->get('field_company_url')->first()->getUrl();
+    }
+  }
+}

--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -52,5 +52,8 @@ function hatter_preprocess_user(&$vars) {
     if ($url->count() > 0) {
       $vars['url'] = $user->get('field_company_url')->first()->getUrl();
     }
+
+    // Link to the user entity.
+    $vars['user_link'] = $user->url();
   }
 }

--- a/web/themes/custom/hatter/templates/block/block--views-block--speakers-block-1.html.twig
+++ b/web/themes/custom/hatter/templates/block/block--views-block--speakers-block-1.html.twig
@@ -1,0 +1,18 @@
+{%
+  set classes = [
+  'block',
+  'block-' ~ configuration.provider|clean_class,
+  'block-' ~ plugin_id|clean_class,
+]
+%}
+<div{{ attributes.addClass(classes) }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes.addClass('banner-title') }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>
+

--- a/web/themes/custom/hatter/templates/field/field--user--field-name--featured-speaker.html.twig
+++ b/web/themes/custom/hatter/templates/field/field--user--field-name--featured-speaker.html.twig
@@ -1,0 +1,3 @@
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}

--- a/web/themes/custom/hatter/templates/field/field--user--field-organization--featured-speaker.html.twig
+++ b/web/themes/custom/hatter/templates/field/field--user--field-organization--featured-speaker.html.twig
@@ -1,0 +1,4 @@
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}
+

--- a/web/themes/custom/hatter/templates/field/field--user--field-title--featured-speaker.html.twig
+++ b/web/themes/custom/hatter/templates/field/field--user--field-title--featured-speaker.html.twig
@@ -1,0 +1,4 @@
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}
+

--- a/web/themes/custom/hatter/templates/field/field--user--user-picture--featured-speaker.html.twig
+++ b/web/themes/custom/hatter/templates/field/field--user--user-picture--featured-speaker.html.twig
@@ -1,0 +1,3 @@
+{% for item in items %}
+  <div{{ attributes.addClass(classes, 'speaker-image') }}>{{ item.content }}</div>
+{% endfor %}

--- a/web/themes/custom/hatter/templates/user/user--featured-speaker.html.twig
+++ b/web/themes/custom/hatter/templates/user/user--featured-speaker.html.twig
@@ -1,7 +1,7 @@
 <div{{ attributes.addClass('speaker-item') }}>
   {{ content.user_picture }}
   <div class="speaker-item__block">
-    <h3 class="speaker-item__title"><a href="{{ user_link }}">{{ content.field_name }}</a></h3>
+    <h3 class="speaker-item__title"><a href="#">{{ content.field_name }}</a></h3>
     <p class="speaker-item__subtitle">
       {{ content.field_title }}
       {% if amp %}

--- a/web/themes/custom/hatter/templates/user/user--featured-speaker.html.twig
+++ b/web/themes/custom/hatter/templates/user/user--featured-speaker.html.twig
@@ -1,0 +1,17 @@
+<div{{ attributes.addClass('speaker-item') }}>
+  {{ content.user_picture }}
+  <div class="speaker-item__block">
+    <h3 class="speaker-item__title"><a href="#">{{ content.field_name }}</a></h3>
+    <p class="speaker-item__subtitle">
+      {{ content.field_title }}
+      {% if amp %}
+        @
+      {% endif %}
+      {% if url %}
+        <a href="{{ url }}">{{ content.field_organization }}</a>
+      {% else %}
+        {{ content.field_organization }}
+      {% endif %}
+    </p>
+  </div>
+</div>

--- a/web/themes/custom/hatter/templates/user/user--featured-speaker.html.twig
+++ b/web/themes/custom/hatter/templates/user/user--featured-speaker.html.twig
@@ -1,7 +1,7 @@
 <div{{ attributes.addClass('speaker-item') }}>
   {{ content.user_picture }}
   <div class="speaker-item__block">
-    <h3 class="speaker-item__title"><a href="#">{{ content.field_name }}</a></h3>
+    <h3 class="speaker-item__title"><a href="{{ user_link }}">{{ content.field_name }}</a></h3>
     <p class="speaker-item__subtitle">
       {{ content.field_title }}
       {% if amp %}

--- a/web/themes/custom/hatter/templates/user/user--featured-speaker.html.twig
+++ b/web/themes/custom/hatter/templates/user/user--featured-speaker.html.twig
@@ -1,7 +1,7 @@
 <div{{ attributes.addClass('speaker-item') }}>
   {{ content.user_picture }}
   <div class="speaker-item__block">
-    <h3 class="speaker-item__title"><a href="#">{{ content.field_name }}</a></h3>
+    <h3 class="speaker-item__title">{{ content.field_name }}</h3>
     <p class="speaker-item__subtitle">
       {{ content.field_title }}
       {% if amp %}


### PR DESCRIPTION
# Description

This satisfies the requirement:

> Make sure we can feature speakers f’reals like the styleguide

From the [43 Days to Midcamp document](https://docs.google.com/document/d/1NfmSQnOiYbkHHe8j6jZFboIjwQbFTaJZO48Ui_27q2I/edit#).  It includes:

- Featured Speaker view mode for User entities
- Theme hook suggestions for the new view mode
- The entityqueue module
- An entityqueue for adding Featured Speakers
- A view for controlling the entityqueue and showing Featured Speakers on the homepage
- Preprocessing for theming variables
- Template files for the view mode and its field

# To test

- `composer install`
- Import config with `drush cim -y`
- Clear caches with `drush cr`
- Visit the entityqueue at http://midcamp.org.docker.amazee.io/admin/structure/entityqueue/featured_speakers/featured_speakers.  Add some Users with the "Speaker" role (up to 3)
- Visit the homepage.  Observe that the speakers display.

![image](https://user-images.githubusercontent.com/4048700/35711400-4b9f4fc0-0782-11e8-838d-a2e39fc34bd1.png)

# Notes

I submitted a PR in the theme (https://github.com/MidCamp/Hatter/pull/39) to remove the background swirl, because it relied on a transparent, half black and white, half colorized sprite to work correctly.
![featured-speaker-styleguide](https://user-images.githubusercontent.com/4048700/35711455-9686bd0c-0782-11e8-8da4-db18bc6ca5d5.png)

That looks really cool but I didn't have a lot of time to think of nice way to fix it so things like this didn't happen:
![featured-speaker-drupal-image](https://user-images.githubusercontent.com/4048700/35711477-b24cc202-0782-11e8-89a6-90e5c6ab638a.png)
Or even this when no image was present:
![featured-speaker-drupal-no-image](https://user-images.githubusercontent.com/4048700/35711485-b943c27c-0782-11e8-9f47-8a38f6bd9ee9.png)
For now I've settled for no background image at all.
