### PR TITLE
Add Speaker Bios to Session, Training nodes

### DIFF
--- a/conf/drupal/config/core.entity_view_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.topic.default.yml
@@ -22,16 +22,17 @@ content:
   body:
     label: hidden
     type: text_default
-    weight: 1
+    weight: 0
     settings: {  }
     third_party_settings: {  }
     region: content
   field_people:
-    type: entity_reference_label
-    weight: 0
+    type: entity_reference_entity_view
+    weight: 1
     region: content
     label: above
     settings:
+      view_mode: compact
       link: false
     third_party_settings: {  }
   field_topic_type:

--- a/conf/drupal/config/core.entity_view_display.node.training.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.training.default.yml
@@ -31,9 +31,10 @@ content:
     weight: 0
     label: above
     settings:
+      view_mode: compact
       link: false
     third_party_settings: {  }
-    type: entity_reference_label
+    type: entity_reference_entity_view
     region: content
   field_registration_link:
     weight: 3

--- a/conf/drupal/config/core.entity_view_display.user.user.compact.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.compact.yml
@@ -4,10 +4,23 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.user.compact
+    - field.field.user.user.field_bio
+    - field.field.user.user.field_company_url
+    - field.field.user.user.field_do_profile
+    - field.field.user.user.field_eventbrite_email
+    - field.field.user.user.field_mailing_list
+    - field.field.user.user.field_name
+    - field.field.user.user.field_organization
+    - field.field.user.user.field_site
+    - field.field.user.user.field_title
+    - field.field.user.user.field_tracks
+    - field.field.user.user.field_twitter
     - field.field.user.user.user_picture
-    - image.style.thumbnail
+    - image.style.medium
   module:
     - image
+    - name
+    - text
     - user
 _core:
   default_config_hash: C3k_McOy8bL8rTnIjspy5OfFdgqV1z6OdGZaI-tO5eM
@@ -16,6 +29,45 @@ targetEntityType: user
 bundle: user
 mode: compact
 content:
+  field_bio:
+    type: text_default
+    weight: 4
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  field_name:
+    type: name_default
+    weight: 1
+    region: content
+    label: hidden
+    settings:
+      format: default
+      output: plain
+      multiple: default
+      multiple_delimiter: ', '
+      multiple_and: text
+      multiple_delimiter_precedes_last: never
+      multiple_el_al_min: '3'
+      multiple_el_al_first: '1'
+      markup: false
+    third_party_settings: {  }
+  field_organization:
+    type: entity_reference_label
+    weight: 3
+    region: content
+    label: hidden
+    settings:
+      link: true
+    third_party_settings: {  }
+  field_title:
+    type: string
+    weight: 2
+    region: content
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
   masquerade:
     weight: 50
     region: content
@@ -23,10 +75,17 @@ content:
     type: image
     weight: 0
     settings:
-      image_style: thumbnail
-      image_link: content
+      image_style: medium
+      image_link: ''
     third_party_settings: {  }
     label: hidden
     region: content
 hidden:
+  field_company_url: true
+  field_do_profile: true
+  field_eventbrite_email: true
+  field_mailing_list: true
+  field_site: true
+  field_tracks: true
+  field_twitter: true
   member_for: true

