### PR TITLE
hide submit session link

### DIFF
--- a/web/themes/custom/hatter/templates/block/block--system-branding-block.html.twig
+++ b/web/themes/custom/hatter/templates/block/block--system-branding-block.html.twig
@@ -27,7 +27,7 @@
             <h1 class="event__title">{{ site_name }}</h1>
           {% endif %}
           <h2 class="event__subtitle">{{ site_slogan }}</h2>
-          <a href="/submit-session" class="event__button button--primary">Submit a Session</a>
+          {# <a href="/submit-session" class="event__button button--primary">Submit a Session</a> #}
           <a href="https://tickets.midcamp.org/" class="event__button button--primary">Buy a Ticket</a>
         </div>
       </div>


### PR DESCRIPTION
Now that session submission is over, I've hidden the `Submit a sesssion` link in the home page branding block