### PR TITLE
User profile company logo

### DIFF
--- a/conf/drupal/config/core.entity_form_display.user.user.default.yml
+++ b/conf/drupal/config/core.entity_form_display.user.user.default.yml
@@ -81,6 +81,7 @@ third_party_settings:
         - field_title
         - field_organization
         - field_company_url
+        - field_company_logo
       parent_name: ''
       weight: 1
       format_type: details
@@ -116,7 +117,7 @@ content:
     type: text_textarea
     region: content
   field_company_logo:
-    weight: 19
+    weight: 7
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
@@ -210,7 +211,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 18
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/drupal/config/core.entity_form_display.user.user.default.yml
+++ b/conf/drupal/config/core.entity_form_display.user.user.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.user.user.field_bio
+    - field.field.user.user.field_company_logo
     - field.field.user.user.field_company_url
     - field.field.user.user.field_do_profile
     - field.field.user.user.field_eventbrite_email
@@ -113,6 +114,14 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: text_textarea
+    region: content
+  field_company_logo:
+    weight: 19
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
     region: content
   field_company_url:
     weight: 6

--- a/conf/drupal/config/core.entity_view_display.user.user.default.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.user.user.field_bio
+    - field.field.user.user.field_company_logo
     - field.field.user.user.field_company_url
     - field.field.user.user.field_do_profile
     - field.field.user.user.field_eventbrite_email
@@ -35,6 +36,15 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: text_default
+    region: content
+  field_company_logo:
+    weight: 9
+    label: above
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings: {  }
+    type: image
     region: content
   field_do_profile:
     weight: 2

--- a/conf/drupal/config/core.entity_view_display.user.user.default.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.default.yml
@@ -16,7 +16,7 @@ dependencies:
     - field.field.user.user.field_tracks
     - field.field.user.user.field_twitter
     - field.field.user.user.user_picture
-    - image.style.thumbnail
+    - image.style.featured_speaker
   module:
     - image
     - link
@@ -39,9 +39,9 @@ content:
     region: content
   field_company_logo:
     weight: 9
-    label: above
+    label: hidden
     settings:
-      image_style: ''
+      image_style: featured_speaker
       image_link: ''
     third_party_settings: {  }
     type: image
@@ -122,8 +122,8 @@ content:
     type: image
     weight: 0
     settings:
-      image_style: thumbnail
-      image_link: content
+      image_style: featured_speaker
+      image_link: ''
     third_party_settings: {  }
     label: hidden
     region: content

--- a/conf/drupal/config/core.entity_view_display.user.user.featured_speaker.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.featured_speaker.yml
@@ -84,6 +84,7 @@ content:
     region: content
 hidden:
   field_bio: true
+  field_company_logo: true
   field_do_profile: true
   field_eventbrite_email: true
   field_mailing_list: true

--- a/conf/drupal/config/field.field.user.user.field_company_logo.yml
+++ b/conf/drupal/config/field.field.user.user.field_company_logo.yml
@@ -1,0 +1,38 @@
+uuid: 01048857-745c-4b40-abdb-f70a5e37f27c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_company_logo
+  module:
+    - image
+    - user
+id: user.user.field_company_logo
+field_name: field_company_logo
+entity_type: user
+bundle: user
+label: 'Company Logo'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: 'png gif jpg jpeg'
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  max_resolution: ''
+  min_resolution: ''
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  max_filesize: ''
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/conf/drupal/config/field.storage.user.field_company_logo.yml
+++ b/conf/drupal/config/field.storage.user.field_company_logo.yml
@@ -1,0 +1,30 @@
+uuid: b6845113-0e7e-4470-a28c-c8700cb37fb0
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - user
+id: user.field_company_logo
+field_name: field_company_logo
+entity_type: user
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
## Description

- Adds `field_company_logo` to the User profile
- Uses `featured_speaker` image style to display user image, company logo on user entity default display
- Hides field label for `field_company_logo` on user entity default display

## To Test

- `composer install`
- `drush cim -y`
- Navigate to a User, observe the company logo field exists

## Notes

I had permissions issues in the image directory for the new field initially.  I had to `chmod` inside my Vagrant to resolve, but IIRC this is just an issue locally.