### PR TITLE
Create VBO action to unset field_accepted_confirmed

### DIFF
--- a/conf/drupal/config/system.action.topic_reject.yml
+++ b/conf/drupal/config/system.action.topic_reject.yml
@@ -1,0 +1,12 @@
+uuid: e1c4e240-b127-4838-9e96-54b36a33202c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - midcamp_vbo
+id: topic_reject
+label: 'Reject or unconfirm topic'
+type: node
+plugin: topic_reject
+configuration: {  }

--- a/web/modules/custom/midcamp_vbo/config/install/system.action.topic_reject.yml
+++ b/web/modules/custom/midcamp_vbo/config/install/system.action.topic_reject.yml
@@ -1,0 +1,11 @@
+id: topic_reject
+label: 'Reject or unconfirm topic'
+status: true
+langcode: en
+type: node
+plugin: topic_reject
+dependencies:
+  module:
+    - node
+    - midcamp_vbo
+

--- a/web/modules/custom/midcamp_vbo/config/schema/midcamp_vbo.schema.yml
+++ b/web/modules/custom/midcamp_vbo/config/schema/midcamp_vbo.schema.yml
@@ -2,3 +2,6 @@
 action.configuration.topic_accept_confirm:
   type: action_configuration_default
   label: 'Accept and confirm topic'
+action.configuration.topic_reject:
+  type: action_configuration_default
+  label: 'Reject and un-confirm topic'

--- a/web/modules/custom/midcamp_vbo/src/Plugin/Action/TopicReject.php
+++ b/web/modules/custom/midcamp_vbo/src/Plugin/Action/TopicReject.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\midcamp_vbo\Plugin\Action;
+
+use Drupal\Core\Action\ActionBase;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Reject or un-confirm topic.
+ *
+ * @Action(
+ *  id = "topic_reject",
+ *  label = @Translation("Reject or un-confirm topic"),
+ *  type = "node",
+ * )
+ */
+class TopicReject extends ActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($entity = NULL) {
+    if ($entity->hasField('field_accepted_confirmed')) {
+      $entity->field_accepted_confirmed->value = 0;
+      $entity->save();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    $access = $object->status->access('edit', $account, TRUE)
+      ->andIf($object->field_accepted_confirmed->access('edit', $account, TRUE));
+
+    return $return_as_object ? $access : $access->isAllowed();
+  }
+
+}


### PR DESCRIPTION
# Description

Adds inverse action to the one provided by `Drupal\midcamp_vbo\Plugin\Action\TopicAcceptConfirm`.

# To Test

- Visit https://nginx-midcamp-org-feature-vbo-action.us.amazee.io/ 
- Navigate to the content overview page
- Select a confirmed node and use the bulk operations action "Reject or unconfirm topic"
- Observe that the node is no longer accepted