### PR TITLE
Add Transcript field to Topics.

### DIFF
--- a/conf/drupal/config/core.entity_form_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.topic.default.yml
@@ -15,11 +15,15 @@ dependencies:
     - field.field.node.topic.field_session_length
     - field.field.node.topic.field_topic_type
     - field.field.node.topic.field_track
+    - field.field.node.topic.field_transcript
     - field.field.node.topic.field_video
     - node.type.topic
+    - workflows.workflow.session_proposal
   module:
+    - content_moderation
     - datetime_range
     - file
+    - link
     - text
     - video_embed_field
     - webform
@@ -96,12 +100,26 @@ content:
     third_party_settings: {  }
     type: options_buttons
     region: content
+  field_transcript:
+    weight: 101
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+    type: link_default
+    region: content
   field_video:
     weight: 11
     settings: {  }
     third_party_settings: {  }
     type: video_embed_field_textfield
     region: content
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    settings: {  }
+    region: content
+    third_party_settings: {  }
   status:
     type: boolean_checkbox
     weight: 8

--- a/conf/drupal/config/core.entity_form_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.topic.default.yml
@@ -43,12 +43,12 @@ content:
     region: content
   created:
     type: datetime_timestamp
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   field_feedback_form:
-    weight: 26
+    weight: 15
     settings:
       default_data: true
     third_party_settings: {  }
@@ -101,7 +101,7 @@ content:
     type: options_buttons
     region: content
   field_transcript:
-    weight: 101
+    weight: 11
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -109,14 +109,14 @@ content:
     type: link_default
     region: content
   field_video:
-    weight: 11
+    weight: 12
     settings: {  }
     third_party_settings: {  }
     type: video_embed_field_textfield
     region: content
   moderation_state:
     type: moderation_state_default
-    weight: 100
+    weight: 16
     settings: {  }
     region: content
     third_party_settings: {  }
@@ -137,7 +137,7 @@ content:
     region: content
   uid:
     type: entity_reference_autocomplete
-    weight: 12
+    weight: 13
     region: content
     settings:
       match_operator: CONTAINS

--- a/conf/drupal/config/core.entity_view_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.topic.default.yml
@@ -15,11 +15,13 @@ dependencies:
     - field.field.node.topic.field_session_length
     - field.field.node.topic.field_topic_type
     - field.field.node.topic.field_track
+    - field.field.node.topic.field_transcript
     - field.field.node.topic.field_video
     - node.type.topic
   module:
     - datetime_range
     - file
+    - link
     - text
     - user
     - video_embed_field
@@ -33,6 +35,11 @@ content:
     label: hidden
     type: text_default
     weight: 2
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  content_moderation_control:
+    weight: -20
     settings: {  }
     third_party_settings: {  }
     region: content
@@ -86,6 +93,18 @@ content:
       link: false
     third_party_settings: {  }
     type: entity_reference_label
+    region: content
+  field_transcript:
+    weight: 8
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
     region: content
   field_video:
     weight: 3

--- a/conf/drupal/config/core.entity_view_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.topic.default.yml
@@ -34,17 +34,17 @@ content:
   body:
     label: hidden
     type: text_default
-    weight: 2
+    weight: 3
     settings: {  }
     third_party_settings: {  }
     region: content
   content_moderation_control:
-    weight: -20
+    weight: 0
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_feedback_form:
-    weight: 7
+    weight: 9
     label: above
     settings:
       source_entity: true
@@ -53,7 +53,7 @@ content:
     region: content
   field_people:
     type: entity_reference_entity_view
-    weight: 4
+    weight: 7
     region: content
     label: above
     settings:
@@ -69,7 +69,7 @@ content:
     type: file_default
     region: content
   field_schedule_location:
-    weight: 1
+    weight: 2
     label: hidden
     settings:
       link: false
@@ -77,7 +77,7 @@ content:
     type: entity_reference_label
     region: content
   field_schedule_time:
-    weight: 0
+    weight: 1
     label: above
     settings:
       timezone_override: America/Chicago
