### PR TITLE
Install NPM dependencies inside the CLI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,6 @@ jobs:
           name: Install dev dependencies
           command: |
             - docker-compose exec cli composer install
-            - docker-compose exec cli npm ci --unsafe-perm
       - run:
           name: Run Behat tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,8 @@ jobs:
             docker-compose exec cli drush site-install --verbose config_installer config_installer_sync_configure_form.sync_directory=../conf/drupal/config/ --yes
       - run:
           name: Install dev dependencies
-          command: |
-            - docker-compose exec cli composer install
+          command:
+            docker-compose exec cli composer install
       - run:
           name: Run Behat tests
           command: |

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,9 +1,14 @@
+FROM amazeeio/node:10-builder as builder
+COPY package.json package-lock.json /app/
+COPY ./web/themes/custom/hatter_2019 /app/web/themes/custom/hatter_2019
+RUN npm ci
 FROM amazeeio/php:7.1-cli-drupal
 
 COPY composer.json composer.lock /app/
 RUN composer install --prefer-dist --no-dev --no-suggest --optimize-autoloader --apcu-autoloader
 
 COPY . /app
+COPY --from=builder /app/web/themes/custom/hatter_2019/ /app/web/themes/custom/hatter_2019/
 
 # Define where the Drupal Root is located
 ENV WEBROOT=/web


### PR DESCRIPTION
## Description 

Installs NPM dependencies in `Dockerfile.cli`, since `npm` tooling isn't configured in a Docker container currently.  The `npm install` / `npm ci` commands are not needed  in CI since the Dockerfile handles them--the only reason `composer install` is getting run there is because it is installing dev dependencies to allow Behat testing.

## To Test

### Locally

- Run `docker-compose up -d --build`
- Visit http://midcamp.org.docker.amazee.io/admin/appearance and set the Hatter 2019 theme as default
- Observe the theme looks as expected, indicating the `npm ci` task has been performed successfully

### In a remote Lagoon environment

- Visit the remote environment corresponding with this PR (https://nginx-midcamp-org-feature-fix-circle.us.amazee.io/) 
- At https://nginx-midcamp-org-feature-fix-circle.us.amazee.io/admin/appearance set the Hatter 2019 theme as default
- Observe the theme looks as expected, indicating the `npm ci` task has been performed successfully