### PR TITLE
remove registration link from branding block

### DIFF
--- a/web/themes/custom/hatter/templates/block/block--system-branding-block.html.twig
+++ b/web/themes/custom/hatter/templates/block/block--system-branding-block.html.twig
@@ -28,7 +28,7 @@
           {% endif %}
           <h2 class="event__subtitle">{{ site_slogan }}</h2>
           <!--a href="/submit-session" class="event__button button--primary">Submit a Session</a-->
-          <a href="https://www.eventbrite.com/e/midcamp-2019-midwest-drupal-camp-chicago-illinois-tickets-52035893759" class="event__button button--primary">Buy a Ticket</a>
+          <!--a href="https://www.eventbrite.com/e/midcamp-2019-midwest-drupal-camp-chicago-illinois-tickets-52035893759" class="event__button button--primary">Buy a Ticket</a-->
         </div>
       </div>
     </div>


### PR DESCRIPTION
Camp is over, so I've commented out the `Buy a Ticket` link in the home page header.