### PR TITLE
News, Venue, Sponsors, Schedule updates

### DIFF
--- a/conf/drupal/config/block.block.views_block__event_sponsors_block_2.yml
+++ b/conf/drupal/config/block.block.views_block__event_sponsors_block_2.yml
@@ -22,9 +22,10 @@ settings:
   label_display: visible
   views_label: ''
   items_per_page: none
+  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: /2018/sponsors
+    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }

--- a/conf/drupal/config/block.block.views_block__event_sponsors_block_3.yml
+++ b/conf/drupal/config/block.block.views_block__event_sponsors_block_3.yml
@@ -22,9 +22,10 @@ settings:
   label_display: visible
   views_label: ''
   items_per_page: none
+  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: /2018/sponsors
+    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }

--- a/conf/drupal/config/block.block.views_block__event_sponsors_block_4.yml
+++ b/conf/drupal/config/block.block.views_block__event_sponsors_block_4.yml
@@ -22,9 +22,10 @@ settings:
   label_display: visible
   views_label: ''
   items_per_page: none
+  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: /2018/sponsors
+    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }

--- a/conf/drupal/config/block.block.views_block__event_sponsors_block_5.yml
+++ b/conf/drupal/config/block.block.views_block__event_sponsors_block_5.yml
@@ -22,9 +22,10 @@ settings:
   label_display: visible
   views_label: ''
   items_per_page: none
+  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: /2018/sponsors
+    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }

--- a/conf/drupal/config/block.block.views_block__event_sponsors_block_7.yml
+++ b/conf/drupal/config/block.block.views_block__event_sponsors_block_7.yml
@@ -22,9 +22,10 @@ settings:
   label_display: visible
   views_label: ''
   items_per_page: none
+  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: /2018/sponsors
+    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }

--- a/conf/drupal/config/block.block.views_block__training_block_1.yml
+++ b/conf/drupal/config/block.block.views_block__training_block_1.yml
@@ -1,0 +1,31 @@
+uuid: 2d9c0a84-34b9-4492-ad96-8d54d231c5af
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.training
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: views_block__training_block_1
+theme: hatter
+region: content
+weight: 0
+provider: null
+plugin: 'views_block:training-block_1'
+settings:
+  id: 'views_block:training-block_1'
+  label: ''
+  provider: views
+  label_display: '0'
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: '/*/training'
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -48,6 +48,7 @@ module:
   metatag: 0
   metatag_open_graph: 0
   midcamp_event_label_block: 0
+  midcamp_utility: 0
   midcamp_vbo: 0
   name: 0
   node: 0

--- a/conf/drupal/config/field.field.node.topic.field_event.yml
+++ b/conf/drupal/config/field.field.node.topic.field_event.yml
@@ -7,7 +7,7 @@ dependencies:
     - node.type.topic
     - taxonomy.vocabulary.event
   content:
-    - 'taxonomy_term:event:58ab979d-12f0-4b19-ab75-5625aa986afb'
+    - 'taxonomy_term:event:17285735-fe51-4f45-b481-321ae7af649f'
 id: node.topic.field_event
 field_name: field_event
 entity_type: node
@@ -18,7 +18,7 @@ required: false
 translatable: false
 default_value:
   -
-    target_uuid: 58ab979d-12f0-4b19-ab75-5625aa986afb
+    target_uuid: 17285735-fe51-4f45-b481-321ae7af649f
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/conf/drupal/config/field.field.node.training.field_event.yml
+++ b/conf/drupal/config/field.field.node.training.field_event.yml
@@ -7,7 +7,7 @@ dependencies:
     - node.type.training
     - taxonomy.vocabulary.event
   content:
-    - 'taxonomy_term:event:58ab979d-12f0-4b19-ab75-5625aa986afb'
+    - 'taxonomy_term:event:17285735-fe51-4f45-b481-321ae7af649f'
 id: node.training.field_event
 field_name: field_event
 entity_type: node
@@ -18,7 +18,7 @@ required: false
 translatable: true
 default_value:
   -
-    target_uuid: 58ab979d-12f0-4b19-ab75-5625aa986afb
+    target_uuid: 17285735-fe51-4f45-b481-321ae7af649f
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/conf/drupal/config/node.type.page.yml
+++ b/conf/drupal/config/node.type.page.yml
@@ -1,7 +1,27 @@
 uuid: f3822a76-63a5-4ad7-ac34-7636e23fe120
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - menu_ui
+    - scheduler
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+      - midcamp-2019-navigation
+    parent: 'main:'
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
 _core:
   default_config_hash: zhtPXoRcC6REiepM0k16zw__FDW5YOXDR6U2WlldTrs
 name: 'Basic page'

--- a/conf/drupal/config/user.role.authenticated.yml
+++ b/conf/drupal/config/user.role.authenticated.yml
@@ -14,6 +14,8 @@ permissions:
   - 'access shortcuts'
   - 'access site-wide contact form'
   - 'access user profiles'
