### PR TITLE
Schedule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,9 @@
           "drupal/core": {
             "RSS view with fields give wrong URL from path field (https://www.drupal.org/node/2673980)": "https://www.drupal.org/files/issues/rss_view_with_fields-2673980-27.patch"
           },
+          "drupal/core": {
+            "The Views integration Datetime Range fields should extend the views integration for regular Datetime fields (https://www.drupal.org/node/2786577)": "https://www.drupal.org/files/issues/improve_the_views-2786577-76-core.patch"
+          },
           "drupal/twig_extensions": {
             "Error after upgrading to Drupal 8.1 (https://www.drupal.org/project/twig_extensions/issues/2726531)": "https://www.drupal.org/files/issues/error_after_upgrading-2726531-9.patch"
           },
@@ -103,3 +106,4 @@
         }
     }
 }
+

--- a/conf/drupal/config/core.date_format.day_and_time.yml
+++ b/conf/drupal/config/core.date_format.day_and_time.yml
@@ -1,0 +1,8 @@
+uuid: e084e34b-d092-4bf6-a625-e552e70c54a5
+langcode: en
+status: true
+dependencies: {  }
+id: day_and_time
+label: 'Day and Time'
+locked: false
+pattern: 'l, g:i a'

--- a/conf/drupal/config/core.date_format.long.yml
+++ b/conf/drupal/config/core.date_format.long.yml
@@ -7,4 +7,4 @@ _core:
 id: long
 label: 'Default long date'
 locked: false
-pattern: 'l, F j, Y - H:i'
+pattern: 'l, F j, Y - g:i a'

--- a/conf/drupal/config/core.date_format.medium.yml
+++ b/conf/drupal/config/core.date_format.medium.yml
@@ -7,4 +7,4 @@ _core:
 id: medium
 label: 'Default medium date'
 locked: false
-pattern: 'D, m/d/Y - H:i'
+pattern: 'D, m/d/Y - g:i a'

--- a/conf/drupal/config/core.date_format.short.yml
+++ b/conf/drupal/config/core.date_format.short.yml
@@ -7,4 +7,4 @@ _core:
 id: short
 label: 'Default short date'
 locked: false
-pattern: 'm/d/Y - H:i'
+pattern: 'm/d/Y - g:i a'

--- a/conf/drupal/config/core.date_format.time_only.yml
+++ b/conf/drupal/config/core.date_format.time_only.yml
@@ -1,0 +1,8 @@
+uuid: 5d5dcaf2-48f2-42c5-b885-706216ce97e3
+langcode: en
+status: true
+dependencies: {  }
+id: time_only
+label: 'Time Only'
+locked: false
+pattern: 'g:i a'

--- a/conf/drupal/config/core.entity_form_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.topic.default.yml
@@ -8,10 +8,13 @@ dependencies:
     - field.field.node.topic.field_event
     - field.field.node.topic.field_meta_tags
     - field.field.node.topic.field_people
+    - field.field.node.topic.field_schedule_location
+    - field.field.node.topic.field_schedule_time
     - field.field.node.topic.field_topic_type
     - field.field.node.topic.field_track
     - node.type.topic
   module:
+    - datetime_range
     - text
 id: node.topic.default
 targetEntityType: node
@@ -20,7 +23,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 4
+    weight: 6
     settings:
       rows: 9
       summary_rows: 3
@@ -28,13 +31,22 @@ content:
     third_party_settings: {  }
     region: content
   field_people:
-    weight: 3
-    settings:
-      match_operator: CONTAINS
-      size: 60
-      placeholder: ''
+    weight: 5
+    settings: {  }
     third_party_settings: {  }
-    type: entity_reference_autocomplete_tags
+    type: options_select
+    region: content
+  field_schedule_location:
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_schedule_time:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    type: daterange_default
     region: content
   field_topic_type:
     weight: 1
@@ -43,14 +55,14 @@ content:
     type: options_buttons
     region: content
   field_track:
-    weight: 2
+    weight: 4
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   status:
     type: boolean_checkbox
-    weight: 5
+    weight: 7
     region: content
     settings:
       display_label: true
@@ -64,7 +76,7 @@ content:
     third_party_settings: {  }
     region: content
   url_redirects:
-    weight: 6
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/drupal/config/core.entity_view_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.topic.default.yml
@@ -8,10 +8,13 @@ dependencies:
     - field.field.node.topic.field_event
     - field.field.node.topic.field_meta_tags
     - field.field.node.topic.field_people