--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -17,7 +17,8 @@ function hatter_theme_suggestions_taxonomy_term_alter(&$suggestions, $vars, $hoo
  */
 function hatter_theme_suggestions_field_alter(&$suggestions, $vars, $hook) {
   // Add field template suggestions for user view modes.
-  if ($vars['element']['#bundle'] == 'user' && $vars['element']['#view_mode'] == 'featured_speaker') {
+  $user_view_modes = ['featured_speaker', 'compact'];
+  if ($vars['element']['#bundle'] == 'user' && in_array($vars['element']['#view_mode'], $user_view_modes)) {
     $suggestions[] = 'field__' . $vars['element']['#bundle'] . '__' .
                       $vars['element']['#field_name'] . '__' .
                       $vars['element']['#view_mode'];
@@ -39,9 +40,11 @@ function hatter_theme_suggestions_user_alter(&$suggestions, $vars, $hook) {
 function hatter_preprocess_user(&$vars) {
   $user = $vars['user'];
 
-  if ($vars['elements']['#view_mode'] == 'featured_speaker') {
+  $user_view_modes = ['featured_speaker', 'compact'];
+  if (in_array($vars['elements']['#view_mode'], $user_view_modes)) {
     $job_title = $user->get('field_title');
     $company = $user->get('field_organization');
+    $picture = $user->get('user_picture');
 
     // Only show the ampersand when both fields have value.
     if ($job_title->count() > 0 && $company->count() > 0) {
@@ -51,6 +54,10 @@ function hatter_preprocess_user(&$vars) {
     $url = $user->get('field_company_url');
     if ($url->count() > 0) {
       $vars['url'] = $user->get('field_company_url')->first()->getUrl();
+    }
+
+    if ($picture->count() > 0) {
+      $vars['picture'] = TRUE;
     }
   }
 }

--- a/web/themes/custom/hatter/templates/field/field--user--field-name--compact.html.twig
+++ b/web/themes/custom/hatter/templates/field/field--user--field-name--compact.html.twig
@@ -1,0 +1,3 @@
+{% for item in items %}
+  <h4>{{ item.content }}</h4>
+{% endfor %}

--- a/web/themes/custom/hatter/templates/field/field--user--field-organization--compact.html.twig
+++ b/web/themes/custom/hatter/templates/field/field--user--field-organization--compact.html.twig
@@ -1,0 +1,4 @@
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}
+

--- a/web/themes/custom/hatter/templates/field/field--user--field-title--compact.html.twig
+++ b/web/themes/custom/hatter/templates/field/field--user--field-title--compact.html.twig
@@ -1,0 +1,4 @@
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}
+

--- a/web/themes/custom/hatter/templates/user/user--compact.html.twig
+++ b/web/themes/custom/hatter/templates/user/user--compact.html.twig
@@ -1,0 +1,37 @@
+<div {{ attributes.addClass('clearfix') }}>
+  <div class="l-66-33--1">
+    {{ content.field_name }}
+    {{ content.field_title }}
+    {% if amp %}
+      @
+    {% endif %}
+    {% if url %}
+      <a href="{{ url }}">{{ content.field_organization }}</a>
+    {% else %}
+      {{ content.field_organization }}
+    {% endif %}
+    {{ content.field_bio }}
+  </div>
+    <div class="l-66-33--2">{{ content.user_picture }}</div>
+  </div>
+
+{#<div {{ attributes.addClass('clearfix') }}>#}
+  {#{% if picture %}#}
+    {#<div class="l-6up">{{ content.user_picture }}</div>#}
+    {#<div class="l-33-66--2">#}
+  {#{% else %}#}
+    {#<div class="l-1up">#}
+  {#{% endif %}#}
+    {#{{ content.field_name }}#}
+    {#{{ content.field_title }}#}
+    {#{% if amp %}#}
+      {#@#}
+    {#{% endif %}#}
+    {#{% if url %}#}
+      {#<a href="{{ url }}">{{ content.field_organization }}</a>#}
+    {#{% else %}#}
+      {#{{ content.field_organization }}#}
+    {#{% endif %}#}
+    {#{{ content.field_bio }}#}
+  {#</div>#}
+{#</div>#}


### PR DESCRIPTION
## Description

- Updates "Compact" view display on User entities to include basic fields:
  - Picture
  - Name
  - Job Title
  - Organization
  - About Me
- Renders User entity w/"Compact" view mode in Topic, Training nodes
- Updates preprocessing, template suggestions for use in Compact view mode
- Template files for cleaner markup

## To Test
- `composer install`
- `drush cim -y`
- View Topic nodes.  Observe the new treatment for Speaker display
- View Session nodes.  Observe the new treatment for Speaker display

## Questions

Not sure if these are looking quite right at the moment.  Would definitely like some feedback on how to improve.  Also looking for thoughts on how best to incorporate the company logo here.

### Speakers on top
For Training nodes, I left the speakers at the top:
![training](https://user-images.githubusercontent.com/4048700/36063206-6340f8ae-0e3f-11e8-8849-446963592814.png)

### Speakers on bottom
For Topic nodes, I moved the speakers to the bottom:
![topic](https://user-images.githubusercontent.com/4048700/36063209-692cbd84-0e3f-11e8-966d-becb8298d81d.png)