@@ -87,7 +87,7 @@ content:
     type: daterange_default
     region: content
   field_track:
-    weight: 6
+    weight: 8
     label: inline
     settings:
       link: false
@@ -95,7 +95,7 @@ content:
     type: entity_reference_label
     region: content
   field_transcript:
-    weight: 8
+    weight: 6
     label: above
     settings:
       trim_length: 80
@@ -107,7 +107,7 @@ content:
     type: link
     region: content
   field_video:
-    weight: 3
+    weight: 4
     label: hidden
     settings:
       responsive: true

--- a/conf/drupal/config/core.entity_view_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.topic.default.yml
@@ -96,7 +96,7 @@ content:
     region: content
   field_transcript:
     weight: 6
-    label: above
+    label: hidden
     settings:
       trim_length: 80
       url_only: false

--- a/conf/drupal/config/core.entity_view_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.topic.default.yml
@@ -96,7 +96,7 @@ content:
     region: content
   field_transcript:
     weight: 6
-    label: hidden
+    label: above
     settings:
       trim_length: 80
       url_only: false

--- a/conf/drupal/config/field.field.node.topic.field_transcript.yml
+++ b/conf/drupal/config/field.field.node.topic.field_transcript.yml
@@ -1,0 +1,24 @@
+uuid: cc02b550-d424-448a-99fa-a700132ca085
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_transcript
+    - node.type.topic
+  module:
+    - link
+id: node.topic.field_transcript
+field_name: field_transcript
+entity_type: node
+bundle: topic
+label: Transcript
+description: 'Add a link to the transcript for the session.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 0
+  title_predefined: ''
+field_type: link

--- a/conf/drupal/config/field.storage.node.field_transcript.yml
+++ b/conf/drupal/config/field.storage.node.field_transcript.yml
@@ -1,0 +1,23 @@
+uuid: 12939f9d-7a07-4c00-b45b-91e32c370622
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - link
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: custom
+id: node.field_transcript
+field_name: field_transcript
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/user.role.anonymous.yml
+++ b/conf/drupal/config/user.role.anonymous.yml
@@ -19,6 +19,7 @@ permissions:
   - 'view field_feedback_form'
   - 'view field_schedule_location'
   - 'view field_schedule_time'
+  - 'view field_transcript'
   - 'view field_video'
   - 'view own field_accepted_confirmed'
   - 'view own field_feedback_form'

--- a/conf/drupal/config/user.role.authenticated.yml
+++ b/conf/drupal/config/user.role.authenticated.yml
@@ -29,6 +29,7 @@ permissions:
   - 'view field_feedback_form'
   - 'view field_schedule_location'
   - 'view field_schedule_time'
+  - 'view field_transcript'
   - 'view field_video'
   - 'view latest version'
   - 'view own field_accepted_confirmed'

--- a/conf/drupal/config/user.role.organizer.yml
+++ b/conf/drupal/config/user.role.organizer.yml
@@ -7,7 +7,11 @@ label: Organizer
 weight: 4
 is_admin: null
 permissions:
+  - 'create field_transcript'
+  - 'edit field_transcript'
+  - 'edit own field_transcript'
   - 'use session_proposal transition publish'
   - 'use session_proposal transition submitted_proposal'
   - 'view any unpublished content'
   - 'view latest version'
+  - 'view own field_transcript'

--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -114,6 +114,13 @@ function hatter_preprocess_field(array &$variables, $hook) {
         }
       }
       break;
+    case 'field_transcript':
+      if ($variables['entity_type'] == 'node' && $variables['element']['#bundle'] == 'topic') {
+        foreach ($variables['items'] as $index => $item) {
+          $variables['items'][$index]['content']['#title'] = 'View Transcript';
+        }
+      }
+      break;
   }
 }
 


### PR DESCRIPTION
# Description 

- Adds Transcript field to Topic nodes so Sessions can be linked to their video transcripts

# To test

- Import config with `drush cim -y`
- Observe `field_transcript` exists on the `topic` content type
- Observe editing this field is limited to the `organizer` role
- Observe `anonymous` and `authenticated` users can view the field's contents