### PR TITLE
Update production config, ensure Sponsor/Venue views get args, fix organization links

### DIFF
--- a/conf/drupal/config/block.block.views_block__event_sponsors_block_1.yml
+++ b/conf/drupal/config/block.block.views_block__event_sponsors_block_1.yml
@@ -26,6 +26,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: '/2018/*'
-    negate: false
+    pages: '2018*'
+    negate: true
     context_mapping: {  }

--- a/conf/drupal/config/block.block.views_block__event_sponsors_block_6.yml
+++ b/conf/drupal/config/block.block.views_block__event_sponsors_block_6.yml
@@ -22,9 +22,10 @@ settings:
   label_display: visible
   views_label: ''
   items_per_page: none
+  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: /2018/sponsors
+    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }

--- a/conf/drupal/config/block.block.views_block__event_sponsors_block_8.yml
+++ b/conf/drupal/config/block.block.views_block__event_sponsors_block_8.yml
@@ -22,9 +22,10 @@ settings:
   label_display: visible
   views_label: ''
   items_per_page: none
+  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: /2018/sponsors
+    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }

--- a/conf/drupal/config/views.view.event_sponsors.yml
+++ b/conf/drupal/config/views.view.event_sponsors.yml
@@ -298,7 +298,7 @@ display:
           admin_label: ''
           empty: false
           tokenize: false
-          content: "<div class=\"l-1up button--center-container\">\n      <a href=\"/become-a-sponsor\" class=\"cta-link\">Become a Sponsor<span class=\"cta-arrow\"></span></a>\n      <a href=\"/2018/sponsors\" class=\"cta-link\">See all Sponsors<span class=\"cta-arrow\"></span></a>\n    </div>"
+          content: "<div class=\"l-1up button--center-container\">\r\n      <a href=\"/2019/sponsor-midcamp\" class=\"cta-link\">Become a Sponsor<span class=\"cta-arrow\"></span></a>\r\n      <a href=\"/2019/sponsors\" class=\"cta-link\">See all Sponsors<span class=\"cta-arrow\"></span></a>\r\n    </div>"
           plugin_id: text_custom
       empty:
         area:
@@ -1043,7 +1043,7 @@ display:
   block_7:
     display_plugin: block
     id: block_7
-    display_title: 'Training Sponsors block'
+    display_title: 'Summit Sponsors block'
     position: 1
     display_options:
       display_extenders: {  }
@@ -1058,7 +1058,7 @@ display:
         filter_groups: false
         css_class: false
       block_description: 'Sponsor page Training'
-      title: 'Training Sponsors'
+      title: 'Summit Sponsors'
       style:
         type: default
         options:
@@ -1240,7 +1240,7 @@ display:
         operator: AND
         groups:
           1: AND
-      title: 'Sprint Sponsors'
+      title: 'Contribution Day Sponsors'
       style:
         type: default
         options:

--- a/web/modules/custom/midcamp_utility/midcamp_utility.module
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.module
@@ -28,8 +28,9 @@ function midcamp_utility_help($route_name, RouteMatchInterface $route_match) {
  * Implements hook_views_pre_view().
  */
 function midcamp_utility_views_pre_view(ViewExecutable $view, $display_id, array &$args) {
-  // Ensure the Event Venue view gets the correct argument when contextual filters not available
-  if ($view->id() == 'event_venue') {
+  // Ensure the Event Venue, Sponsors views get the correct argument when contextual filters not available
+  $event_views = ['event_venue', 'event_sponsors'];
+  if (in_array($view->id(), $event_views)) {
     // Ensure we are on a Views page
     $current_route = \Drupal::routeMatch();
     if ($current_route->getParameter('view_id')) {
@@ -46,6 +47,13 @@ function midcamp_utility_views_pre_view(ViewExecutable $view, $display_id, array
         $view->setArguments([$tid]);
       } else {
         // Otherwise default to the 2019 tid.
+        $view->setArguments(['97']);
+      }
+    }
+    // Ensure nodes without `field_event` values default to 2019 year.
+    if ($current_route->getParameter('node')) {
+      $node = $current_route->getParameter('node');
+      if ($node->hasField('field_event') && $node->get('field_event')->isEmpty()) {
         $view->setArguments(['97']);
       }
     }

--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -62,8 +62,15 @@ function hatter_preprocess_user(&$vars) {
     }
 
     $url = $user->get('field_company_url');
-    if ($url->count() > 0) {
+    if ($url->count() > 0 && $company->count() > 0) {
+      // Get the term ID from `field_organization`
+      $organization_tid = $user->get('field_organization')->getValue();
+      $organization_tid = $organization_tid[0]['target_id'];
+      // Get the term name so we can link it to the `field_company_url` value
+      $term = Drupal\taxonomy\Entity\Term::load($organization_tid);
+
       $vars['url'] = $user->get('field_company_url')->first()->getUrl();
+      $vars['org_name'] = $term->getName();
     }
 
     if ($picture->count() > 0) {

--- a/web/themes/custom/hatter/templates/user/user--compact.html.twig
+++ b/web/themes/custom/hatter/templates/user/user--compact.html.twig
@@ -6,7 +6,7 @@
       @
     {% endif %}
     {% if url %}
-      <a href="{{ url }}">{{ content.field_organization }}</a>
+      <a href="{{ url }}">{{ org_name }}</a>
     {% else %}
       {{ content.field_organization }}
     {% endif %}


### PR DESCRIPTION
# Description 

- Exports config from `production`
- Updates `midcamp_utility_views_pre_view()` to ensure both `event_venue` and `event_sponsors` views get arguments from URL path if possible, and default to the 2019 event on nodes without events assigned.
- Updates `hatter_preprocess_user()` to get the term name from `field_organization` and passes it to TWIG for rendering (fixes bad links resulting from wrapping `item.content` in a link)

# To Test

Visit the test environment at https://nginx-midcamp-org-feature-config-views-updates.us.amazee.io.  Verify the following pages are displaying their Venue and Sponsor blocks in the footer:

- [ ] [2019/news](https://nginx-midcamp-org-feature-config-views-updates.us.amazee.io/2019/news)
- [ ] [jobs](https://nginx-midcamp-org-feature-config-views-updates.us.amazee.io/jobs)
- [ ] [2019/submitted-sessions](https://nginx-midcamp-org-feature-config-views-updates.us.amazee.io/2019/submitted-sessions)
- [ ] [speaker-terms-and-conditions](https://nginx-midcamp-org-feature-config-views-updates.us.amazee.io/speaker-terms-and-conditions)
- [ ] [topic-tracks](https://nginx-midcamp-org-feature-config-views-updates.us.amazee.io/topic-tracks)
- [ ] [code-conduct](https://nginx-midcamp-org-feature-config-views-updates.us.amazee.io/code-conduct)

Visit the [submitted sessions page](https://nginx-midcamp-org-feature-config-views-updates.us.amazee.io/2019/submitted-sessions) and click through to some sessions.  Observe the speaker companies now link to the websites and not to an internal taxonomy term (like [this one](https://nginx-midcamp-org-feature-config-views-updates.us.amazee.io/2019/topic-proposal/finding-place-where-accessibility-and-seo-happily-co-exist)).

*NOTE: Images may not display in the test environment*