+  - 'create topic content'
+  - 'edit own topic content'
   - 'post comments'
   - 'search content'
   - 'skip comment approval'

--- a/conf/drupal/config/views.view.event_sponsors.yml
+++ b/conf/drupal/config/views.view.event_sponsors.yml
@@ -315,13 +315,53 @@ display:
             format: basic_html
           plugin_id: text
       relationships: {  }
-      arguments: {  }
+      arguments:
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: taxonomy_tid
+          default_argument_options:
+            term_page: '1'
+            node: true
+            anyall: ','
+            limit: false
+            vids: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          plugin_id: numeric
       display_extenders: {  }
     cache_metadata:
       max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -429,6 +469,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -541,6 +582,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -653,6 +695,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -765,6 +808,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -877,6 +921,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -989,6 +1034,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -1101,6 +1147,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - user
         - 'user.node_grants:view'
         - user.permissions
@@ -1213,6 +1260,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - user
         - 'user.node_grants:view'
         - user.permissions

--- a/conf/drupal/config/views.view.event_venue.yml
+++ b/conf/drupal/config/views.view.event_venue.yml
@@ -246,9 +246,13 @@ display:
             title: All
           title_enable: false
           title: ''
-          default_argument_type: fixed
+          default_argument_type: taxonomy_tid
           default_argument_options:
-            argument: '97'
+            term_page: '1'
+            node: true
+            anyall: ','
+            limit: false
+            vids: {  }
           default_argument_skip_url: false
           summary_options:
             base_path: ''

--- a/conf/drupal/config/views.view.event_venue.yml
+++ b/conf/drupal/config/views.view.event_venue.yml
@@ -9,6 +9,7 @@ dependencies:
   module:
     - address
     - node
+    - taxonomy
     - user
 id: event_venue
 label: 'Event Venue'
@@ -230,7 +231,44 @@ display:
       footer: {  }
       empty: {  }
       relationships: {  }
-      arguments: {  }
+      arguments:
+        term_node_tid_depth:
+          id: term_node_tid_depth
+          table: node_field_data
+          field: term_node_tid_depth
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: '97'
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          depth: 0
+          break_phrase: false
+          use_taxonomy_term_path: false
+          entity_type: node
+          plugin_id: taxonomy_index_tid_depth
       display_extenders: {  }
       css_class: container
     cache_metadata:
@@ -238,6 +276,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - 'user.node_grants:view'
         - user.permissions
       tags:
@@ -255,6 +294,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - 'user.node_grants:view'
         - user.permissions
       tags:

--- a/conf/drupal/config/views.view.news.yml
+++ b/conf/drupal/config/views.view.news.yml
@@ -6,8 +6,14 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - node.type.article
     - system.menu.main
+    - system.menu.midcamp-2019-navigation
+    - taxonomy.vocabulary.event
+  content:
+    - 'taxonomy_term:event:17285735-fe51-4f45-b481-321ae7af649f'
+    - 'taxonomy_term:event:58ab979d-12f0-4b19-ab75-5625aa986afb'
   module:
     - node
+    - taxonomy
     - user
 id: news
 label: News
@@ -164,6 +170,50 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: boolean
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            - 2
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: textfield
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
       sorts:
         created:
           id: created
@@ -192,6 +242,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -202,7 +253,7 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
-      path: news
+      path: 2018/news
       menu:
         type: normal
         title: News
@@ -214,6 +265,141 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_2:
+    display_plugin: page
+    id: page_2
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: 2019/news
+      menu:
+        type: normal
+        title: News
+        description: ''
+        expanded: false
+        parent: 'menu_link_content:7561816d-7280-4de7-9626-cbb973eab912'
+        weight: -47
+        context: '0'
+        menu_name: midcamp-2019-navigation
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            article: article
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        field_article_news_value:
+          id: field_article_news_value
+          table: node__field_article_news
+          field: field_article_news_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            - 97
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: textfield
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/conf/drupal/config/views.view.news.yml
+++ b/conf/drupal/config/views.view.news.yml
@@ -282,7 +282,7 @@ display:
         title: News
         description: ''
         expanded: false
-        parent: 'menu_link_content:7561816d-7280-4de7-9626-cbb973eab912'
+        parent: 'menu_link_content:db3c8044-0b1c-4432-b89f-8a2b03de0754'
         weight: -47
         context: '0'
         menu_name: midcamp-2019-navigation

--- a/conf/drupal/config/views.view.schedule.yml
+++ b/conf/drupal/config/views.view.schedule.yml
@@ -484,7 +484,7 @@ display:
           empty: false
           tokenize: false
           content:
