### PR TITLE
Set primary button class for Trainings, Summits.

### DIFF
--- a/conf/drupal/config/views.view.summits.yml
+++ b/conf/drupal/config/views.view.summits.yml
@@ -294,7 +294,7 @@ display:
             trim_whitespace: false
             alt: ''
             rel: ''
-            link_class: button--tertiary
+            link_class: button--primary
             prefix: ''
             suffix: ''
             target: ''

--- a/conf/drupal/config/views.view.training.yml
+++ b/conf/drupal/config/views.view.training.yml
@@ -778,7 +778,7 @@ display:
             trim_whitespace: false
             alt: ''
             rel: ''
-            link_class: button--tertiary
+            link_class: button--primary
             prefix: ''
             suffix: ''
             target: ''
@@ -847,7 +847,7 @@ display:
             preserve_tags: ''
             html: false
           element_type: ''
-          element_class: button--tertiary
+          element_class: button--primary
           element_label_type: ''
           element_label_class: ''
           element_label_colon: false

--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -86,9 +86,10 @@ function hatter_preprocess_field(array &$variables, $hook) {
   switch ($variables['element']['#field_name']) {
     case 'field_registration_link':
       // Add button class to `field_registration_link` in the `training` node type.
-      if (isset($variables['element']['#bundle']) && $variables['element']['#bundle'] == 'training') {
+      $registration_nodes = ['training', 'summit'];
+      if (isset($variables['element']['#bundle']) && in_array($variables['element']['#bundle'], $registration_nodes)) {
         foreach (\Drupal\Core\Render\Element::children($variables['element']) as $id) {
-          $variables['items'][$id]['content']['#options']['attributes']['class'][] = 'button--tertiary';
+          $variables['items'][$id]['content']['#options']['attributes']['class'][] = 'button--primary';
         }
       }
       break;


### PR DESCRIPTION
# Description

Sets `button--primary` class for registration links on Summit, Training nodes and landing pages.

# To Test

Visit the following pages, observing the button styles are consistent with the primary button styles in [Hatter](https://midcamp.github.io/Hatter/elements/element-buttons/):

- Summit node
- Summit landing
- Training node
- Training landing

# Screenshots

![image](https://user-images.githubusercontent.com/4048700/52445165-f8b9fe80-2aef-11e9-87da-712f54887990.png)
