### PR TITLE
Wednesday schedule

### DIFF
--- a/conf/drupal/config/views.view.attendees.yml
+++ b/conf/drupal/config/views.view.attendees.yml
@@ -766,7 +766,7 @@ display:
         description: ''
         expanded: false
         parent: 'menu_link_content:db3c8044-0b1c-4432-b89f-8a2b03de0754'
-        weight: 0
+        weight: -45
         context: '0'
         menu_name: midcamp-2019-navigation
       display_description: ''

--- a/conf/drupal/config/views.view.news.yml
+++ b/conf/drupal/config/views.view.news.yml
@@ -283,7 +283,7 @@ display:
         description: ''
         expanded: false
         parent: 'menu_link_content:db3c8044-0b1c-4432-b89f-8a2b03de0754'
-        weight: -47
+        weight: -46
         context: '0'
         menu_name: midcamp-2019-navigation
       filters:

--- a/conf/drupal/config/views.view.organizers.yml
+++ b/conf/drupal/config/views.view.organizers.yml
@@ -310,7 +310,7 @@ display:
         description: ''
         expanded: false
         parent: 'menu_link_content:db3c8044-0b1c-4432-b89f-8a2b03de0754'
-        weight: 10
+        weight: -44
         context: '0'
         menu_name: midcamp-2019-navigation
     cache_metadata:

--- a/conf/drupal/config/views.view.schedule_2019.yml
+++ b/conf/drupal/config/views.view.schedule_2019.yml
@@ -3,14 +3,18 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.body
     - field.storage.node.field_people
     - field.storage.node.field_schedule_location
     - field.storage.node.field_schedule_time
     - field.storage.node.field_track
+    - node.type.summit
+    - node.type.training
   module:
     - datetime
     - datetime_range
     - node
+    - text
     - user
 id: schedule_2019
 label: 'Schedule 2019'
@@ -62,11 +66,11 @@ display:
         options:
           grouping:
             -
-              field: field_schedule_time
-              rendered: true
+              field: type
+              rendered: false
               rendered_strip: false
           row_class: schedule__teaser
-          default_row_class: true
+          default_row_class: false
       row:
         type: fields
         options:
@@ -501,7 +505,7 @@ display:
           empty: false
           tokenize: false
           content:
-            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/training\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/sprints\">Saturday</a>\r\n</div>\r\n<h2>Thursday, March 21, 2019</h2>"
+            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/schedule/wednesday\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/sprints\">Saturday</a>\r\n</div>\r\n<h2>Thursday, March 21, 2019</h2>"
             format: full_html
           plugin_id: text
       footer: {  }
@@ -542,7 +546,7 @@ display:
           empty: false
           tokenize: false
           content:
-            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/training\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/contribution-day\">Saturday</a>\r\n</div>\r\n<h2>Thursday, March 21, 2019</h2>"
+            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/schedule/wednesday\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/contribution-day\">Saturday</a>\r\n</div>\r\n<h2>Thursday, March 21, 2019</h2>"
             format: full_html
           plugin_id: text
       defaults:
@@ -578,7 +582,7 @@ display:
           empty: false
           tokenize: false
           content:
-            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/training\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/contribution-day\">Saturday</a>\r\n</div>\r\n<h2>Friday, March 22, 2019</h2>"
+            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/schedule/wednesday\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/contribution-day\">Saturday</a>\r\n</div>\r\n<h2>Friday, March 22, 2019</h2>"
             format: full_html
           plugin_id: text
       defaults:
@@ -656,4 +660,407 @@ display:
         - 'config:field.storage.node.field_people'
         - 'config:field.storage.node.field_schedule_location'
         - 'config:field.storage.node.field_schedule_time'