-            value: "<div class=\"schedule__nav\">\n      <a href=\"/training\">Thursday</a> | <a href=\"/schedule/friday\">Friday</a> | <a href=\"/schedule/saturday\">Saturday</a> | <a href=\"/sprints\">Sunday</a>\n</div>\n<h2>Friday, March 9, 2018</h2>"
+            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2018/training\">Thursday</a> | <a href=\"/2018/schedule/friday\">Friday</a> | <a href=\"/2018/schedule/saturday\">Saturday</a> | <a href=\"/2018/sprints\">Sunday</a>\r\n</div>\r\n<h2>Friday, March 9, 2018</h2>"
             format: full_html
           plugin_id: text
       footer: {  }
@@ -545,7 +545,7 @@ display:
           empty: false
           tokenize: false
           content:
-            value: "<div class=\"schedule__nav\">\n      <a href=\"/training\">Thursday</a> | <a href=\"/schedule/friday\">Friday</a> | <a href=\"/schedule/saturday\">Saturday</a> | <a href=\"/sprints\">Sunday</a>\n</div>\n<h2>Saturday, March 10, 2018</h2>"
+            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2018/training\">Thursday</a> | <a href=\"/2018/schedule/friday\">Friday</a> | <a href=\"/2018/schedule/saturday\">Saturday</a> | <a href=\"/2018/sprints\">Sunday</a>\r\n</div>\r\n<h2>Saturday, March 10, 2018</h2>"
             format: full_html
           plugin_id: text
       defaults:

--- a/conf/drupal/config/views.view.schedule.yml
+++ b/conf/drupal/config/views.view.schedule.yml
@@ -512,7 +512,7 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
-      path: schedule/friday
+      path: 2018/schedule/friday
       display_description: ''
     cache_metadata:
       max-age: -1
@@ -533,7 +533,7 @@ display:
     position: 2
     display_options:
       display_extenders: {  }
-      path: schedule/saturday
+      path: 2018/schedule/saturday
       header:
         area:
           id: area
@@ -632,7 +632,7 @@ display:
     display_options:
       display_extenders: {  }
       display_description: ''
-      path: Dwayne-social-butterfly
+      path: 2018/Dwayne-social-butterfly
       fields:
         field_schedule_time:
           id: field_schedule_time
@@ -890,6 +890,7 @@ display:
         operator: AND
         groups:
           1: AND
+      enabled: false
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.schedule_2019.yml
+++ b/conf/drupal/config/views.view.schedule_2019.yml
@@ -1,0 +1,626 @@
+uuid: 6822e821-ac3b-4500-8a07-5cbae0245d2f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_people
+    - field.storage.node.field_schedule_location
+    - field.storage.node.field_schedule_time
+    - field.storage.node.field_track
+  module:
+    - datetime
+    - datetime_range
+    - node
+    - user
+id: schedule_2019
+label: 'Schedule 2019'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: none
+        options:
+          items_per_page: 0
+          offset: 0
+      style:
+        type: default
+        options:
+          grouping:
+            -
+              field: field_schedule_time
+              rendered: true
+              rendered_strip: false
+          row_class: schedule__teaser
+          default_row_class: true
+      row:
+        type: fields
+      fields:
+        field_schedule_time:
+          id: field_schedule_time
+          table: node__field_schedule_time
+          field: field_schedule_time
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: daterange_default
+          settings:
+            timezone_override: America/Chicago
+            format_type: time_only
+            separator: to
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_track:
+          id: field_track
+          table: node__field_track
+          field: field_track
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: div
+          element_class: schedule__track
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h4
+          element_class: schedule__title
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        field_people:
+          id: field_people
+          table: node__field_people
+          field: field_people
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: div
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_schedule_location:
+          id: field_schedule_location
+          table: node__field_schedule_location
+          field: field_schedule_location
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: div
+          element_class: schedule__room
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        field_schedule_time_value:
+          id: field_schedule_time_value
+          table: node__field_schedule_time
+          field: field_schedule_time_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: between
+          value:
+            min: '2019-03-21 00:00:00'
+            max: '2019-03-22 05:00:00'
+            value: ''
+            type: date
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      sorts:
+        field_schedule_time_value:
+          id: field_schedule_time_value
+          table: node__field_schedule_time
+          field: field_schedule_time_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          granularity: minute
+          plugin_id: datetime
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+      title: 'Camp Schedule'
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content:
+            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/training\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/sprints\">Saturday</a>\r\n</div>\r\n<h2>Thursday, March 21, 2019</h2>"
+            format: full_html
+          plugin_id: text
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      css_class: schedule
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_people'
+        - 'config:field.storage.node.field_schedule_location'
+        - 'config:field.storage.node.field_schedule_time'
+        - 'config:field.storage.node.field_track'
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Thursday
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: 2019/schedule/thursday
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_people'
+        - 'config:field.storage.node.field_schedule_location'
+        - 'config:field.storage.node.field_schedule_time'
+        - 'config:field.storage.node.field_track'
+  page_2:
+    display_plugin: page
+    id: page_2
+    display_title: Friday
+    position: 2
+    display_options:
+      display_extenders: {  }
+      path: 2019/schedule/friday
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content:
+            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/training\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/sprints\">Sunday</a>\r\n</div>\r\n<h2>Friday, March 22, 2019</h2>"
+            format: full_html
+          plugin_id: text
+      defaults:
+        header: false
+        filters: false
+        filter_groups: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        field_schedule_time_value:
+          id: field_schedule_time_value
+          table: node__field_schedule_time
+          field: field_schedule_time_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: between
+          value:
+            min: '2019-03-22 05:00:00'
+            max: '2019-03-23 05:00:00'
+            value: ''
+            type: date
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_people'
+        - 'config:field.storage.node.field_schedule_location'
+        - 'config:field.storage.node.field_schedule_time'
+        - 'config:field.storage.node.field_track'

