### PR TITLE
Multi year organizers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,8 @@
     "extra": {
         "patches": {
           "drupal/core": {
-            "RSS view with fields give wrong URL from path field (https://www.drupal.org/node/2673980)": "https://www.drupal.org/files/issues/rss_view_with_fields-2673980-27.patch"
+            "RSS view with fields give wrong URL from path field (https://www.drupal.org/node/2673980)": "https://www.drupal.org/files/issues/rss_view_with_fields-2673980-27.patch",
+            "Add hook_post_config_import_NAME after config import (https://www.drupal.org/project/drupal/issues/2901418)": "https://www.drupal.org/files/issues/2019-02-01/2901418-28.patch"
           },
           "drupal/twig_extensions": {
             "Error after upgrading to Drupal 8.1 (https://www.drupal.org/project/twig_extensions/issues/2726531)": "https://www.drupal.org/files/issues/error_after_upgrading-2726531-9.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4348d8cc4fa80616b94c24e5d02948fb",
+    "content-hash": "fd1c0ee88955f578b00532363c27d587",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1989,7 +1989,8 @@
                     "merge-extra": false
                 },
                 "patches_applied": {
-                    "RSS view with fields give wrong URL from path field (https://www.drupal.org/node/2673980)": "https://www.drupal.org/files/issues/rss_view_with_fields-2673980-27.patch"
+                    "RSS view with fields give wrong URL from path field (https://www.drupal.org/node/2673980)": "https://www.drupal.org/files/issues/rss_view_with_fields-2673980-27.patch",
+                    "Add hook_post_config_import_NAME after config import (https://www.drupal.org/project/drupal/issues/2901418)": "https://www.drupal.org/files/issues/2019-02-01/2901418-28.patch"
                 }
             },
             "autoload": {

--- a/conf/drupal/config/core.entity_form_display.user.user.default.yml
+++ b/conf/drupal/config/core.entity_form_display.user.user.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.user.user.field_mailing_list
     - field.field.user.user.field_name
     - field.field.user.user.field_organization
+    - field.field.user.user.field_organizer_year
     - field.field.user.user.field_site
     - field.field.user.user.field_title
     - field.field.user.user.field_tracks
@@ -162,6 +163,15 @@ content:
     region: content
   field_organization:
     weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_organizer_year:
+    weight: 20
     settings:
       match_operator: CONTAINS
       size: 60

--- a/conf/drupal/config/core.entity_view_display.user.user.default.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.user.user.field_mailing_list
     - field.field.user.user.field_name
     - field.field.user.user.field_organization
+    - field.field.user.user.field_organizer_year
     - field.field.user.user.field_site
     - field.field.user.user.field_title
     - field.field.user.user.field_tracks
@@ -131,4 +132,5 @@ hidden:
   field_company_url: true
   field_eventbrite_email: true
   field_mailing_list: true
+  field_organizer_year: true
   member_for: true

--- a/conf/drupal/config/field.field.user.user.field_organizer_year.yml
+++ b/conf/drupal/config/field.field.user.user.field_organizer_year.yml
@@ -1,0 +1,30 @@
+uuid: e44b49c5-d499-410f-89f2-af113d064302
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_organizer_year
+    - taxonomy.vocabulary.event
+  module:
+    - user
+id: user.user.field_organizer_year
+field_name: field_organizer_year
+entity_type: user
+bundle: user
+label: 'Organizer year'
+description: 'Select the events this user has helped organize. '
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      event: event
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/drupal/config/field.storage.user.field_organizer_year.yml
+++ b/conf/drupal/config/field.storage.user.field_organizer_year.yml
@@ -1,0 +1,24 @@
+uuid: 83b0d23f-df61-4086-83f1-2ca695345953
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - taxonomy
+    - user
+third_party_settings:
+  field_permissions:
+    permission_type: custom
+id: user.field_organizer_year
+field_name: field_organizer_year
+entity_type: user
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/views.view.organizers.yml
+++ b/conf/drupal/config/views.view.organizers.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.user.featured_speaker
+    - system.menu.midcamp-2019-navigation
     - taxonomy.vocabulary.event
   content:
     - 'taxonomy_term:event:17285735-fe51-4f45-b481-321ae7af649f'
@@ -303,6 +304,15 @@ display:
         operator: AND
         groups:
           1: AND
+      menu:
+        type: normal
+        title: Organizers
+        description: ''
+        expanded: false
+        parent: 'menu_link_content:db3c8044-0b1c-4432-b89f-8a2b03de0754'
+        weight: 10
+        context: '0'
+        menu_name: midcamp-2019-navigation
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.organizers.yml
+++ b/conf/drupal/config/views.view.organizers.yml
@@ -4,8 +4,12 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.user.featured_speaker
-    - user.role.organizer
+    - taxonomy.vocabulary.event
+  content:
+    - 'taxonomy_term:event:17285735-fe51-4f45-b481-321ae7af649f'
+    - 'taxonomy_term:event:58ab979d-12f0-4b19-ab75-5625aa986afb'
   module:
+    - taxonomy
     - user
 id: organizers
 label: Organizers
@@ -127,16 +131,16 @@ display:
           expose:
             operator: ''
           group: 1
-        roles_target_id:
-          id: roles_target_id
-          table: user__roles
-          field: roles_target_id
+        field_organizer_year_target_id:
+          id: field_organizer_year_target_id
+          table: user__field_organizer_year
+          field: field_organizer_year_target_id
           relationship: none
           group_type: group
           admin_label: ''
           operator: or
           value:
-            organizer: organizer
+            2: 2
           group: 1
           exposed: false
           expose:
@@ -165,8 +169,12 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          entity_type: user
-          plugin_id: user_roles
+          type: select
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
       sorts:
         field_name_family:
           id: field_name_family
@@ -205,6 +213,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - user
         - user.permissions
       tags: {  }
   page_1:
@@ -220,5 +229,85 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - user
+        - user.permissions
+      tags: {  }
+  page_2:
+    display_plugin: page
+    id: page_2
+    display_title: 'Page 2'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      path: 2019/organizers
+      filters:
+        status:
+          value: '1'
+          table: users_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: user
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        field_organizer_year_target_id:
+          id: field_organizer_year_target_id
+          table: user__field_organizer_year
+          field: field_organizer_year_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            97: 97
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
         - user.permissions
       tags: {  }

--- a/web/modules/custom/midcamp_utility/midcamp_utility.post_config_import.php
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.post_config_import.php
@@ -11,7 +11,8 @@ use Drupal\Core\Config\ConfigImporter;
  * Implements hook_post_config_import_NAME().
  * Adds event terms to existing users with the `organizer` role.
  */
-function midcamp_utility_post_config_import_organizer_update(&$sandbox, ConfigImporter $configImporter) {
+function midcamp_utility_post_config_import_organizer_update_2018(&$sandbox, ConfigImporter $configImporter) {
+  // Last year's organizers were set by role.
   $organizer_uids = \Drupal::entityQuery('user')
     ->condition('status', 1)
     ->condition('roles', 'organizer')
@@ -21,6 +22,21 @@ function midcamp_utility_post_config_import_organizer_update(&$sandbox, ConfigIm
 
   foreach ($organizers as $organizer) {
     $organizer->field_organizer_year[] = ['target_id' => 2];
+    $organizer->save();
+  }
+}
+
+/**
+ * Implements hook_post_config_import_NAME().
+ * Adds 2019 event term to 2019 event organizers.
+ */
+function midcamp_utility_post_config_import_organizer_update_2019(&$sandbox, ConfigImporter $configImporter) {
+  // uids of 2019 event organizers.
+  $organizer_uids = [157, 3, 170, 13, 6, 25, 26, 67, 14, 16, 9, 7, 48, 4, 161];
+
+  $organizers = \Drupal\user\Entity\User::loadMultiple($organizer_uids);
+
+  foreach ($organizers as $organizer) {
     $organizer->field_organizer_year[] = ['target_id' => 97];
     $organizer->save();
   }

--- a/web/modules/custom/midcamp_utility/midcamp_utility.post_config_import.php
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.post_config_import.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Contains post config import hooks for midcamp_utility module.
+ */
+
+use Drupal\Core\Config\ConfigImporter;
+
+/**
+ * Implements hook_post_config_import_NAME().
+ * Adds event terms to existing users with the `organizer` role.
+ */
+function midcamp_utility_post_config_import_organizer_update(&$sandbox, ConfigImporter $configImporter) {
+  $organizer_uids = \Drupal::entityQuery('user')
+    ->condition('status', 1)
+    ->condition('roles', 'organizer')
+    ->execute();
+
+  $organizers = \Drupal\user\Entity\User::loadMultiple($organizer_uids);
+
+  foreach ($organizers as $organizer) {
+    $organizer->field_organizer_year[] = ['target_id' => 2];
+    $organizer->field_organizer_year[] = ['target_id' => 97];
+    $organizer->save();
+  }
+}

--- a/web/themes/custom/hatter/templates/user/user--featured-speaker.html.twig
+++ b/web/themes/custom/hatter/templates/user/user--featured-speaker.html.twig
@@ -1,5 +1,11 @@
 <div{{ attributes.addClass('speaker-item') }}>
-  {{ content.user_picture }}
+  {% if content.user_picture|render %}
+    {{ content.user_picture }}
+  {% else %}
+    <div class="speaker-image">
+      <img src="/themes/custom/hatter/logo.png" width="400" height="400" class="image-style-featured-speaker">
+    </div>
+  {% endif %}
   <div class="speaker-item__block">
     <h3 class="speaker-item__title">{{ content.field_name }}</h3>
     <p class="speaker-item__subtitle">


### PR DESCRIPTION
# Description

The existing [Organizers page](https://www.midcamp.org/2018/organizers) Is based on role, which isn't well suited to displaying different organizers over different years.  This PR:

- Adds `field_organizer_year`, an entity reference field to the `event` taxonomy, allowing Users to be tagged as an organizer for a given event
- Implements admin-only permissions on `field_organizer_year` so nobody else can see it or edit its values
- Patches Drupal Core to allow for `hook_post_config_import_NAME()`, which allows you to run arbitrary updates after a config import (see https://www.drupal.org/project/drupal/issues/2901418).  This allows the next step, which is to:
- Assign the value for MidCamp 2018 to all existing users with the Organizer role, reflecting the pattern set last year.  
- Assign the value for MidCamp 2019 to this year's organizers by UID (for those I could find with user accounts).  
- Updates the Organizer view to use the new field for filtering instead of the user role, creates a 2019 display.
- Sets a default image if no image exists in the Featured Speaker display template for `user` entities.

# To Test

- See the old Organizers page rebuilt at https://nginx-midcamp-org-feature-multi-year-organizers.us.amazee.io/2018/organizers
- See the new Organizers page at https://nginx-midcamp-org-feature-multi-year-organizers.us.amazee.io/2019/organizers