### PR TITLE
Add a display for Wednesday's social.

### DIFF
--- a/conf/drupal/config/views.view.schedule_2019.yml
+++ b/conf/drupal/config/views.view.schedule_2019.yml
@@ -530,6 +530,90 @@ display:
         - 'config:field.storage.node.field_schedule_location'
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: 'Wednesday Social'
+    position: 4
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        field_schedule_time_value:
+          id: field_schedule_time_value
+          table: node__field_schedule_time
+          field: field_schedule_time_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: between
+          value:
+            min: '2019-03-20 00:00:00'
+            max: '2019-03-21 05:00:00'
+            value: ''
+            type: date
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: datetime
+      defaults:
+        filters: false
+        filter_groups: false
+        header: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      header: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_people'
+        - 'config:field.storage.node.field_schedule_location'
+        - 'config:field.storage.node.field_schedule_time'
+        - 'config:field.storage.node.field_track'
   page_1:
     display_plugin: page
     id: page_1
@@ -683,6 +767,7 @@ display:
         sorts: false
         style: false
         row: false
+        footer: false
       filters:
         status:
           value: '1'
@@ -1204,6 +1289,18 @@ display:
           inline: {  }
           separator: ''
           hide_empty: false
+      footer:
+        view:
+          id: view
+          table: views
+          field: view
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          view_to_insert: 'schedule_2019:block_1'
+          inherit_arguments: false
+          plugin_id: view
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
## Description

The [Wednesday schedule](https://www.midcamp.org/2019/schedule/wednesday) was configured to display `summit` and `training` node types, and as a result was not capable of displaying the Wednesday evening social event.  This PR addresses that by:

- Creating a block display on the `schedule_2019` View to query `topic` nodes scheduled on Wednesday
- Updates the Wednesday display of the view to render the new display in the footer

## To Test

https://nginx-midcamp-org-feature-wednesday-social-schedule.us.amazee.io/2019/schedule/wednesday

- Import config with `drush cim -y`
- Create a Topic node scheduled on Wednesday evening for the social
- Visit the Wednesday schedule page.  Observe it displays below the rest of the content

## Screenshots

![image](https://user-images.githubusercontent.com/4048700/53462601-fc171a80-3a09-11e9-91be-62eced9b298a.png)

## Notes

The Thurs/Fri schedules don't include any descriptive text, and that pattern has been followed for inclusion of the Wednesday social as well.  It looks a little spartan, we might consider adding the description here ultimately.