--- a/conf/drupal/config/views.view.sessions.yml
+++ b/conf/drupal/config/views.view.sessions.yml
@@ -302,7 +302,7 @@ display:
   accepted:
     display_plugin: page
     id: accepted
-    display_title: Accepted
+    display_title: 'Accepted 2018'
     position: 4
     display_options:
       display_extenders: {  }
@@ -331,7 +331,7 @@ display:
           inline: {  }
           separator: ''
           hide_empty: false
-      path: accepted-sessions
+      path: 2018/accepted-sessions
       header:
         area:
           id: area
@@ -733,6 +733,50 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: boolean
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            2: 2
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
@@ -1645,6 +1689,516 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
+  page_4:
+    display_plugin: page
+    id: page_4
+    display_title: 'Accepted 2019'
+    position: 4
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'Accepted Sessions'
+      defaults:
+        title: false
+        style: false
+        row: false
+        header: false
+        empty: false
+        fields: false
+        filters: false
+        filter_groups: false
+        sorts: false
+      style:
+        type: default
+        options:
+          row_class: schedule__teaser
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      path: 2019/accepted-sessions
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: '<p>Below is the list of accepted and confirmed sessions. We still have a handful of sessions to confirm and will post the full session schedule shortly. Thanks to all who submitted!</p>'
+            format: basic_html
+          plugin_id: text
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'Session selection and confirmation is still underway. Check back again soon.'
+            format: basic_html
+          plugin_id: text
+      fields:
+        field_track:
+          id: field_track
+          table: node__field_track
+          field: field_track
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: div
+          element_class: schedule__track
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h4
+          element_class: schedule__title
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        field_people:
+          id: field_people
+          table: node__field_people
+          field: field_people
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            topic: topic
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          group: 1
+        field_topic_type_target_id:
+          id: field_topic_type_target_id
+          table: node__field_topic_type
+          field: field_topic_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            14: 14
+          group: 1
+          exposed: false
+          expose:
+            operator_id: field_topic_type_target_id_op
+            label: 'Topic Type'
+            description: ''
+            use_operator: false
+            operator: field_topic_type_target_id_op
+            identifier: field_topic_type_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              speaker: '0'
+              content_editor: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: topic_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_track_target_id:
+          id: field_track_target_id
+          table: node__field_track
+          field: field_track_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_track_target_id_op
+            label: 'Session Track'
+            description: ''
+            use_operator: false
+            operator: field_track_target_id_op
+            identifier: field_track_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              speaker: '0'
+              content_editor: '0'
+              administrator: '0'
+              sponsor: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: session_tracks
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_accepted_confirmed_value:
+          id: field_accepted_confirmed_value
+          table: node__field_accepted_confirmed
+          field: field_accepted_confirmed_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            97: 97
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      sorts:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_people'
+        - 'config:field.storage.node.field_track'
   user_sessions:
     display_plugin: page
     id: user_sessions
@@ -1705,6 +2259,9 @@ display:
         arguments: false
         relationships: false
         access: false
+        header: false
+        filters: false
+        filter_groups: false
       relationships:
         uid:
           id: uid
@@ -1722,6 +2279,165 @@ display:
         options:
           role:
             authenticated: authenticated
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: "<p>MidCamp is looking for folks just like you to speak to our Drupal audience! Experienced speakers are always welcome, but camp is also a great place to start for first-time speakers. From the opening of session submission through the beginning of camp, we'll have communication to assist speakers (new and old) in creating engaging and informative sessions.</p>\r\n<p>Sessions submission will close December 12, 2018. <a href=\"/node/add/topic\">Submit your session today!</a></p>"
+            format: basic_html
+          plugin_id: text
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            topic: topic
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          group: 1
+        field_topic_type_target_id:
+          id: field_topic_type_target_id
+          table: node__field_topic_type
+          field: field_topic_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            14: 14
+          group: 1
+          exposed: false
+          expose:
+            operator_id: field_topic_type_target_id_op
+            label: 'Topic Type'
+            description: ''
+            use_operator: false
+            operator: field_topic_type_target_id_op
+            identifier: field_topic_type_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              speaker: '0'
+              content_editor: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: topic_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            97: 97
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
     cache_metadata:
       max-age: 0
       contexts:

