### PR TITLE
Update job company filter

### DIFF
--- a/conf/drupal/config/field.field.node.job.field_sponsor_company.yml
+++ b/conf/drupal/config/field.field.node.job.field_sponsor_company.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - field.storage.node.field_sponsor_company
     - node.type.job
-    - node.type.sponsor
 id: node.job.field_sponsor_company
 field_name: field_sponsor_company
 entity_type: node
@@ -17,12 +16,10 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  handler: 'default:node'
+  handler: views
   handler_settings:
-    target_bundles:
-      sponsor: sponsor
-    sort:
-      field: _none
-    auto_create: false
-    auto_create_bundle: ''
+    view:
+      view_name: sponsor_company_field_filter
+      display_name: entity_reference_1
+      arguments: {  }
 field_type: entity_reference

--- a/conf/drupal/config/field.storage.node.field_sponsor_company.yml
+++ b/conf/drupal/config/field.storage.node.field_sponsor_company.yml
@@ -3,7 +3,11 @@ langcode: en
 status: true
 dependencies:
   module:
+    - field_permissions
     - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
 id: node.field_sponsor_company
 field_name: field_sponsor_company
 entity_type: node

--- a/conf/drupal/config/views.view.sponsor_company_field_filter.yml
+++ b/conf/drupal/config/views.view.sponsor_company_field_filter.yml
@@ -1,0 +1,236 @@
+uuid: 1b081987-b3c6-49da-9b05-a0ad934fbef2
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.sponsor
+    - taxonomy.vocabulary.event
+  content:
+    - 'taxonomy_term:event:17285735-fe51-4f45-b481-321ae7af649f'
+  module:
+    - node
+    - taxonomy
+    - user
+id: sponsor_company_field_filter
+label: 'Sponsor Company Field Filter'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: none
+        options:
+          offset: 0
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          inline: {  }
+          separator: ''
+          hide_empty: false
+          default_field_elements: true
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            sponsor: sponsor
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            97: 97
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          order: DESC
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  entity_reference_1:
+    display_plugin: entity_reference
+    id: entity_reference_1
+    display_title: 'Entity Reference'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            title: title
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/conf/drupal/config/webform.webform.tourism_quote.yml
+++ b/conf/drupal/config/webform.webform.tourism_quote.yml
@@ -151,7 +151,7 @@ handlers:
     settings:
       states:
         - completed
-      to_mail: dsdobrzynski@gmail.com
+      to_mail: 'dsdobrzynski@gmail.com,info@midcamp.org'
       to_options: {  }
       cc_mail: ''
       cc_options: {  }


### PR DESCRIPTION
## Description

- Exports prod config update for Tourism webform
- Creates entity reference View to filter sponsors by `Midcamp 2019` event
- Updates `field_sponsor_company` handler on Job content type to use new View to filter companies to this year's sponsors

## To test

Alternatively, use the available environment at https://nginx-midcamp-org-feature-update-job-company-filter.us.amazee.io/

- [ ] Import config with `drush cim -y`
- [ ] Add a Job posting at http://midcamp.org.docker.amazee.io/node/add/job.  Observe that you can only select companies who exist as Sponsor nodes tagged to the current event year