### PR TITLE
Update Docker image, export prod config, add config_ignore module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "drupal-composer/drupal-scaffold": "^2.3",
         "drupal/address": "1.x-dev",
         "drupal/admin_toolbar": "^1.18",
+        "drupal/config_ignore": "^2.1",
         "drupal/config_installer": "^1.5",
         "drupal/contact_formatter": "^1.0",
         "drupal/core": "^8.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7ab199cade0d9f56fa2aba111c0ee7f7",
+    "content-hash": "24239a048bcf0cd5acbd88c8dbf2a396",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1312,6 +1312,132 @@
             "homepage": "https://www.drupal.org/project/captcha",
             "support": {
                 "source": "http://cgit.drupalcode.org/captcha"
+            }
+        },
+        {
+            "name": "drupal/config_filter",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/config_filter",
+                "reference": "8.x-1.2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/config_filter-8.x-1.2.zip",
+                "reference": "8.x-1.2",
+                "shasum": "ba3d76dc6bb1eb8644ce8997ca2890496a50ae0e"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "suggest": {
+                "drupal/config_split": "Split site configuration for different environments."
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.2",
+                    "datestamp": "1522943885",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Fabian Bircher",
+                    "homepage": "https://www.drupal.org/u/bircher",
+                    "email": "opensource@fabianbircher.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Nuvole Web",
+                    "homepage": "http://nuvole.org",
+                    "email": "info@nuvole.org",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "pescetti",
+                    "homepage": "https://www.drupal.org/user/436244"
+                }
+            ],
+            "description": "Config Filter allows other modules to interact with a ConfigStorage through filter plugins.",
+            "homepage": "https://www.drupal.org/project/config_filter",
+            "keywords": [
+                "Drupal",
+                "configuration",
+                "configuration management"
+            ],
+            "support": {
+                "source": "http://cgit.drupalcode.org/config_filter",
+                "issues": "https://www.drupal.org/project/issues/config_filter",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
+            }
+        },
+        {
+            "name": "drupal/config_ignore",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/config_ignore",
+                "reference": "8.x-2.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/config_ignore-8.x-2.1.zip",
+                "reference": "8.x-2.1",
+                "shasum": "07e00684930706632b3f2fc2a7433ffdae57cde7"
+            },
+            "require": {
+                "drupal/config_filter": "1.*",
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-2.1",
+                    "datestamp": "1507706044",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Tommy Lynge Jørgensen",
+                    "homepage": "https://www.drupal.org/u/tlyngej",
+                    "email": "tlyngej@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Fabian Bircher",
+                    "homepage": "https://www.drupal.org/u/bircher",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Ignore certain configuration during import.",
+            "homepage": "http://drupal.org/project/config_ignore",
+            "support": {
+                "source": "http://cgit.drupalcode.org/config_ignore",
+                "issues": "http://drupal.org/project/config_ignore",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
             }
         },
         {

--- a/conf/drupal/config/block.block.hatter_content.yml
+++ b/conf/drupal/config/block.block.hatter_content.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_content
 theme: hatter
 region: content
-weight: -7
+weight: -9
 provider: null
 plugin: system_main_block
 settings:

--- a/conf/drupal/config/block.block.hatter_help.yml
+++ b/conf/drupal/config/block.block.hatter_help.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_help
 theme: hatter
 region: content
-weight: -12
+weight: -14
 provider: null
 plugin: help_block
 settings:

--- a/conf/drupal/config/block.block.hatter_local_actions.yml
+++ b/conf/drupal/config/block.block.hatter_local_actions.yml
@@ -9,7 +9,7 @@ _core:
 id: hatter_local_actions
 theme: hatter
 region: content
-weight: -8
+weight: -10
 provider: null
 plugin: local_actions_block
 settings:

--- a/conf/drupal/config/block.block.hatter_messages.yml
+++ b/conf/drupal/config/block.block.hatter_messages.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_messages
 theme: hatter
 region: content
-weight: -11
+weight: -13
 provider: null
 plugin: system_messages_block
 settings:

--- a/conf/drupal/config/block.block.hatter_page_title.yml
+++ b/conf/drupal/config/block.block.hatter_page_title.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_page_title
 theme: hatter
 region: content
-weight: -9
+weight: -11
 provider: null
 plugin: page_title_block
 settings:

--- a/conf/drupal/config/block.block.midcamp2019.yml
+++ b/conf/drupal/config/block.block.midcamp2019.yml
@@ -1,0 +1,31 @@
+uuid: 27f1a127-ab54-4f1d-87c1-1c46575785a3
+langcode: en
+status: true
+dependencies:
+  content:
+    - 'block_content:basic:718a2f09-3a75-462a-9c04-3e21f78a81bb'
+  module:
+    - block_content
+    - system
+  theme:
+    - hatter
+id: midcamp2019
+theme: hatter
+region: content
+weight: -15
+provider: null
+plugin: 'block_content:718a2f09-3a75-462a-9c04-3e21f78a81bb'
+settings:
+  id: 'block_content:718a2f09-3a75-462a-9c04-3e21f78a81bb'
+  label: 'MidCamp 2019'
+  provider: block_content
+  label_display: '0'
+  status: true
+  info: ''
+  view_mode: full
+visibility:
+  request_path:
+    id: request_path
+    pages: '<front>'
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.tabs.yml
+++ b/conf/drupal/config/block.block.tabs.yml
@@ -7,7 +7,7 @@ dependencies:
 id: tabs
 theme: hatter
 region: content
-weight: -10
+weight: -12
 provider: null
 plugin: local_tasks_block
 settings:

--- a/conf/drupal/config/block.block.views_block__event_news_block_1.yml
+++ b/conf/drupal/config/block.block.views_block__event_news_block_1.yml
@@ -11,7 +11,7 @@ dependencies:
 id: views_block__event_news_block_1
 theme: hatter
 region: content
-weight: -6
+weight: -8
 provider: null
 plugin: 'views_block:event_news-block_1'
 settings:

--- a/conf/drupal/config/block.block.views_block__event_sponsors_block_2.yml
+++ b/conf/drupal/config/block.block.views_block__event_sponsors_block_2.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__event_sponsors_block_2
 theme: hatter
 region: content
-weight: -3
+weight: -5
 provider: null
 plugin: 'views_block:event_sponsors-block_2'
 settings:

--- a/conf/drupal/config/block.block.views_block__event_sponsors_block_3.yml
+++ b/conf/drupal/config/block.block.views_block__event_sponsors_block_3.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__event_sponsors_block_3
 theme: hatter
 region: content
-weight: -1
+weight: -3
 provider: null
 plugin: 'views_block:event_sponsors-block_3'
 settings:

--- a/conf/drupal/config/block.block.views_block__event_sponsors_block_4.yml
+++ b/conf/drupal/config/block.block.views_block__event_sponsors_block_4.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__event_sponsors_block_4
 theme: hatter
 region: content
-weight: -5
+weight: -7
 provider: null
 plugin: 'views_block:event_sponsors-block_4'
 settings:

--- a/conf/drupal/config/block.block.views_block__event_sponsors_block_5.yml
+++ b/conf/drupal/config/block.block.views_block__event_sponsors_block_5.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__event_sponsors_block_5
 theme: hatter
 region: content
-weight: -4
+weight: -6
 provider: null
 plugin: 'views_block:event_sponsors-block_5'
 settings:

--- a/conf/drupal/config/block.block.views_block__event_sponsors_block_6.yml
+++ b/conf/drupal/config/block.block.views_block__event_sponsors_block_6.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__event_sponsors_block_6
 theme: hatter
 region: content
-weight: 1
+weight: 2
 provider: null
 plugin: 'views_block:event_sponsors-block_6'
 settings:

--- a/conf/drupal/config/block.block.views_block__event_sponsors_block_7.yml
+++ b/conf/drupal/config/block.block.views_block__event_sponsors_block_7.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__event_sponsors_block_7
 theme: hatter
 region: content
-weight: -2
+weight: -4
 provider: null
 plugin: 'views_block:event_sponsors-block_7'
 settings:

--- a/conf/drupal/config/block.block.views_block__event_sponsors_block_8.yml
+++ b/conf/drupal/config/block.block.views_block__event_sponsors_block_8.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__event_sponsors_block_8
 theme: hatter
 region: content
-weight: 0
+weight: 1
 provider: null
 plugin: 'views_block:event_sponsors-block_8'
 settings:

--- a/conf/drupal/config/block.block.views_block__speakers_block_1.yml
+++ b/conf/drupal/config/block.block.views_block__speakers_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__speakers_block_1
 theme: hatter
 region: content
-weight: 0
+weight: -1
 provider: null
 plugin: 'views_block:speakers-block_1'
 settings:

--- a/conf/drupal/config/block.block.webform.yml
+++ b/conf/drupal/config/block.block.webform.yml
@@ -10,7 +10,7 @@ dependencies:
 id: webform
 theme: hatter
 region: content
-weight: 0
+weight: -2
 provider: null
 plugin: webform_block
 settings:

--- a/conf/drupal/config/config_ignore.settings.yml
+++ b/conf/drupal/config/config_ignore.settings.yml
@@ -1,0 +1,6 @@
+ignored_config_entities:
+  0: 'mailchimp.settings:api_key'
+  2: 'mailchimp.settings:connected_id'
+  4: 'mailchimp.settings:connected_paths'
+_core:
+  default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -12,6 +12,8 @@ module:
   color: 0
   comment: 0
   config: 0
+  config_filter: 0
+  config_ignore: 0
   contact: 0
   contact_formatter: 0
   contextual: 0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
       WEBROOT: web
 
-    image: amazeeio/drupal:php70-basic
+    image: amazeeio/drupal:php71-basic
     volumes:
       - .:/var/www/drupal/public_html
     volumes_from:


### PR DESCRIPTION
# Description

- Updates Docker image to `amazeeio/drupal:php71-basic ` to keep local environments consistent with remotes (remotes were updated to PHP 7.1 on March 28)
- Exports config from production environment (primarily content changes via block placement)
- Downloads the [Config Ignore](https://www.drupal.org/project/config_ignore) module, configured to exclude the MailChimp API (now we don't need to reset this on every `cim`)

# To Test
- `pygmy restart`
- `composer install`
- SSH into the Docker environment.  Confirm PHP 7.1 is installed with `php -v`
- Run `drush cim -y` to import config.  Observe the following:
  - Production config is imported/preserved
  - Config Ignore module is enabled and configured
  - MailChimp API keys are no longer overwritten