+    - field.field.node.topic.field_schedule_location
+    - field.field.node.topic.field_schedule_time
     - field.field.node.topic.field_topic_type
     - field.field.node.topic.field_track
     - node.type.topic
   module:
+    - datetime_range
     - text
     - user
 id: node.topic.default
@@ -22,7 +25,7 @@ content:
   body:
     label: hidden
     type: text_default
-    weight: 1
+    weight: 3
     settings: {  }
     third_party_settings: {  }
     region: content
@@ -34,16 +37,26 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-  field_topic_type:
-    weight: 3
-    label: inline
+  field_schedule_location:
+    weight: 2
+    label: hidden
     settings:
       link: false
     third_party_settings: {  }
     type: entity_reference_label
     region: content
+  field_schedule_time:
+    weight: 1
+    label: above
+    settings:
+      timezone_override: America/Chicago
+      format_type: day_and_time
+      separator: '-'
+    third_party_settings: {  }
+    type: daterange_default
+    region: content
   field_track:
-    weight: 2
+    weight: 4
     label: inline
     settings:
       link: false
@@ -54,4 +67,5 @@ hidden:
   field_accepted_confirmed: true
   field_event: true
   field_meta_tags: true
+  field_topic_type: true
   links: true

--- a/conf/drupal/config/field.field.node.topic.field_schedule_location.yml
+++ b/conf/drupal/config/field.field.node.topic.field_schedule_location.yml
@@ -1,0 +1,29 @@
+uuid: 142c75fa-116a-4636-94e2-3445e90a00d8
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_schedule_location
+    - node.type.topic
+    - taxonomy.vocabulary.location
+id: node.topic.field_schedule_location
+field_name: field_schedule_location
+entity_type: node
+bundle: topic
+label: Location
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      location: location
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/drupal/config/field.field.node.topic.field_schedule_time.yml
+++ b/conf/drupal/config/field.field.node.topic.field_schedule_time.yml
@@ -1,0 +1,21 @@
+uuid: fcf197f4-a663-44a8-acf4-d7885f663d22
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_schedule_time
+    - node.type.topic
+  module:
+    - datetime_range
+id: node.topic.field_schedule_time
+field_name: field_schedule_time
+entity_type: node
+bundle: topic
+label: Time
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: daterange

--- a/conf/drupal/config/field.storage.node.field_schedule_location.yml
+++ b/conf/drupal/config/field.storage.node.field_schedule_location.yml
@@ -1,0 +1,20 @@
+uuid: 457eaa7a-fd93-4e7b-8faf-8da279369059
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_schedule_location
+field_name: field_schedule_location
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/field.storage.node.field_schedule_time.yml
+++ b/conf/drupal/config/field.storage.node.field_schedule_time.yml
@@ -1,0 +1,20 @@
+uuid: db5f5a71-116f-4d8c-8e57-252807cb93c9
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime_range
+    - node
+id: node.field_schedule_time
+field_name: field_schedule_time
+entity_type: node
+type: daterange
+settings:
+  datetime_type: datetime
+module: datetime_range
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/taxonomy.vocabulary.location.yml
+++ b/conf/drupal/config/taxonomy.vocabulary.location.yml
@@ -1,0 +1,9 @@
+uuid: e535e4b5-5230-4f50-b533-417d2eaf7a94
+langcode: en
+status: true
+dependencies: {  }
+name: Location
+vid: location
+description: 'Room or address'
+hierarchy: 0
+weight: 0

