### PR TITLE
Fix 2019 Schedule groupings, override for Wednesday schedule.

### DIFF
--- a/conf/drupal/config/views.view.schedule_2019.yml
+++ b/conf/drupal/config/views.view.schedule_2019.yml
@@ -70,8 +70,8 @@ display:
         options:
           grouping:
             -
-              field: type
-              rendered: false
+              field: field_schedule_time
+              rendered: true
               rendered_strip: false
           row_class: schedule__teaser
           default_row_class: false
@@ -681,6 +681,8 @@ display:
         fields: false
         header: false
         sorts: false
+        style: false
+        row: false
       filters:
         status:
           value: '1'
@@ -1185,6 +1187,23 @@ display:
           entity_type: node
           entity_field: title
           plugin_id: standard
+      style:
+        type: default
+        options:
+          grouping:
+            -
+              field: type
+              rendered: false
+              rendered_strip: false
+          row_class: schedule__teaser
+          default_row_class: false
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: false
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
## Description

PR #228 introduced a regression in the `schedule_2019` view displays for Thursday and Friday sessions whereby the grouping based on `field_schedule_time` was removed.  This PR restores the original grouping, and adds an override for the Wednesday display to allow the Summit & Training schedule to display differently. 

## To Test

- Import config with `drush cim -y`
- Navigate to the 2019 schedule.  Observe the Wednesday schedule is grouped by `type` (Summits and Trainings) and the Thursday/Friday schedules are grouped by time