--- a/conf/drupal/config/views.view.sessions.yml
+++ b/conf/drupal/config/views.view.sessions.yml
@@ -9,10 +9,13 @@ dependencies:
     - field.storage.node.field_topic_type
     - field.storage.node.field_track
     - node.type.topic
+    - taxonomy.vocabulary.event
     - taxonomy.vocabulary.session_tracks
     - taxonomy.vocabulary.topic_type
     - user.role.authenticated
   content:
+    - 'taxonomy_term:event:17285735-fe51-4f45-b481-321ae7af649f'
+    - 'taxonomy_term:event:58ab979d-12f0-4b19-ab75-5625aa986afb'
     - 'taxonomy_term:topic_type:39f8a394-f9fc-45ae-85a2-46aabfd3212f'
     - 'taxonomy_term:topic_type:f9f1e3ca-ad7f-4636-b8c2-bb5d29f7b35b'
   module:
@@ -765,12 +768,160 @@ display:
   page_1:
     display_plugin: page
     id: page_1
-    display_title: Submitted
+    display_title: 'Submitted 2018'
     position: 1
     display_options:
       display_extenders: {  }
-      path: submitted-sessions
+      path: 2018/submitted-sessions
       display_description: ''
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            topic: topic
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          group: 1
+        field_topic_type_target_id:
+          id: field_topic_type_target_id
+          table: node__field_topic_type
+          field: field_topic_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            14: 14
+          group: 1
+          exposed: false
+          expose:
+            operator_id: field_topic_type_target_id_op
+            label: 'Topic Type'
+            description: ''
+            use_operator: false
+            operator: field_topic_type_target_id_op
+            identifier: field_topic_type_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              speaker: '0'
+              content_editor: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: topic_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            2: 2
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
     cache_metadata:
       max-age: 0
       contexts:
@@ -1312,6 +1463,188 @@ display:
         - 'config:field.storage.node.body'
         - 'config:field.storage.node.field_topic_type'
         - 'config:field.storage.node.field_track'
+  page_3:
+    display_plugin: page
+    id: page_3
+    display_title: 'Submitted 2019'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: 2019/submitted-sessions
+      display_description: ''
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            topic: topic
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          group: 1
+        field_topic_type_target_id:
+          id: field_topic_type_target_id
+          table: node__field_topic_type
+          field: field_topic_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            14: 14
+          group: 1
+          exposed: false
+          expose:
+            operator_id: field_topic_type_target_id_op
+            label: 'Topic Type'
+            description: ''
+            use_operator: false
+            operator: field_topic_type_target_id_op
+            identifier: field_topic_type_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              speaker: '0'
+              content_editor: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: topic_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            97: 97
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      defaults:
+        filters: false
+        filter_groups: false
+        header: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: "<p>MidCamp is looking for folks just like you to speak to our Drupal audience! Experienced speakers are always welcome, but camp is also a great place to start for first-time speakers. From the opening of session submission through the beginning of camp, we'll have communication to assist speakers (new and old) in creating engaging and informative sessions.</p>\r\n<p>Sessions submission will close December 12, 2018. <a href=\"/node/add/topic\">Submit your session today!</a></p>"
+            format: basic_html
+          plugin_id: text
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
   user_sessions:
     display_plugin: page
     id: user_sessions

--- a/conf/drupal/config/views.view.training.yml
+++ b/conf/drupal/config/views.view.training.yml
@@ -3,20 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.teaser
     - field.storage.node.body
     - field.storage.node.field_registration_link
     - field.storage.node.field_track
-    - node.type.topic
     - node.type.training
     - system.menu.main
-    - taxonomy.vocabulary.topic_type
-  content:
-    - 'taxonomy_term:topic_type:39f8a394-f9fc-45ae-85a2-46aabfd3212f'
   module:
     - link
     - node
-    - taxonomy
     - text
     - user
 id: training
@@ -83,51 +77,132 @@ display:
       style:
         type: default
         options:
-          row_class: ''
+          grouping: {  }
+          row_class: schedule__teaser
           default_row_class: true
-          uses_fields: false
       row:
-        type: 'entity:node'
+        type: fields
         options:
-          view_mode: teaser
-      fields:
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          entity_type: node
-          entity_field: title
-          label: ''
-          alter:
-            alter_text: false
-            make_link: false
-            absolute: false
-            trim: false
-            word_boundary: false
-            ellipsis: false
-            strip_tags: false
-            html: false
+          default_field_elements: true
+          inline: {  }
+          separator: ''
           hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
