### PR TITLE
Add 2019 registration link to front page branding block

### DIFF
--- a/web/themes/custom/hatter/templates/block/block--system-branding-block.html.twig
+++ b/web/themes/custom/hatter/templates/block/block--system-branding-block.html.twig
@@ -27,7 +27,7 @@
             <h1 class="event__title">{{ site_name }}</h1>
           {% endif %}
           <h2 class="event__subtitle">{{ site_slogan }}</h2>
-          {<a href="https://www.eventbrite.com/e/midcamp-2019-midwest-drupal-camp-chicago-illinois-tickets-52035893759" class="event__button button--primary">Register</a>}
+          <a href="https://www.eventbrite.com/e/midcamp-2019-midwest-drupal-camp-chicago-illinois-tickets-52035893759" class="event__button button--primary">Register</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Add new eventbrite link to home page branding block. 