### PR TITLE
Organizers Page

### DIFF
--- a/conf/drupal/config/system.action.user_add_role_action.organizer.yml
+++ b/conf/drupal/config/system.action.user_add_role_action.organizer.yml
@@ -1,0 +1,14 @@
+uuid: 9aa904a7-a132-4860-afbf-8cfbf710beb8
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.organizer
+  module:
+    - user
+id: user_add_role_action.organizer
+label: 'Add the Organizer role to the selected user(s)'
+type: user
+plugin: user_add_role_action
+configuration:
+  rid: organizer

--- a/conf/drupal/config/system.action.user_remove_role_action.organizer.yml
+++ b/conf/drupal/config/system.action.user_remove_role_action.organizer.yml
@@ -1,0 +1,14 @@
+uuid: 931af774-79d3-4245-b94e-7342dcbbe6f9
+langcode: en
+status: true
+dependencies:
+  config:
+    - user.role.organizer
+  module:
+    - user
+id: user_remove_role_action.organizer
+label: 'Remove the Organizer role from the selected user(s)'
+type: user
+plugin: user_remove_role_action
+configuration:
+  rid: organizer

--- a/conf/drupal/config/user.role.organizer.yml
+++ b/conf/drupal/config/user.role.organizer.yml
@@ -1,0 +1,9 @@
+uuid: d79f367c-c1f4-424c-8588-fff1754f9ff1
+langcode: en
+status: true
+dependencies: {  }
+id: organizer
+label: Organizer
+weight: 4
+is_admin: null
+permissions: {  }

--- a/conf/drupal/config/views.view.organizers.yml
+++ b/conf/drupal/config/views.view.organizers.yml
@@ -169,7 +169,20 @@ display:
           plugin_id: user_roles
       sorts: {  }
       title: Organizers
-      header: {  }
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content:
+            value: '<p>MidCamp is organized by a group of volunteers from the Drupal community in Chicago, and beyond!</p>'
+            format: basic_html
+          plugin_id: text
       footer: {  }
       empty: {  }
       relationships: {  }

--- a/conf/drupal/config/views.view.organizers.yml
+++ b/conf/drupal/config/views.view.organizers.yml
@@ -1,0 +1,199 @@
+uuid: 25d13cdd-f33a-4c6d-8f25-c59ff9527897
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.user.featured_speaker
+    - user.role.organizer
+  module:
+    - user
+id: organizers
+label: Organizers
+module: views
+description: ''
+tag: ''
+base_table: users_field_data
+base_field: uid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access user profiles'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: none
+        options:
+          items_per_page: 0
+          offset: 0
+      style:
+        type: grid
+        options:
+          uses_fields: false
+          columns: 3
+          automatic_width: false
+          alignment: horizontal
+          col_class_default: false
+          col_class_custom: 'l-3up speaker-item'
+          row_class_default: false
+          row_class_custom: ''
+      row:
+        type: 'entity:user'
+        options:
+          relationship: none
+          view_mode: featured_speaker
+      fields:
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          entity_type: user
+          entity_field: name
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: user_name
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        status:
+          value: '1'
+          table: users_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: user
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        roles_target_id:
+          id: roles_target_id
+          table: user__roles
+          field: roles_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            organizer: organizer
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          entity_type: user
+          plugin_id: user_roles
+      sorts: {  }
+      title: Organizers
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags: {  }
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: organizers
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags: {  }


### PR DESCRIPTION
# Description

Satisfies ["organizers page" requirement](https://docs.google.com/document/d/1WBe3lO-6nPO0i5yfXNNujQMLJ4XGEui3Plh4bcAJwDk/edit#).

- Creates user role `organizer`
- Creates View `organizers` with Page display at path `/organizers`

# To Test

- Import config with `drush cim -y`
- Navigate to the [People admin page](http://midcamp.org.docker.amazee.io/admin/people).  Randomly select some users and select the Action `Add the Organizer role to the selected user(s)`.
- Navigate to the [Organizers page](http://midcamp.org.docker.amazee.io/organizers).  Observe your users with the `organizer` role are now displaying

# Notes

I set this up as a basic view page with a grid.  I am targeting the "Featured Speaker" view mode for User entities.  Do we have any preference on what this should look like?  I made these decisions arbitrarily, but am happy to take a different approach if we have something specific we want here.

One issue is that currently entities are displaying which do not have all (or in some cases any) fields populated (see screenshot below).

I can build more functionality into this View to check for things like Name or Image and filter out Organizer users who do not have those values populated, but it seems easier to make that a governance issue and just not assign roles to those users until they populate some fields.

Definitely open to suggestions on this.

# Screenshot

![image](https://user-images.githubusercontent.com/4048700/36442765-6908d996-163c-11e8-9cef-80355ff21079.png)