--- a/conf/drupal/config/views.view.schedule.yml
+++ b/conf/drupal/config/views.view.schedule.yml
@@ -1,0 +1,591 @@
+uuid: ac86e172-dc2e-4fda-8230-b0c53900574c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_people
+    - field.storage.node.field_schedule_location
+    - field.storage.node.field_schedule_time
+    - field.storage.node.field_track
+  module:
+    - datetime
+    - datetime_range
+    - node
+    - user
+id: schedule
+label: Schedule
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: none
+        options:
+          items_per_page: 0
+          offset: 0
+      style:
+        type: default
+        options:
+          grouping:
+            -
+              field: field_schedule_time
+              rendered: true
+              rendered_strip: false
+          row_class: schedule__teaser
+          default_row_class: true
+      row:
+        type: fields
+      fields:
+        field_schedule_time:
+          id: field_schedule_time
+          table: node__field_schedule_time
+          field: field_schedule_time
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: daterange_default
+          settings:
+            timezone_override: ''
+            format_type: time_only
+            separator: to
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_track:
+          id: field_track
+          table: node__field_track
+          field: field_track
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: div
+          element_class: schedule__track
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h4
+          element_class: schedule__title
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        field_people:
+          id: field_people
+          table: node__field_people
+          field: field_people
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: div
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_schedule_location:
+          id: field_schedule_location
+          table: node__field_schedule_location
+          field: field_schedule_location
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: div
+          element_class: schedule__room
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        field_schedule_time_value:
+          id: field_schedule_time_value
+          table: node__field_schedule_time
+          field: field_schedule_time_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: between
+          value:
+            min: '2018-03-09 00:00:00'
+            max: '2018-03-09 23:59:59'
+            value: ''
+            type: date
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      sorts: {  }
+      title: 'Camp Schedule'
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content:
+            value: "<div class=\"schedule__nav\">\n      <a href=\"/training\">Thursday</a> | <a href=\"/schedule/friday\">Friday</a> | <a href=\"/schedule/saturday\">Saturday</a><!-- | <a href=\"#\">Sunday</a-->\n</div>\n<h2>Friday, March 9, 2018</h2>"
+            format: full_html
+          plugin_id: text
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      css_class: schedule
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_people'
+        - 'config:field.storage.node.field_schedule_location'
+        - 'config:field.storage.node.field_schedule_time'
+        - 'config:field.storage.node.field_track'
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: schedule/friday
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_people'
+        - 'config:field.storage.node.field_schedule_location'
+        - 'config:field.storage.node.field_schedule_time'
+        - 'config:field.storage.node.field_track'
+  page_2:
+    display_plugin: page
+    id: page_2
+    display_title: 'Page 2'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      path: schedule/saturday
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content:
+            value: "<div class=\"schedule__nav\">\n      <a href=\"/training\">Thursday</a> | <a href=\"/schedule/friday\">Friday</a> | <a href=\"/schedule/saturday\">Saturday</a><!-- | <a href=\"#\">Sunday</a-->\n</div>\n<h2>Saturday, March 10, 2018</h2>"
+            format: full_html
+          plugin_id: text
+      defaults:
+        header: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        field_schedule_time_value:
+          id: field_schedule_time_value
+          table: node__field_schedule_time
+          field: field_schedule_time_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: between
+          value:
+            min: '2018-03-10 00:00:00'
+            max: '2018-03-10 23:59:59'
+            value: ''
+            type: date
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_people'
+        - 'config:field.storage.node.field_schedule_location'
+        - 'config:field.storage.node.field_schedule_time'
+        - 'config:field.storage.node.field_track'

--- a/conf/drupal/config/views.view.schedule.yml
+++ b/conf/drupal/config/views.view.schedule.yml
@@ -121,7 +121,7 @@ display:
           click_sort_column: value
           type: daterange_default
           settings:
-            timezone_override: ''
+            timezone_override: America/Chicago
             format_type: time_only
             separator: to
           group_column: value
@@ -478,11 +478,12 @@ display:
   page_1:
     display_plugin: page
     id: page_1
-    display_title: Page
+    display_title: Friday
     position: 1
     display_options:
       display_extenders: {  }
       path: schedule/friday
+      display_description: ''
     cache_metadata:
       max-age: -1
       contexts:
@@ -498,7 +499,7 @@ display:
   page_2:
     display_plugin: page
     id: page_2
-    display_title: 'Page 2'
+    display_title: Saturday
     position: 2
     display_options:
       display_extenders: {  }
@@ -577,6 +578,7 @@ display:
         operator: AND
         groups:
           1: AND
+      display_description: ''
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
- apply core patch allowing actual views date filters
- add location taxonomy for session rooms
- add new date formats
- add/configure date range field to topic content type
- add/configure location taxonomy ref to topic content type
- add schedule view with pages for /schedule/friday and /schedule/saturday

This is a simplified version of the designed schedule to get us up and running ASAP. We can work towards getting speaker photos, logos and company names on the next iteration

<img width="1440" alt="camp schedule midcamp 2018 2018-02-09 22-05-56" src="https://user-images.githubusercontent.com/984057/36058444-9e8a3308-0de5-11e8-9b27-639ffa0ae624.png">