### PR TITLE
Update Schedule Display

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4937,12 +4937,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/MidCamp/Hatter.git",
-                "reference": "6546bba49137f2daf0ca3820897c5a8e5dabd00c"
+                "reference": "d2475e67545ad72536da1846dac43ff7fb258c5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MidCamp/Hatter/zipball/6546bba49137f2daf0ca3820897c5a8e5dabd00c",
-                "reference": "6546bba49137f2daf0ca3820897c5a8e5dabd00c",
+                "url": "https://api.github.com/repos/MidCamp/Hatter/zipball/d2475e67545ad72536da1846dac43ff7fb258c5f",
+                "reference": "d2475e67545ad72536da1846dac43ff7fb258c5f",
                 "shasum": ""
             },
             "require": {
@@ -4961,7 +4961,7 @@
                 "source": "https://github.com/MidCamp/Hatter/tree/master",
                 "issues": "https://github.com/MidCamp/Hatter/issues"
             },
-            "time": "2018-11-26T22:02:11+00:00"
+            "time": "2019-02-16T17:17:12+00:00"
         },
         {
             "name": "oomphinc/composer-installers-extender",

--- a/conf/drupal/config/core.entity_view_display.user.user.schedule.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.schedule.yml
@@ -17,7 +17,7 @@ dependencies:
     - field.field.user.user.field_tracks
     - field.field.user.user.field_twitter
     - field.field.user.user.user_picture
-    - image.style.medium
+    - image.style.schedule_presenter
   module:
     - image
     - name
@@ -33,7 +33,7 @@ content:
     weight: 3
     label: hidden
     settings:
-      image_style: featured_speaker
+      image_style: medium
       image_link: ''
     third_party_settings: {  }
     type: image
@@ -66,7 +66,7 @@ content:
     type: image
     weight: 0
     settings:
-      image_style: medium
+      image_style: schedule_presenter
       image_link: ''
     third_party_settings: {  }
     label: hidden

--- a/conf/drupal/config/core.entity_view_display.user.user.schedule.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.schedule.yml
@@ -1,0 +1,84 @@
+uuid: 4d001b51-06bd-4420-ab8d-9a39816a63c3
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.user.schedule
+    - field.field.user.user.field_bio
+    - field.field.user.user.field_company_logo
+    - field.field.user.user.field_company_url
+    - field.field.user.user.field_do_profile
+    - field.field.user.user.field_eventbrite_email
+    - field.field.user.user.field_mailing_list
+    - field.field.user.user.field_name
+    - field.field.user.user.field_organization
+    - field.field.user.user.field_site
+    - field.field.user.user.field_title
+    - field.field.user.user.field_tracks
+    - field.field.user.user.field_twitter
+    - field.field.user.user.user_picture
+    - image.style.medium
+  module:
+    - image
+    - name
+    - user
+_core:
+  default_config_hash: L2mtwGWH_7wDRCMIR4r_Iu_jmvQ10DV1L8ht8iNZ5qY
+id: user.user.schedule
+targetEntityType: user
+bundle: user
+mode: schedule
+content:
+  field_company_logo:
+    weight: 3
+    label: hidden
+    settings:
+      image_style: featured_speaker
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+    region: content
+  field_name:
+    weight: 1
+    label: hidden
+    settings:
+      format: default
+      markup: false
+      output: default
+      multiple: default
+      multiple_delimiter: ', '
+      multiple_and: text
+      multiple_delimiter_precedes_last: never
+      multiple_el_al_min: '3'
+      multiple_el_al_first: '1'
+    third_party_settings: {  }
+    type: name_default
+    region: content
+  field_organization:
+    weight: 2
+    label: hidden
+    settings:
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  user_picture:
+    type: image
+    weight: 0
+    settings:
+      image_style: medium
+      image_link: ''
+    third_party_settings: {  }
+    label: hidden
+    region: content
+hidden:
+  field_bio: true
+  field_company_url: true
+  field_do_profile: true
+  field_eventbrite_email: true
+  field_mailing_list: true
+  field_site: true
+  field_title: true
+  field_tracks: true
+  field_twitter: true
+  member_for: true

--- a/conf/drupal/config/core.entity_view_mode.user.schedule.yml
+++ b/conf/drupal/config/core.entity_view_mode.user.schedule.yml
@@ -1,0 +1,10 @@
+uuid: 985a68c0-8b52-41bd-809d-e38c95315f3f
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: user.schedule
+label: Schedule
+targetEntityType: user
+cache: true

--- a/conf/drupal/config/image.style.schedule_presenter.yml
+++ b/conf/drupal/config/image.style.schedule_presenter.yml
@@ -1,0 +1,15 @@
+uuid: 8fe11307-3e80-48ca-a377-e946879994c0
+langcode: en
+status: true
+dependencies: {  }
+name: schedule_presenter
+label: 'Schedule Presenter'
+effects:
+  0a9c18b8-9c13-4df4-8d90-9cd540cfd8a9:
+    uuid: 0a9c18b8-9c13-4df4-8d90-9cd540cfd8a9
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 400
+      height: 400
+      anchor: center-center

--- a/conf/drupal/config/views.view.schedule_2019.yml
+++ b/conf/drupal/config/views.view.schedule_2019.yml
@@ -239,7 +239,7 @@ display:
             trim: false
             preserve_tags: ''
             html: false
-          element_type: h4
+          element_type: h3
           element_class: schedule__title
           element_label_type: ''
           element_label_class: ''

--- a/conf/drupal/config/views.view.schedule_2019.yml
+++ b/conf/drupal/config/views.view.schedule_2019.yml
@@ -312,9 +312,9 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: target_id
-          type: entity_reference_label
+          type: entity_reference_entity_view
           settings:
-            link: false
+            view_mode: schedule
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -323,7 +323,7 @@ display:
           delta_reversed: false
           delta_first_last: false
           multi_type: separator
-          separator: ', '
+          separator: ' '
           field_api_classes: false
           plugin_id: field
         field_schedule_location:

--- a/conf/drupal/config/views.view.schedule_2019.yml
+++ b/conf/drupal/config/views.view.schedule_2019.yml
@@ -69,6 +69,11 @@ display:
           default_row_class: true
       row:
         type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: false
       fields:
         field_schedule_time:
           id: field_schedule_time
@@ -299,7 +304,7 @@ display:
             trim: false
             preserve_tags: ''
             html: false
-          element_type: div
+          element_type: '0'
           element_class: ''
           element_label_type: ''
           element_label_class: ''

--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -17,7 +17,7 @@ function hatter_theme_suggestions_taxonomy_term_alter(&$suggestions, $vars, $hoo
  */
 function hatter_theme_suggestions_field_alter(&$suggestions, $vars, $hook) {
   // Add field template suggestions for user view modes.
-  $user_view_modes = ['featured_speaker', 'compact'];
+  $user_view_modes = ['featured_speaker', 'compact', 'schedule'];
   if ($vars['element']['#bundle'] == 'user' && in_array($vars['element']['#view_mode'], $user_view_modes)) {
     $suggestions[] = 'field__' . $vars['element']['#bundle'] . '__' .
                       $vars['element']['#field_name'] . '__' .

--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -93,6 +93,26 @@ function hatter_preprocess_field(array &$variables, $hook) {
         }
       }
       break;
+    case 'field_name':
+      /**
+       * Pull field_organization into the field_name template to concatenate.
+       *
+       * See @file field--user--field-name--schedule.html.twig
+       */
+      if ($variables['entity_type'] == 'user' && $variables['element']['#view_mode'] == 'schedule') {
+        $user = $variables['element']['#object'];
+
+        if ($user->get('field_organization')->getValue()) {
+          // Get the term ID from `field_organization`
+          $organization_tid = $user->get('field_organization')->getValue();
+          $organization_tid = $organization_tid[0]['target_id'];
+          // Get the term name so we can add it to the `field_name` template
+          $term = Drupal\taxonomy\Entity\Term::load($organization_tid);
+
+          $variables['org_name'] = $term->getName();
+        }
+      }
+      break;
   }
 }
 

--- a/web/themes/custom/hatter/templates/field/field--user--field-company-logo--schedule.html.twig
+++ b/web/themes/custom/hatter/templates/field/field--user--field-company-logo--schedule.html.twig
@@ -1,0 +1,19 @@
+{#
+/**
+ * @file
+ * Theme override to present all user data.
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ *   print a subset such as 'content.field_example'. Fields attached to a user
+ *   such as 'user_picture' are available as 'content.user_picture'.
+ * - attributes: HTML attributes for the container element.
+ * - user: A Drupal User entity.
+ *
+ * @see template_preprocess_user()
+ */
+#}
+<div{{ attributes.addClass('schedule__speaker__logo') }}>
+  {%- for item in items -%}
+    {{ item.content }}
+  {%- endfor -%}
+</div>

--- a/web/themes/custom/hatter/templates/field/field--user--field-name--schedule.html.twig
+++ b/web/themes/custom/hatter/templates/field/field--user--field-name--schedule.html.twig
@@ -1,4 +1,9 @@
 {% for item in items %}
-  <div{{ attributes.addClass('schedule__speaker__name') }}><strong>{{ item.content }}</strong></div>
+  <div{{ attributes.addClass('schedule__speaker__name') }}>
+  {% if org_name %}
+    <strong>{{- item.content -}}</strong>,&nbsp;{{- org_name -}}
+  {% else %}
+    <strong>{{- item.content -}}</strong>
+  {% endif %}
+  </div>
 {% endfor %}
-

--- a/web/themes/custom/hatter/templates/field/field--user--field-name--schedule.html.twig
+++ b/web/themes/custom/hatter/templates/field/field--user--field-name--schedule.html.twig
@@ -1,0 +1,4 @@
+{% for item in items %}
+  <div{{ attributes.addClass('schedule__speaker__name') }}><strong>{{ item.content }}</strong></div>
+{% endfor %}
+

--- a/web/themes/custom/hatter/templates/field/field--user--user-picture--schedule.html.twig
+++ b/web/themes/custom/hatter/templates/field/field--user--user-picture--schedule.html.twig
@@ -1,0 +1,10 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ */
+#}
+
+{% for item in items %}
+  <div{{ attributes.addClass('schedule__speaker__photo') }}>{{ item.content }}</div>
+{% endfor %}

--- a/web/themes/custom/hatter/templates/user/user--schedule.html.twig
+++ b/web/themes/custom/hatter/templates/user/user--schedule.html.twig
@@ -1,0 +1,19 @@
+{#
+/**
+ * @file
+ * Theme override to present all user data.
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ *   print a subset such as 'content.field_example'. Fields attached to a user
+ *   such as 'user_picture' are available as 'content.user_picture'.
+ * - attributes: HTML attributes for the container element.
+ * - user: A Drupal User entity.
+ *
+ * @see template_preprocess_user()
+ */
+#}
+<div{{ attributes.addClass('schedule__speaker') }}>
+  {% if content %}
+    {{- content -}}
+  {% endif %}
+</div>

--- a/web/themes/custom/hatter/templates/user/user--schedule.html.twig
+++ b/web/themes/custom/hatter/templates/user/user--schedule.html.twig
@@ -14,6 +14,6 @@
 #}
 <div{{ attributes.addClass('schedule__speaker') }}>
   {% if content %}
-    {{- content -}}
+    {{- content|without('field_organization') -}}
   {% endif %}
 </div>


### PR DESCRIPTION
# Description

In conjunction with [Style Guide PR 41](https://github.com/MidCamp/Hatter/pull/41), this updates the Schedule display to show speaker images, titles and company logos.  

Changes include:

- Introduction of a `schedule` view mode for `User` entities
- Introduction of a `schedule_presenter` image style to crop an appropriately sized square image (required for the border radius on `.schedule__speaker__photo`)
- Updates to the `schedule_2019` view to use the `schedule` view mode, remove extraneous wrapping divs
- Use `h3` for session titles
- Create new template suggestions for fields on the `schedule` user view mode
- Writes `field_organization` value into the `field_name` template via `hatter_preprocess_field()` to resolve a nagging whitespace issue that should have been easier to resolve in TWIG
- Adds various TWIG templates for appropriate elements and classes

# To Test

- Check out this branch locally
- In your style guide directory `cd styleguide` check out the `feature/schedule-updates-grid` branch
- Navigate to http://midcamp.org.docker.amazee.io/2019/schedule/thursday and observe the new styles

# Screenshots

## Desktop
![image](https://user-images.githubusercontent.com/4048700/52902598-cd629e00-31d8-11e9-9ec3-74e968c6bdb5.png)

## Tablet
![image](https://user-images.githubusercontent.com/4048700/52902577-6a710700-31d8-11e9-98ef-3ead75dfe015.png)

## Mobile
![image](https://user-images.githubusercontent.com/4048700/52902584-9ee4c300-31d8-11e9-95d1-65d9826f80cc.png)

