### PR TITLE
POC: Theme switcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
         "drupal/recaptcha": "^2.2",
         "drupal/redirect": "^1.0",
         "drupal/scheduler": "^1.0@RC",
+        "drupal/switch_page_theme": "^1.0",
         "drupal/twig_extensions": "1.x-dev",
         "drupal/video_embed_media": "^1.5",
         "drupal/viewsreference": "^1.0@alpha",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d27574b9e1458af0f7cde699ab9dcf5b",
+    "content-hash": "9fbe199f718f3e42538fa2b4472949b3",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3855,6 +3855,53 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/scheduler",
                 "issues": "https://www.drupal.org/project/issues/scheduler"
+            }
+        },
+        {
+            "name": "drupal/switch_page_theme",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/switch_page_theme.git",
+                "reference": "8.x-1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/switch_page_theme-8.x-1.0.zip",
+                "reference": "8.x-1.0",
+                "shasum": "77016580b68cfad9e65991b3d0ed8477a4e5b3aa"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0",
+                    "datestamp": "1505717644",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "deepali_agarwal",
+                    "homepage": "https://www.drupal.org/user/2438242"
+                }
+            ],
+            "description": "Switches active theme on specific pages.",
+            "homepage": "https://www.drupal.org/project/switch_page_theme",
+            "support": {
+                "source": "https://git.drupalcode.org/project/switch_page_theme"
             }
         },
         {

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -63,6 +63,7 @@ module:
   scheduler: 0
   search: 0
   shortcut: 0
+  switch_page_theme: 0
   system: 0
   taxonomy: 0
   text: 0

--- a/conf/drupal/config/switch_page_theme.settings.yml
+++ b/conf/drupal/config/switch_page_theme.settings.yml
@@ -1,0 +1,15 @@
+spt_table:
+  -
+    status: '1'
+    pages: '/2018*'
+    theme: bartik
+    weight: '-10'
+    roles:
+      anonymous: 0
+      speaker: 0
+      content_editor: 0
+      administrator: 0
+      authenticated: 0
+      sponsor: 0
+      organizer: 0
+    remove: Remove


### PR DESCRIPTION
Leverages [Switch Page Theme](https://www.drupal.org/project/switch_page_theme) module to demonstrate varying page themes by path pattern.

Implementation can be observed at https://nginx-midcamp-org-feature-poc-theme-switching.us.amazee.io/, which still uses the Hatter theme.  2018 year pages like https://nginx-midcamp-org-feature-poc-theme-switching.us.amazee.io/2018 or https://nginx-midcamp-org-feature-poc-theme-switching.us.amazee.io/2018/schedule/friday are currently set to use Bartik.

Example configuration:
![image](https://user-images.githubusercontent.com/4048700/64256793-bfad0580-cee9-11e9-9853-603a03206182.png)
