### PR TITLE
Change Speakers field to autocomplete.

### DIFF
--- a/conf/drupal/config/core.entity_form_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.topic.default.yml
@@ -37,9 +37,12 @@ content:
     region: content
   field_people:
     weight: 6
-    settings: {  }
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
-    type: options_select
+    type: entity_reference_autocomplete
     region: content
   field_presenter_slides:
     weight: 10


### PR DESCRIPTION
# Description

Updates `field_people` to use autocomplete instead of select list on Topic entity form.

# To test

- Visit /node/add/topic.  Observe the Speakers list is now autocomplete

# Screenshots

## Before
![image](https://user-images.githubusercontent.com/4048700/49395302-b80ec500-f6fb-11e8-9bf0-2ab26e794e3c.png)

## After
![image](https://user-images.githubusercontent.com/4048700/49395314-c0670000-f6fb-11e8-846a-78a091d8e76a.png)