+      fields:
+        field_track:
+          id: field_track
+          table: node__field_track
+          field: field_track
           relationship: none
           group_type: group
           admin_label: ''
+          label: ''
           exclude: false
-          element_type: ''
-          element_class: ''
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: div
+          element_class: schedule__track
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: true
+          element_label_colon: false
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h4
+          element_class: schedule__title
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -138,6 +213,139 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        body:
+          id: body
+          table: node__body
+          field: body
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_summary_or_trimmed
+          settings:
+            trim_length: 300
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_registration_link:
+          id: field_registration_link
+          table: node__field_registration_link
+          field: field_registration_link
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: uri
+          type: link
+          settings:
+            trim_length: 80
+            url_only: false
+            url_plain: false
+            rel: '0'
+            target: '0'
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
       filters:
         status:
           id: status
@@ -181,40 +389,26 @@ display:
           id: type
           table: node_field_data
           field: type
-          value:
-            topic: topic
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-          group: 1
-        field_topic_type_target_id:
-          id: field_topic_type_target_id
-          table: node__field_topic_type
-          field: field_topic_type_target_id
           relationship: none
           group_type: group
           admin_label: ''
-          operator: or
+          operator: in
           value:
-            14: 14
+            training: training
           group: 1
           exposed: false
           expose:
-            operator_id: field_topic_type_target_id_op
-            label: 'Topic Type'
+            operator_id: ''
+            label: ''
             description: ''
             use_operator: false
-            operator: field_topic_type_target_id_op
-            identifier: field_topic_type_target_id
+            operator: ''
+            identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-              anonymous: '0'
-              speaker: '0'
-              content_editor: '0'
-              administrator: '0'
             reduce: false
           is_grouped: false
           group_info:
@@ -228,29 +422,26 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          reduce_duplicates: false
-          type: select
-          limit: true
-          vid: topic_type
-          hierarchy: false
-          error_message: true
-          plugin_id: taxonomy_index_tid
-      sorts: {  }
-      title: 'Submitted Sessions'
-      header:
-        area:
-          id: area
-          table: views
-          field: area
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+      sorts:
+        title:
+          id: title
+          table: node_field_data
+          field: title
           relationship: none
           group_type: group
           admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: "<p>MidCamp is looking for folks just like you to speak to our Drupal audience! Experienced speakers are always welcome, but camp is also a great place to start for first-time speakers. From the opening of session submission through the beginning of camp, we'll have communication to assist speakers (new and old) in creating engaging and informative sessions.</p>\n<p>Sessions submission will close January 26, 2018. <a href=\"/node/add/topic\">Submit your session today!</a></p>"
-            format: basic_html
-          plugin_id: text
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+      title: 'Submitted Sessions'
+      header: {  }
       footer: {  }
       empty:
         area:
@@ -263,7 +454,7 @@ display:
           empty: true
           tokenize: false
           content:
-            value: 'No sessions submitted yet. What are you waiting for?'
+            value: 'Session selection and confirmation is still underway. Check back again soon.'
             format: basic_html
           plugin_id: text
       relationships: {  }
@@ -279,10 +470,74 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
-        - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.body'
+        - 'config:field.storage.node.field_registration_link'
+        - 'config:field.storage.node.field_track'
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: Block
+    position: 2
+    display_options:
+      display_extenders: {  }
+      arguments:
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: taxonomy_tid
+          default_argument_options:
+            term_page: '1'
+            node: true
+            anyall: ','
+            limit: false
+            vids: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          plugin_id: numeric
+      defaults:
+        arguments: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'
+        - 'config:field.storage.node.field_registration_link'
+        - 'config:field.storage.node.field_track'
   page_2:
     display_plugin: page
     id: page_2

--- a/conf/drupal/config/views.view.trainings.yml
+++ b/conf/drupal/config/views.view.trainings.yml
@@ -5,8 +5,11 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - node.type.topic
+    - taxonomy.vocabulary.event
     - taxonomy.vocabulary.topic_type
   content:
+    - 'taxonomy_term:event:17285735-fe51-4f45-b481-321ae7af649f'
+    - 'taxonomy_term:event:58ab979d-12f0-4b19-ab75-5625aa986afb'
     - 'taxonomy_term:topic_type:f9f1e3ca-ad7f-4636-b8c2-bb5d29f7b35b'
   module:
     - node
@@ -217,6 +220,50 @@ display:
           hierarchy: false
           error_message: true
           plugin_id: taxonomy_index_tid
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            2: 2
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
       sorts: {  }
       title: 'Submitted Trainings'
       header: {  }
@@ -255,12 +302,175 @@ display:
   page_1:
     display_plugin: page
     id: page_1
-    display_title: Submitted
+    display_title: 'Submitted 2018'
     position: 1
     display_options:
       display_extenders: {  }
