### PR TITLE
Add an "Accepted" workflow state

### DIFF
--- a/conf/drupal/config/workflows.workflow.session_proposal.yml
+++ b/conf/drupal/config/workflows.workflow.session_proposal.yml
@@ -20,7 +20,7 @@ type_settings:
     published:
       published: true
       default_revision: true
-      label: Accepted
+      label: Published
       weight: 1
     submitted:
       published: false

--- a/conf/drupal/config/workflows.workflow.session_proposal.yml
+++ b/conf/drupal/config/workflows.workflow.session_proposal.yml
@@ -12,6 +12,11 @@ label: 'Session and Training Proposal'
 type: content_moderation
 type_settings:
   states:
+    accepted:
+      published: true
+      default_revision: true
+      label: Accepted
+      weight: 3
     draft:
       label: Draft
       published: false
@@ -33,21 +38,33 @@ type_settings:
       to: draft
       weight: 0
       from:
+        - accepted
         - draft
         - published
         - submitted
+    proposal_accepted:
+      label: 'Proposal Accepted'
+      from:
+        - accepted
+        - published
+        - submitted
+      to: accepted
+      weight: 3
     publish:
       label: Publish
       to: published
       weight: 1
       from:
+        - accepted
         - draft
         - published
         - submitted
     submitted_proposal:
       label: 'Submitted Proposal'
       from:
+        - accepted
         - draft
+        - published
         - submitted
       to: submitted
       weight: 2


### PR DESCRIPTION
# Description

- Sets the default `published` state label back to its original "Published"
- Creates a new workflow state called "Accepted" which remains published and is set as default revision

# To test

- Import configuration with `drush cim -y`
- Publish some unpublished Topic Proposal content

# Notes

This is the first year we are introducing workflow for Topic proposals.  Previous years leveraged `field_accepted_confirmed` to indicate accepted sessions, so we will want to consider if we should continue using that field or deprecate it.  This PR does nothing to address that, and is meant only to allow a sane path for publishing session proposals prior to final selection. 