### PR TITLE
Add Session Length radio to Topic nodes.

### DIFF
--- a/conf/drupal/config/core.entity_form_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.topic.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.topic.field_presenter_slides
     - field.field.node.topic.field_schedule_location
     - field.field.node.topic.field_schedule_time
+    - field.field.node.topic.field_session_length
     - field.field.node.topic.field_topic_type
     - field.field.node.topic.field_track
     - field.field.node.topic.field_video
@@ -27,7 +28,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 6
+    weight: 7
     settings:
       rows: 9
       summary_rows: 3
@@ -35,29 +36,35 @@ content:
     third_party_settings: {  }
     region: content
   field_people:
-    weight: 5
+    weight: 6
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   field_presenter_slides:
-    weight: 26
+    weight: 10
     settings:
       progress_indicator: throbber
     third_party_settings: {  }
     type: file_generic
     region: content
   field_schedule_location:
-    weight: 3
+    weight: 4
     settings: {  }
     third_party_settings: {  }
     type: options_select
     region: content
   field_schedule_time:
-    weight: 2
+    weight: 3
     settings: {  }
     third_party_settings: {  }
     type: daterange_default
+    region: content
+  field_session_length:
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
     region: content
   field_topic_type:
     weight: 1
@@ -66,20 +73,20 @@ content:
     type: options_buttons
     region: content
   field_track:
-    weight: 4
+    weight: 5
     settings: {  }
     third_party_settings: {  }
     type: options_buttons
     region: content
   field_video:
-    weight: 26
+    weight: 11
     settings: {  }
     third_party_settings: {  }
     type: video_embed_field_textfield
     region: content
   status:
     type: boolean_checkbox
-    weight: 7
+    weight: 8
     region: content
     settings:
       display_label: true
@@ -93,7 +100,7 @@ content:
     third_party_settings: {  }
     region: content
   url_redirects:
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/drupal/config/core.entity_view_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.topic.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.topic.field_presenter_slides
     - field.field.node.topic.field_schedule_location
     - field.field.node.topic.field_schedule_time
+    - field.field.node.topic.field_session_length
     - field.field.node.topic.field_topic_type
     - field.field.node.topic.field_track
     - field.field.node.topic.field_video
@@ -45,7 +46,8 @@ content:
   field_presenter_slides:
     weight: 5
     label: above
-    settings: {  }
+    settings:
+      use_description_as_link_text: true
     third_party_settings: {  }
     type: file_default
     region: content
@@ -68,7 +70,7 @@ content:
     type: daterange_default
     region: content
   field_track:
-    weight: 5
+    weight: 6
     label: inline
     settings:
       link: false
@@ -90,5 +92,6 @@ hidden:
   field_accepted_confirmed: true
   field_event: true
   field_meta_tags: true
+  field_session_length: true
   field_topic_type: true
   links: true

--- a/conf/drupal/config/field.field.node.topic.field_session_length.yml
+++ b/conf/drupal/config/field.field.node.topic.field_session_length.yml
@@ -1,0 +1,21 @@
+uuid: d89fa038-ae96-41b8-a8ab-b1893558799f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_session_length
+    - node.type.topic
+  module:
+    - options
+id: node.topic.field_session_length
+field_name: field_session_length
+entity_type: node
+bundle: topic
+label: 'Session Length'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/conf/drupal/config/field.storage.node.field_session_length.yml
+++ b/conf/drupal/config/field.storage.node.field_session_length.yml
@@ -1,0 +1,31 @@
+uuid: 998c30fa-7dc8-476c-9635-1e4ba227d741
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+    - options
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_session_length
+field_name: field_session_length
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: '30 minutes'
+      label: '30 minutes'
+    -
+      value: '60 minutes'
+      label: '60 minutes'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
# Description

Adds required field "Session Length" to Topic content type.  Available options are `30 minutes` and `60 minutes`.  

# To Test

Visit https://nginx-midcamp-org-feature-topic-time-field.us.amazee.io/, sign in and attempt to submit a session.  Observe you must select a session length. 