### PR TITLE
Open submissions

### DIFF
--- a/conf/drupal/config/field.field.node.topic.field_event.yml
+++ b/conf/drupal/config/field.field.node.topic.field_event.yml
@@ -7,7 +7,7 @@ dependencies:
     - node.type.topic
     - taxonomy.vocabulary.event
   content:
-    - 'taxonomy_term:event:17285735-fe51-4f45-b481-321ae7af649f'
+    - 'taxonomy_term:event:edb1c63f-3af1-4ce3-b9d0-55336993e692'
 id: node.topic.field_event
 field_name: field_event
 entity_type: node
@@ -18,7 +18,7 @@ required: false
 translatable: false
 default_value:
   -
-    target_uuid: 17285735-fe51-4f45-b481-321ae7af649f
+    target_uuid: edb1c63f-3af1-4ce3-b9d0-55336993e692
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/conf/drupal/config/user.role.authenticated.yml
+++ b/conf/drupal/config/user.role.authenticated.yml
@@ -14,6 +14,7 @@ permissions:
   - 'access shortcuts'
   - 'access site-wide contact form'
   - 'access user profiles'
+  - 'create topic content'
   - 'edit own topic content'
   - 'post comments'
   - 'search content'

--- a/features/topic.feature
+++ b/features/topic.feature
@@ -24,3 +24,10 @@ Feature: Topic Content Type
       | field-topic-type  | input     | radio |
       | field-people      | textfield | text  |
       | body              | textarea  |       |
+
+  Scenario: Authenticated user role cannot publish Topic content
+    Given I am logged in as a user with the "authenticated" role
+    And I am at "node/add/topic"
+    Then I should see "Draft" in the "#edit-moderation-state-0-state" element
+    And I should see "Submitted" in the "#edit-moderation-state-0-state" element
+    And I should not see "Accepted" in the "#edit-moderation-state-0-state" element


### PR DESCRIPTION
- Updates default term for `field_event` to "MidCamp 2020"
- Reenable `create topic content` permission for anonymous users so they can submit Topic Proposals
- Adds basic Behat test