### PR TITLE
Buttonize the Register Today link on Training nodes

### DIFF
--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -61,3 +61,19 @@ function hatter_preprocess_user(&$vars) {
     }
   }
 }
+
+/**
+ * Implements hook_preprocess_field().
+ */
+function hatter_preprocess_field(array &$variables, $hook) {
+  switch ($variables['element']['#field_name']) {
+    case 'field_registration_link':
+      // Add button class to `field_registration_link` in the `training` node type.
+      if (isset($variables['element']['#bundle']) && $variables['element']['#bundle'] == 'training') {
+        foreach (\Drupal\Core\Render\Element::children($variables['element']) as $id) {
+          $variables['items'][$id]['content']['#options']['attributes']['class'][] = 'button--tertiary';
+        }
+      }
+      break;
+  }
+}


### PR DESCRIPTION
# Description

- Adds link class for field_registration_link with preprocess_field function

# To Test

- `drush cr`
- Visit a [training node](http://midcamp.org.docker.amazee.io/training/git-ur-pro-dev-workflow-and-go-continuous-integration-zero-hero).  Observe the Register Today link is styled as `button--tertiary`.

# Notes

- Could probably use the [Link Class](https://www.drupal.org/project/link_class) module for easier control of things like this, but in lieu of larger needs beyond this one link I went with preprocessing instead.

# Screenshot

![image](https://user-images.githubusercontent.com/4048700/36353903-4a0b93ae-1492-11e8-9cc5-d8f4e3b47193.png)

I chose `button--tertiary` for the class here, please advise if we need something different.