### PR TITLE
Make Circle Work Again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     working_directory: /var/www/drupal/public_html
 
     docker:
-      - image: amazeeio/drupal:php70-basic
+      - image: amazeeio/drupal:php71-basic
         user: drupal
     environment:
           TEST_RESULTS: /tmp/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ workflows:
   build_and_test:
     jobs:
       - build
-    filters:
-      branches:
-          ignore:
-            - gh-pages
+#    filters:
+#      branches:
+#          ignore:
+#            - gh-pages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,14 +27,3 @@ jobs:
 
       - store_test_results:
           path: $TEST_RESULTS
-
-
-workflows:
-  version: 2
-  build_and_test:
-    jobs:
-      - build
-#    filters:
-#      branches:
-#          ignore:
-#            - gh-pages


### PR DESCRIPTION
Circle was failing because of the key `filters` in the `build_and_test` workflow:
![image](https://user-images.githubusercontent.com/4048700/43603582-f0e6b954-9658-11e8-8252-feda7dac19f1.png)

This PR removes workflows entirely for now, since we are only building, and not testing.  

Additionally, use the PHP 71 docker image in Circle.