### PR TITLE
Topic: Presenter slide upload

### DIFF
--- a/conf/drupal/config/core.entity_form_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.topic.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.topic.field_event
     - field.field.node.topic.field_meta_tags
     - field.field.node.topic.field_people
+    - field.field.node.topic.field_presenter_slides
     - field.field.node.topic.field_schedule_location
     - field.field.node.topic.field_schedule_time
     - field.field.node.topic.field_topic_type
@@ -15,6 +16,7 @@ dependencies:
     - node.type.topic
   module:
     - datetime_range
+    - file
     - text
 id: node.topic.default
 targetEntityType: node
@@ -35,6 +37,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: options_select
+    region: content
+  field_presenter_slides:
+    weight: 26
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
+    type: file_generic
     region: content
   field_schedule_location:
     weight: 3

--- a/conf/drupal/config/core.entity_view_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.topic.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.node.topic.field_event
     - field.field.node.topic.field_meta_tags
     - field.field.node.topic.field_people
+    - field.field.node.topic.field_presenter_slides
     - field.field.node.topic.field_schedule_location
     - field.field.node.topic.field_schedule_time
     - field.field.node.topic.field_topic_type
@@ -15,6 +16,7 @@ dependencies:
     - node.type.topic
   module:
     - datetime_range
+    - file
     - text
     - user
 id: node.topic.default
@@ -38,6 +40,13 @@ content:
       view_mode: compact
       link: false
     third_party_settings: {  }
+  field_presenter_slides:
+    weight: 5
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: file_default
+    region: content
   field_schedule_location:
     weight: 2
     label: hidden

--- a/conf/drupal/config/field.field.node.topic.field_presenter_slides.yml
+++ b/conf/drupal/config/field.field.node.topic.field_presenter_slides.yml
@@ -1,0 +1,27 @@
+uuid: 5d3dc47a-7f5a-4911-bb15-b91992592e1e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_presenter_slides
+    - node.type.topic
+  module:
+    - file
+id: node.topic.field_presenter_slides
+field_name: field_presenter_slides
+entity_type: node
+bundle: topic
+label: 'Presenter Slides'
+description: 'Upload speaker slides'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'pdf ppt pptx'
+  max_filesize: ''
+  description_field: true
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: file

--- a/conf/drupal/config/field.storage.node.field_presenter_slides.yml
+++ b/conf/drupal/config/field.storage.node.field_presenter_slides.yml
@@ -1,0 +1,23 @@
+uuid: bffd79c7-ca9e-4d99-8871-0220d5badf7c
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - node
+id: node.field_presenter_slides
+field_name: field_presenter_slides
+entity_type: node
+type: file
+settings:
+  display_field: true
+  display_default: true
+  uri_scheme: public
+  target_type: file
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
# Description

- Adds `field_presenter_slide` to the Topic node type 
  - File field
  - Limited to PDF, PPT, PPTX file extensions
  - Allows for optional display

# To Test

- `drush cim -y`
- Navigate to an existing Topics session.  Add a file in `field_presenter_slide`.  
  - Observe it allows uploading of files
  - Observe it displays on the front end
  - Observe it can be toggled on or off with the "Include file in display" boolean

# Screenshots

**Form display**
![image](https://user-images.githubusercontent.com/4048700/36352582-a5d9d5ea-1480-11e8-843d-eaaaea48cdcd.png)


**Front end display**
![image](https://user-images.githubusercontent.com/4048700/36352569-8369e8ba-1480-11e8-9442-e36cbb40b007.png)

# Questions

- What file formats should be allowed?  I arbitrarily added PDFs and PowerPoint files.
- Should web links (like Google Slides, Reveal JS presentations) be supported?  If so it might be better to refactor this with Media entities.
- If #129 is accepted, suggest we make this field "Private" so only the author (or admins) can edit it.