### PR TITLE
Revert "Comment out production domains"

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -25,13 +25,12 @@ environments:
         - "2018.midcamp.org":
             tls-acme: 'true'
             insecure: Redirect
-        # Uncomment these lines when the GitHub redirect to the static page is removed.
-        # - "midcamp.org":
-        #     tls-acme: 'true'
-        #     insecure: Redirect
-        # - "www.midcamp.org":
-        #     tls-acme: 'true'
-        #     insecure: Redirect
+        - "midcamp.org":
+            tls-acme: 'true'
+            insecure: Redirect
+        - "www.midcamp.org":
+            tls-acme: 'true'
+            insecure: Redirect
     cronjobs:
       - name: drush cron
         schedule: "2 * * * *"


### PR DESCRIPTION
Reverts MidCamp/midcamp#162.  Taking down the GitHub Pages splash and restoring site to the base domain.