### PR TITLE
Update topic content type

### DIFF
--- a/conf/drupal/config/field.field.node.topic.field_topic_type.yml
+++ b/conf/drupal/config/field.field.node.topic.field_topic_type.yml
@@ -6,6 +6,8 @@ dependencies:
     - field.storage.node.field_topic_type
     - node.type.topic
     - taxonomy.vocabulary.topic_type
+  content:
+    - 'taxonomy_term:topic_type:39f8a394-f9fc-45ae-85a2-46aabfd3212f'
 id: node.topic.field_topic_type
 field_name: field_topic_type
 entity_type: node
@@ -14,7 +16,9 @@ label: 'Topic Type'
 description: ''
 required: true
 translatable: false
-default_value: {  }
+default_value:
+  -
+    target_uuid: 39f8a394-f9fc-45ae-85a2-46aabfd3212f
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/conf/drupal/config/field.storage.node.field_topic_type.yml
+++ b/conf/drupal/config/field.storage.node.field_topic_type.yml
@@ -3,8 +3,12 @@ langcode: en
 status: true
 dependencies:
   module:
+    - field_permissions
     - node
     - taxonomy
+third_party_settings:
+  field_permissions:
+    permission_type: custom
 id: node.field_topic_type
 field_name: field_topic_type
 entity_type: node


### PR DESCRIPTION
# Description 

- Defaults `field_topic_type` to "Session" on Topic node type
- Restricts access to `field_topic_type` to administrators so users can't see or change it

# To test

- Navigate to https://nginx-midcamp-org-feature-update-topic-content-type.us.amazee.io/
- Log in with a user account without the Administrator role
- Create a Topic node.  Observe you cannot see or change `field_topic_type`
- Log in as an administrator.  Look at the node you previously created and confirm it is set to "Session"