-      path: submitted-trainings
+      path: 2018/submitted-trainings
       display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_2:
+    display_plugin: page
+    id: page_2
+    display_title: 'Submitted 2019'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: 2019/submitted-trainings
+      display_description: ''
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            topic: topic
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          group: 1
+        field_topic_type_target_id:
+          id: field_topic_type_target_id
+          table: node__field_topic_type
+          field: field_topic_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            - 15
+          group: 1
+          exposed: false
+          expose:
+            operator_id: field_topic_type_target_id_op
+            label: 'Topic Type (field_topic_type)'
+            description: null
+            use_operator: false
+            operator: field_topic_type_target_id_op
+            identifier: field_topic_type_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: textfield
+          limit: true
+          vid: topic_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            97: 97
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
     cache_metadata:
       max-age: -1
       contexts:

--- a/web/modules/custom/midcamp_utility/midcamp_utility.info.yml
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.info.yml
@@ -1,0 +1,5 @@
+name: 'Midcamp Utility'
+type: module
+description: 'Misc modifications and helpers'
+core: 8.x
+package: 'Midcamp'

--- a/web/modules/custom/midcamp_utility/midcamp_utility.module
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.module
@@ -41,7 +41,7 @@ function midcamp_utility_views_pre_view(ViewExecutable $view, $display_id, array
       $term_args = explode('/', $term_path);
 
       // If we've found a taxonomy term path pass the term ID.
-      if (reset($term_args) == 'taxonomy') {
+      if ($term_args[1] == 'taxonomy') {
         $tid = end($term_args);
         $view->setArguments([$tid]);
       } else {

--- a/web/modules/custom/midcamp_utility/midcamp_utility.module
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.module
@@ -40,8 +40,13 @@ function midcamp_utility_views_pre_view(ViewExecutable $view, $display_id, array
       $term_path = \Drupal::service('path.alias_manager')->getPathByAlias('/' . $parts[1]);
       $term_args = explode('/', $term_path);
 
-      // The last $term_args will be the term ID.
-      $view->args[0] = end($term_args);
+      // If we've found a taxonomy term path pass the term ID.
+      if (reset($term_args) == 'taxonomy') {
+        $view->args[0] = end($term_args);
+      } else {
+        // Otherwise default to the 2019 tid.
+        $view->args[0] = '97';
+      }
     }
   }
 }

--- a/web/modules/custom/midcamp_utility/midcamp_utility.module
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.module
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @file
+ * Contains midcamp_utility.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\views\ViewExecutable;
+
+/**
+ * Implements hook_help().
+ */
+function midcamp_utility_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the midcamp_utility module.
+    case 'help.page.midcamp_utility':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Misc modifications and helpers') . '</p>';
+      return $output;
+
+    default:
+  }
+}
+
+/**
+ * Implements hook_views_pre_view().
+ */
+function midcamp_utility_views_pre_view(ViewExecutable $view, $display_id, array &$args) {
+  // Ensure the Event Venue view gets the correct argument when contextual filters not available
+  if ($view->id() == 'event_venue') {
+    // Ensure we are on a Views page
+    $current_route = \Drupal::routeMatch();
+    if ($current_route->getParameter('view_id')) {
+      // Check the first path part for a value matching an Event term alias.
+      $current_uri = \Drupal::request()->getRequestUri();
+      $parts = explode('/', $current_uri);
+      // Get the term ID from the path
+      $term_path = \Drupal::service('path.alias_manager')->getPathByAlias('/' . $parts[1]);
+      $term_args = explode('/', $term_path);
+
+      // The last $term_args will be the term ID.
+      $view->args[0] = end($term_args);
+    }
+  }
+}

--- a/web/modules/custom/midcamp_utility/midcamp_utility.module
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.module
@@ -42,10 +42,11 @@ function midcamp_utility_views_pre_view(ViewExecutable $view, $display_id, array
 
       // If we've found a taxonomy term path pass the term ID.
       if (reset($term_args) == 'taxonomy') {
-        $view->args[0] = end($term_args);
+        $tid = end($term_args);
+        $view->setArguments([$tid]);
       } else {
         // Otherwise default to the 2019 tid.
-        $view->args[0] = '97';
+        $view->setArguments(['97']);
       }
     }
   }

--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -87,17 +87,3 @@ function hatter_preprocess_field(array &$variables, $hook) {
       break;
   }
 }
-
-function hatter_preprocess_views_view(&$variables) {
-  /**
-   * If there are no default args for this view, try to pull them from the path alias.
-   * Need to match the first part of the path pattern to a known Event term alias.
-   * Good for dynamic content like Views pages that do not have a term ID associated with them.
-   */
-  if ($variables['id'] == 'event_venue') {
-    dump($variables);
-    dump($variables['view']->args);
-//    if ($variables['view']->args == )
-    // if there are no args, set them with $variables['view']->setArguments();
-  }
-}

