### PR TITLE
Midcamp 2020 Menu

### DIFF
--- a/conf/drupal/config/block.block.bartik_account_menu.yml
+++ b/conf/drupal/config/block.block.bartik_account_menu.yml
@@ -23,4 +23,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 1
+  expand_all_items: false
 visibility: {  }

--- a/conf/drupal/config/block.block.bartik_footer.yml
+++ b/conf/drupal/config/block.block.bartik_footer.yml
@@ -23,4 +23,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 0
+  expand_all_items: false
 visibility: {  }

--- a/conf/drupal/config/block.block.bartik_main_menu.yml
+++ b/conf/drupal/config/block.block.bartik_main_menu.yml
@@ -23,4 +23,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 1
+  expand_all_items: false
 visibility: {  }

--- a/conf/drupal/config/block.block.bartik_tools.yml
+++ b/conf/drupal/config/block.block.bartik_tools.yml
@@ -23,4 +23,5 @@ settings:
   label_display: visible
   level: 1
   depth: 0
+  expand_all_items: false
 visibility: {  }

--- a/conf/drupal/config/block.block.footer.yml
+++ b/conf/drupal/config/block.block.footer.yml
@@ -21,4 +21,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 0
+  expand_all_items: false
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_account_menu.yml
+++ b/conf/drupal/config/block.block.hatter_account_menu.yml
@@ -23,4 +23,5 @@ settings:
   label_display: '0'
   level: 1
   depth: 1
+  expand_all_items: false
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_main_menu.yml
+++ b/conf/drupal/config/block.block.hatter_main_menu.yml
@@ -23,6 +23,7 @@ settings:
   label_display: '0'
   level: 1
   depth: 2
+  expand_all_items: false
 visibility:
   request_path:
     id: request_path

--- a/conf/drupal/config/block.block.hatter_tools.yml
+++ b/conf/drupal/config/block.block.hatter_tools.yml
@@ -23,4 +23,5 @@ settings:
   label_display: visible
   level: 1
   depth: 0
+  expand_all_items: false
 visibility: {  }

--- a/conf/drupal/config/block.block.midcamp2019navigation.yml
+++ b/conf/drupal/config/block.block.midcamp2019navigation.yml
@@ -21,6 +21,7 @@ settings:
   label_display: '0'
   level: 1
   depth: 2
+  expand_all_items: false
 visibility:
   request_path:
     id: request_path

--- a/conf/drupal/config/block.block.midcamp2020navigation.yml
+++ b/conf/drupal/config/block.block.midcamp2020navigation.yml
@@ -1,22 +1,22 @@
-uuid: 9df7adc9-b47a-4361-b29d-c379394620f3
+uuid: 21fe00cf-8c63-4851-a8d2-42b8103ea12d
 langcode: en
 status: true
 dependencies:
   config:
-    - system.menu.midcamp-2019-navigation
+    - system.menu.midcamp-2020-navigation
   module:
     - system
   theme:
     - hatter
-id: midcamp2019navigation
+id: midcamp2020navigation
 theme: hatter
 region: header
 weight: 0
 provider: null
-plugin: 'system_menu_block:midcamp-2019-navigation'
+plugin: 'system_menu_block:midcamp-2020-navigation'
 settings:
-  id: 'system_menu_block:midcamp-2019-navigation'
-  label: 'Midcamp 2019 Navigation'
+  id: 'system_menu_block:midcamp-2020-navigation'
+  label: 'Midcamp 2020 Navigation'
   provider: system
   label_display: '0'
   level: 1
@@ -25,6 +25,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: "/2019/*\r\n/2019"
-    negate: false
+    pages: "/2018*\r\n/2019*"
+    negate: true
     context_mapping: {  }

--- a/conf/drupal/config/system.menu.midcamp-2020-navigation.yml
+++ b/conf/drupal/config/system.menu.midcamp-2020-navigation.yml
@@ -1,0 +1,8 @@
+uuid: 58dccc88-ca48-49d3-a926-b33f732ac8aa
+langcode: en
+status: true
+dependencies: {  }
+id: midcamp-2020-navigation
+label: 'Midcamp 2020 Navigation'
+description: 'Primary navigation for Midcamp 2020 content'
+locked: false

--- a/conf/drupal/config/taxonomy.vocabulary.event.yml
+++ b/conf/drupal/config/taxonomy.vocabulary.event.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: Event
 vid: event
 description: 'A hierarchical vocabulary for organizing events.'
-hierarchy: 1
 weight: 0

--- a/conf/drupal/config/taxonomy.vocabulary.location.yml
+++ b/conf/drupal/config/taxonomy.vocabulary.location.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: Location
 vid: location
 description: 'Room or address'
-hierarchy: 0
 weight: 0

--- a/conf/drupal/config/taxonomy.vocabulary.organization.yml
+++ b/conf/drupal/config/taxonomy.vocabulary.organization.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: Organization
 vid: organization
 description: ''
-hierarchy: 0
 weight: 0

--- a/conf/drupal/config/taxonomy.vocabulary.session_tracks.yml
+++ b/conf/drupal/config/taxonomy.vocabulary.session_tracks.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: Tracks
 vid: session_tracks
 description: 'Categories topics may fit into for sessions.'
-hierarchy: 0
 weight: 0

--- a/conf/drupal/config/taxonomy.vocabulary.sponsor_packages.yml
+++ b/conf/drupal/config/taxonomy.vocabulary.sponsor_packages.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: 'Sponsor Packages'
 vid: sponsor_packages
 description: 'Available 2018 MidCamp Sponsorship packages'
-hierarchy: 0
 weight: 0

--- a/conf/drupal/config/taxonomy.vocabulary.tags.yml
+++ b/conf/drupal/config/taxonomy.vocabulary.tags.yml
@@ -7,5 +7,4 @@ _core:
 name: Tags
 vid: tags
 description: 'Use tags to group articles on similar topics into categories.'
-hierarchy: 0
 weight: 0

--- a/conf/drupal/config/taxonomy.vocabulary.topic_type.yml
+++ b/conf/drupal/config/taxonomy.vocabulary.topic_type.yml
@@ -5,5 +5,4 @@ dependencies: {  }
 name: 'Topic Type'
 vid: topic_type
 description: ''
-hierarchy: 0
 weight: 0

--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -38,8 +38,9 @@ function hatter_theme_suggestions_user_alter(&$suggestions, $vars, $hook) {
  * Implements THEME_theme_suggestions_HOOK_alter() for menus.
  */
 function hatter_theme_suggestions_menu_alter(&$suggestions, $vars, $hook) {
-  // Let the new menu uses the existing template for now.
-  if ($vars['menu_name'] == 'midcamp-2019-navigation') {
+  // Let the new menus use the existing template for now.
+  $menus = ['midcamp-2019-navigation', 'midcamp-2020-navigation'];
+  if (in_array($vars['menu_name'], $menus)) {
     array_unshift($suggestions, 'menu__main');
   }
 }


### PR DESCRIPTION
## Description
- Exports some stray production config
- Creates a new menu for 2020 Navigation
- Places that menu everywhere except for `/2018` and `/2019` content.
- Restricts 2019 menu to show on `/2019` pages (was previously everywhere but `/2018`)
- Updates `hatter_theme_suggestions_menu_alter` to let the new menu use the same template as the previous two.

## To Test
- Import config with `drush cim -y`
- Navigate to http://midcamp.org.docker.amazee.io/admin/structure/menu/manage/midcamp-2020-navigation
- Add some links
- Look at them from the front end, observe they look/behave as expected.