### PR TITLE
Update slides field permissions

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3053,21 +3053,21 @@
         },
         {
             "name": "drupal/mailchimp",
-            "version": "1.6.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupal.org/project/mailchimp",
-                "reference": "8.x-1.6"
+                "reference": "8.x-1.8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/mailchimp-8.x-1.6.zip",
-                "reference": "8.x-1.6",
-                "shasum": "38ad45cedd660e0504643d338d22c41339d711d2"
+                "url": "https://ftp.drupal.org/files/projects/mailchimp-8.x-1.8.zip",
+                "reference": "8.x-1.8",
+                "shasum": "36586deef17200065f87ef83c4c929a26ebe276d"
             },
             "require": {
                 "drupal/core": "~8.0",
-                "thinkshout/mailchimp-api-php": "1.0.6"
+                "thinkshout/mailchimp-api-php": "2.0.0"
             },
             "require-dev": {
                 "drupal/mailchimp_lists": "*"
@@ -3078,8 +3078,8 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.6",
-                    "datestamp": "1519758784",
+                    "version": "8.x-1.8",
+                    "datestamp": "1543531081",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3100,16 +3100,8 @@
             ],
             "authors": [
                 {
-                    "name": "Greg Boggs",
-                    "homepage": "https://www.drupal.org/user/153069"
-                },
-                {
                     "name": "amyvs",
                     "homepage": "https://www.drupal.org/user/3181721"
-                },
-                {
-                    "name": "caxy4",
-                    "homepage": "https://www.drupal.org/user/2735491"
                 },
                 {
                     "name": "gcb",
@@ -3128,12 +3120,16 @@
                     "homepage": "https://www.drupal.org/user/463332"
                 },
                 {
+                    "name": "rjacobsen0",
+                    "homepage": "https://www.drupal.org/user/3578420"
+                },
+                {
                     "name": "ruscoe",
                     "homepage": "https://www.drupal.org/user/2722087"
                 },
                 {
-                    "name": "seanberto",
-                    "homepage": "https://www.drupal.org/user/54109"
+                    "name": "samuel.mortenson",
+                    "homepage": "https://www.drupal.org/user/2582268"
                 },
                 {
                     "name": "tauno",
@@ -4610,32 +4606,33 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.4.2",
+            "version": "1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+                "reference": "9f83dded91781a01c63574e387eaa769be769115"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
-                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9f83dded91781a01c63574e387eaa769be769115",
+                "reference": "9f83dded91781a01c63574e387eaa769be769115",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "psr/http-message": "~1.0"
+                "psr/http-message": "~1.0",
+                "ralouphie/getallheaders": "^2.0.5"
             },
             "provide": {
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
@@ -4665,13 +4662,14 @@
             "keywords": [
                 "http",
                 "message",
+                "psr-7",
                 "request",
                 "response",
                 "stream",
                 "uri",
                 "url"
             ],
-            "time": "2017-03-20T17:10:46+00:00"
+            "time": "2018-12-04T20:46:45+00:00"
         },
         {
             "name": "igorw/get-in",
@@ -5294,6 +5292,46 @@
                 "psr-3"
             ],
             "time": "2016-10-10T12:19:37+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7.0",
+                "satooshi/php-coveralls": ">=1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "time": "2016-02-11T07:05:27+00:00"
         },
         {
             "name": "react/event-loop",
@@ -7314,16 +7352,16 @@
         },
         {
             "name": "thinkshout/mailchimp-api-php",
-            "version": "1.0.6",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thinkshout/mailchimp-api-php.git",
-                "reference": "ab0910a3e4497fbed0c0cf4e2bb7118d398ef795"
+                "reference": "ffa6cf96efe3a7e8e0de8309737a7dae40f51981"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thinkshout/mailchimp-api-php/zipball/ab0910a3e4497fbed0c0cf4e2bb7118d398ef795",
-                "reference": "ab0910a3e4497fbed0c0cf4e2bb7118d398ef795",
+                "url": "https://api.github.com/repos/thinkshout/mailchimp-api-php/zipball/ffa6cf96efe3a7e8e0de8309737a7dae40f51981",
+                "reference": "ffa6cf96efe3a7e8e0de8309737a7dae40f51981",
                 "shasum": ""
             },
             "require": {
@@ -7331,12 +7369,13 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.8.21"
+                "phpunit/phpunit": "^6.2.2"
             },
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Mailchimp\\": "src/"
+                    "Mailchimp\\": "src/",
+                    "Mailchimp\\http\\": "src/http/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -7346,7 +7385,7 @@
                 "mail",
                 "mailchimp"
             ],
-            "time": "2017-02-18T03:23:31+00:00"
+            "time": "2018-02-27T17:52:03+00:00"
         },
         {
             "name": "twig/extensions",

--- a/conf/drupal/config/field.storage.node.field_presenter_slides.yml
+++ b/conf/drupal/config/field.storage.node.field_presenter_slides.yml
@@ -3,8 +3,12 @@ langcode: en
 status: true
 dependencies:
   module:
+    - field_permissions
     - file
     - node
+third_party_settings:
+  field_permissions:
+    permission_type: custom
 id: node.field_presenter_slides
 field_name: field_presenter_slides
 entity_type: node

--- a/conf/drupal/config/user.role.anonymous.yml
+++ b/conf/drupal/config/user.role.anonymous.yml
@@ -16,6 +16,7 @@ permissions:
   - 'search content'
   - 'use text format restricted_html'
   - 'view field_accepted_confirmed'
+  - 'view field_presenter_slides'
   - 'view field_schedule_location'
   - 'view field_schedule_time'
   - 'view own field_accepted_confirmed'

--- a/conf/drupal/config/user.role.authenticated.yml
+++ b/conf/drupal/config/user.role.authenticated.yml
@@ -24,6 +24,7 @@ permissions:
   - 'use text format basic_html'
   - 'use text format basic_html'
   - 'view field_accepted_confirmed'
+  - 'view field_presenter_slides'
   - 'view field_schedule_location'
   - 'view field_schedule_time'
   - 'view own field_accepted_confirmed'


### PR DESCRIPTION
# Description

- Updates Mailchimp module (among other things, was causing errors on field settings saves https://www.drupal.org/project/mailchimp/issues/2949234)
- Sets field permissions for `field_presenter_slides` so only admins can modify

# To test

- [ ] Visit https://nginx-midcamp-org-feature-slides-field-permissions.us.amazee.io.  Create a new account and add a topic node.  Observe the slides field is gone