--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -87,3 +87,17 @@ function hatter_preprocess_field(array &$variables, $hook) {
       break;
   }
 }
+
+function hatter_preprocess_views_view(&$variables) {
+  /**
+   * If there are no default args for this view, try to pull them from the path alias.
+   * Need to match the first part of the path pattern to a known Event term alias.
+   * Good for dynamic content like Views pages that do not have a term ID associated with them.
+   */
+  if ($variables['id'] == 'event_venue') {
+    dump($variables);
+    dump($variables['view']->args);
+//    if ($variables['view']->args == )
+    // if there are no args, set them with $variables['view']->setArguments();
+  }
+}


### PR DESCRIPTION
## Description

- Updates News view
    - Adds filter to primary display for 2018 content
    - Creates second display to show 2019 content
    - Adds 2019 display to the "About" menu (consistent with 2018 event IA)
- Updates Venue view
    - Adds contextual filter for `event` term ID to show the Venue for the event relative to the page you are viewing
- Creates `midcamp_utility` basic helper module
    - Uses `hook_views_pre_view()` to find a term ID to pass to the event view when one is not available (like on Views pages)
- Updates Sponsors view
    - Adds contextual filter for `event` term ID to show the sponsors relative to the page
    - Updates all Sponsor view blocks to be placed on paths `/*/sponsors`.  Previously was `/2018/sponsors`--now allows for multiple event year sponsor pages
- Updates Schedule view
    - Adds 2018 year to the path, consistent with new path patterns
    - Updates header links for schedule nav
    - Disables unused `page_3` display
- Creates 2019 Schedule view
    - Dupes existing Schedule view, a stopgap measure until additional multi-year functionality is built
- Updates `field_event` on the Training, Topic content types to default to `Midcamp 2019`
    - Ensures training proposals, topic proposals created will be created for the current event year
- Updates Training view
    - Adds contextual filter for `event` term ID to show the training relative to the page
    - Updates all Training view blocks to be placed on paths `/*/training` to populate all event year trainings
- Updates Trainings view
    - Sets up displays for 2018/submitted-trainings and 2019/submitted-trainings
- Updates Basic Page content type to allow placement on new 2019 nav menu
- Updates Sessions view
    - Submitted/Accepted pages created for new event year
    - User profile tab updated to filter to current year

## Testing

Test this PR at https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/ 

- [ ] Observe [2018 News](https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/2018/news) is displaying
- [ ] Observe [2019 News](https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/2019/news) is displaying
- [ ] Observe the Venue view in the footer is displaying the correct venue for the year of the event.  Try on a variety of pages including Views pages ([2019 News](https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/2019/news) and [2018 News](https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/2018/news)), Event pages ([2019](https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/) and [2018](https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/2018)), Topics pages ([2018 Topic](https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/2018/topic-proposal/welcoming-words) and your own created 2019 topic), etc.
- [ ] Visit the [2018 Sponsors page](https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/2018/sponsors) and observe it is showing 2018 sponsors (the missing images are expected, files have not been synced to this environment)
- [ ] Create some sponsors for 2019.  Create a Basic Page with a path alias of `/2019/sponsors` and observe they will appear here too
- [ ] Visit the [2019 Schedule](https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/2019/schedule/thursday).  Observe it has some test content in it, and that it follows the pattern set forth in the [2018 schedule](https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/2018/schedule/friday)
- [ ] Visit the [2019 Training](https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/2019/training) page.  Observe it displays 2019 training nodes.
- [ ] [Add a Topic node](https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/node/add/topic) as an authenticated user.  Observe you can submit your call for papers successfully, and that the node is associated with the current year's event
- [ ] Visit the 2018 [Submitted Sessions](https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/2018/submitted-sessions) and [Accepted Sessions](https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/2018/accepted-sessions) pages.  Observe they work and are limited to 2018 content.
- [ ] Visit the 2019 [Submitted Sessions](https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/2019/submitted-sessions) and [Accepted Sessions](https://nginx-midcamp-org-feature-2019-post-launch-updates.us.amazee.io/2019/accepted-sessions) pages.  Observe they work and are limited to 2019 content.
- [ ] Visit the 2018 (2018/submitted-trainings) and 2019 (2019/submitted-trainings) trainings pages to observe they work as well

## Notes

At the moment I think random pages not generated by Views and without a `field_event` value will show no footer.  There shouldn't be many of these left, but I'll get those sorted out separately, as not to hold up the work needed to open Call For Papers. 

Some of this work is getting us closer to real multiyear functionality, while others (like duplicating the 2018 schedule View for 2019) is simply stopgap measures for now.  At minimum, I'm trying to follow the existing patterns set out from last year's content model, but bigger changes will come later.