+        - 'config:field.storage.node.field_track'
+  page_3:
+    display_plugin: page
+    id: page_3
+    display_title: Wednesday
+    position: 3
+    display_options:
+      display_extenders: {  }
+      path: 2019/schedule/wednesday
+      title: 'Camp Schedule: Wednesday'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+        fields: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            summit: summit
+            training: training
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      display_description: ''
+      fields:
+        field_track:
+          id: field_track
+          table: node__field_track
+          field: field_track
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: div
+          element_class: schedule__track
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h3
+          element_class: schedule__title
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        body:
+          id: body
+          table: node__body
+          field: body
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: article
+          element_class: schedule__description
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_summary_or_trimmed
+          settings:
+            trim_length: 300
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_people:
+          id: field_people
+          table: node__field_people
+          field: field_people
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: '0'
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_entity_view
+          settings:
+            view_mode: schedule
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ' '
+          field_api_classes: false
+          plugin_id: field
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: "{% if type == 'Training Proposal' %}\r\n<h3>Trainings</h3>\r\n{% endif %}\r\n\r\n{% if type == 'Summit' %}\r\n<h3>Summits</h3>\r\n{% endif %}"
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h2
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: type
+          plugin_id: field
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.body'
+        - 'config:field.storage.node.field_people'
         - 'config:field.storage.node.field_track'

--- a/conf/drupal/config/views.view.schedule_2019.yml
+++ b/conf/drupal/config/views.view.schedule_2019.yml
@@ -669,12 +669,14 @@ display:
     display_options:
       display_extenders: {  }
       path: 2019/schedule/wednesday
-      title: 'Camp Schedule: Wednesday'
+      title: 'Camp Schedule'
       defaults:
         title: false
         filters: false
         filter_groups: false
         fields: false
+        header: false
+        sorts: false
       filters:
         status:
           value: '1'
@@ -1053,6 +1055,49 @@ display:
           entity_type: node
           entity_field: type
           plugin_id: field
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content:
+            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/schedule/wednesday\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/sprints\">Saturday</a>\r\n</div>\r\n<h2>Wednesday, March 20, 2019</h2>"
+            format: full_html
+          plugin_id: text
+      sorts:
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: standard
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.schedule_2019.yml
+++ b/conf/drupal/config/views.view.schedule_2019.yml
@@ -778,6 +778,45 @@ display:
           hierarchy: false
           error_message: true
           plugin_id: taxonomy_index_tid
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '!='
+          value: 'Getting started with the Drupal issue queue'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: title
+          plugin_id: string
       filter_groups:
         operator: AND
         groups:

--- a/conf/drupal/config/views.view.schedule_2019.yml
+++ b/conf/drupal/config/views.view.schedule_2019.yml
@@ -10,10 +10,14 @@ dependencies:
     - field.storage.node.field_track
     - node.type.summit
     - node.type.training
+    - taxonomy.vocabulary.event
+  content:
+    - 'taxonomy_term:event:17285735-fe51-4f45-b481-321ae7af649f'
   module:
     - datetime
     - datetime_range
     - node
+    - taxonomy
     - text
     - user
 id: schedule_2019
@@ -730,6 +734,50 @@ display:
           entity_type: node
           entity_field: type
           plugin_id: bundle
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            97: 97
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
@@ -1103,6 +1151,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - user
         - 'user.node_grants:view'
         - user.permissions
       tags:

--- a/conf/drupal/config/views.view.trainings.yml
+++ b/conf/drupal/config/views.view.trainings.yml
@@ -6,7 +6,6 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - node.type.topic
     - node.type.training
-    - system.menu.midcamp-2019-navigation
     - taxonomy.vocabulary.event
     - taxonomy.vocabulary.topic_type
   content:
@@ -461,7 +460,7 @@ display:
         groups:
           1: AND
       menu:
-        type: normal
+        type: none
         title: 'Training (Wed)'
         description: ''
         expanded: false
@@ -469,7 +468,6 @@ display:
         weight: -49
         context: '0'
         menu_name: midcamp-2019-navigation
-        enabled: true
       pager:
         type: none
         options:


### PR DESCRIPTION
## Description

This PR updates the existing `schedule_2019` View to add a Wednesday page display including `summit` and `training_proposal` nodes tagged with this year's event.

## To Test

Visit https://nginx-midcamp-org-feature-wednesday-schedule.us.amazee.io/2019/schedule/wednesday

- Import config with `drush cim -y`
- Navigate to http://midcamp.org.docker.amazee.io/2019/schedule/wednesday.  Observe Trainings and Summits appear here, styled consistently with Session schedule pages.  Observe the navigation at the top of the schedule targets this new page.

## Notes

Need to update the menu once this is deployed.

## Questions

~The existing Training View excluded the node "Getting started with the Drupal issue queue."  Is there a reason to exclude this from the View, or can that node simply be unpublished?~ **EDIT:** Filtering this out, this Training will actually occur on Saturday so it needs to remain published.


