### PR TITLE
Upgrade to PHP 7.3

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -2,7 +2,7 @@ FROM amazeeio/node:10-builder as builder
 COPY package.json package-lock.json /app/
 COPY ./web/themes/custom/hatter_2019 /app/web/themes/custom/hatter_2019
 RUN npm ci
-FROM amazeeio/php:7.1-cli-drupal
+FROM amazeeio/php:7.3-cli-drupal
 
 COPY composer.json composer.lock /app/
 RUN composer install --prefer-dist --no-dev --no-suggest --optimize-autoloader --apcu-autoloader

--- a/Dockerfile.php
+++ b/Dockerfile.php
@@ -1,6 +1,6 @@
 ARG CLI_IMAGE
 FROM ${CLI_IMAGE} as cli
 
-FROM amazeeio/php:7.1-fpm
+FROM amazeeio/php:7.3-fpm-latest
 
 COPY --from=cli /app /app


### PR DESCRIPTION
## Description

Updates the site to use PHP 7.3. 

## To Test

- Visit https://nginx-midcamp-org-feature-php-73.us.amazee.io/admin/reports/status and confirm the site is running PHP 7.3.12
- Browse around and make sure things aren't broken