### PR TITLE
Homepage random session block

### DIFF
--- a/conf/drupal/config/block.block.hatter_2019_addajobbutton.yml
+++ b/conf/drupal/config/block.block.hatter_2019_addajobbutton.yml
@@ -13,7 +13,7 @@ dependencies:
 id: hatter_2019_addajobbutton
 theme: hatter_2019
 region: content
-weight: -14
+weight: -13
 provider: null
 plugin: 'block_content:de1557a6-167f-41a3-945d-05e977e71f1c'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_content.yml
+++ b/conf/drupal/config/block.block.hatter_2019_content.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_2019_content
 theme: hatter_2019
 region: content
-weight: -12
+weight: -11
 provider: null
 plugin: system_main_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_eventlabelblock.yml
+++ b/conf/drupal/config/block.block.hatter_2019_eventlabelblock.yml
@@ -10,7 +10,7 @@ dependencies:
 id: hatter_2019_eventlabelblock
 theme: hatter_2019
 region: content
-weight: -16
+weight: -15
 provider: null
 plugin: event_label_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_help.yml
+++ b/conf/drupal/config/block.block.hatter_2019_help.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_2019_help
 theme: hatter_2019
 region: content
-weight: -19
+weight: -18
 provider: null
 plugin: help_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_local_actions.yml
+++ b/conf/drupal/config/block.block.hatter_2019_local_actions.yml
@@ -9,7 +9,7 @@ _core:
 id: hatter_2019_local_actions
 theme: hatter_2019
 region: content
-weight: -13
+weight: -12
 provider: null
 plugin: local_actions_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_messages.yml
+++ b/conf/drupal/config/block.block.hatter_2019_messages.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_2019_messages
 theme: hatter_2019
 region: content
-weight: -18
+weight: -17
 provider: null
 plugin: system_messages_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_page_title.yml
+++ b/conf/drupal/config/block.block.hatter_2019_page_title.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_2019_page_title
 theme: hatter_2019
 region: content
-weight: -15
+weight: -14
 provider: null
 plugin: page_title_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_tabs.yml
+++ b/conf/drupal/config/block.block.hatter_2019_tabs.yml
@@ -7,7 +7,7 @@ dependencies:
 id: hatter_2019_tabs
 theme: hatter_2019
 region: content
-weight: -17
+weight: -16
 provider: null
 plugin: local_tasks_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_news_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_news_block_1.yml
@@ -11,7 +11,7 @@ dependencies:
 id: hatter_2019_views_block__event_news_block_1
 theme: hatter_2019
 region: content
-weight: -11
+weight: -10
 provider: null
 plugin: 'views_block:event_news-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_10.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_10.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_10
 theme: hatter_2019
 region: content
-weight: -5
+weight: -4
 provider: null
 plugin: 'views_block:event_sponsors-block_10'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_11.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_11.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_11
 theme: hatter_2019
 region: content
-weight: -4
+weight: -3
 provider: null
 plugin: 'views_block:event_sponsors-block_11'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_3.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_3.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_3
 theme: hatter_2019
 region: content
-weight: -6
+weight: -5
 provider: null
 plugin: 'views_block:event_sponsors-block_3'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_4.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_4.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_4
 theme: hatter_2019
 region: content
-weight: -10
+weight: -9
 provider: null
 plugin: 'views_block:event_sponsors-block_4'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_5.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_5.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_5
 theme: hatter_2019
 region: content
-weight: -8
+weight: -7
 provider: null
 plugin: 'views_block:event_sponsors-block_5'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_9.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_9.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_9
 theme: hatter_2019
 region: content
-weight: -9
+weight: -8
 provider: null
 plugin: 'views_block:event_sponsors-block_9'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__speakers_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__speakers_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__speakers_block_1
 theme: hatter_2019
 region: content
-weight: -2
+weight: -1
 provider: null
 plugin: 'views_block:speakers-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__training_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__training_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__training_block_1
 theme: hatter_2019
 region: content
-weight: -1
+weight: 0
 provider: null
 plugin: 'views_block:training-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_webform.yml
+++ b/conf/drupal/config/block.block.hatter_2019_webform.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_webform
 theme: hatter_2019
 region: content
-weight: -3
+weight: -2
 provider: null
 plugin: webform_block
 settings:

--- a/conf/drupal/config/block.block.views_block__random_session_block_1.yml
+++ b/conf/drupal/config/block.block.views_block__random_session_block_1.yml
@@ -1,31 +1,30 @@
-uuid: 3a234436-0daa-464e-a2e0-d53a7af61331
+uuid: f0e31d48-bd3a-4a69-8e8a-04e7ff94fb0b
 langcode: en
 status: true
 dependencies:
   config:
-    - views.view.event_sponsors
+    - views.view.random_session
   module:
     - system
     - views
   theme:
     - hatter_2019
-id: hatter_2019_views_block__event_sponsors_block_2
+id: views_block__random_session_block_1
 theme: hatter_2019
 region: content
-weight: -6
+weight: -19
 provider: null
-plugin: 'views_block:event_sponsors-block_2'
+plugin: 'views_block:random_session-block_1'
 settings:
-  id: 'views_block:event_sponsors-block_2'
+  id: 'views_block:random_session-block_1'
   label: ''
   provider: views
-  label_display: visible
+  label_display: '0'
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/sponsors\r\n/2019/sponsors"
+    pages: '<front>'
     negate: false
     context_mapping: {  }

--- a/conf/drupal/config/views.view.random_session.yml
+++ b/conf/drupal/config/views.view.random_session.yml
@@ -3,6 +3,10 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.body
+    - field.storage.node.field_people
+    - field.storage.node.field_schedule_location
+    - field.storage.node.field_track
     - field.storage.user.user_picture
     - image.style.schedule_presenter
     - node.type.topic
@@ -13,6 +17,7 @@ dependencies:
     - image
     - node
     - taxonomy
+    - text
     - user
 id: random_session
 label: 'Random Session'
@@ -61,56 +66,18 @@ display:
           offset: 0
       style:
         type: default
+        options:
+          grouping: {  }
+          row_class: schedule__teaser
+          default_row_class: false
       row:
         type: fields
-      fields:
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          entity_type: node
-          entity_field: title
-          label: ''
-          alter:
-            alter_text: false
-            make_link: false
-            absolute: false
-            trim: false
-            word_boundary: false
-            ellipsis: false
-            strip_tags: false
-            html: false
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
           hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
+      fields:
         user_picture:
           id: user_picture
           table: user__user_picture
@@ -119,7 +86,7 @@ display:
           group_type: group
           admin_label: ''
           label: ''
-          exclude: false
+          exclude: true
           alter:
             alter_text: false
             text: ''
@@ -165,6 +132,323 @@ display:
             image_style: schedule_presenter
             image_link: ''
           group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_track:
+          id: field_track
+          table: node__field_track
+          field: field_track
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: div
+          element_class: schedule__track
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: h3
+          element_class: schedule__title
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        body:
+          id: body
+          table: node__body
+          field: body
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: div
+          element_class: schedule__description
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: text_summary_or_trimmed
+          settings:
+            trim_length: 600
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_people:
+          id: field_people
+          table: node__field_people
+          field: field_people
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_entity_view
+          settings:
+            view_mode: schedule
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_schedule_location:
+          id: field_schedule_location
+          table: node__field_schedule_location
+          field: field_schedule_location
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: div
+          element_class: schedule__room
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -282,6 +566,42 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: numeric
+        field_accepted_confirmed_value:
+          id: field_accepted_confirmed_value
+          table: node__field_accepted_confirmed
+          field: field_accepted_confirmed_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
       sorts:
         random:
           id: random
@@ -296,7 +616,20 @@ display:
             label: ''
           plugin_id: random
       title: 'Random Session'
-      header: {  }
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content:
+            value: '<h2 class="banner-title">Featured Session</h2>'
+            format: full_html
+          plugin_id: text
       footer: {  }
       empty: {  }
       relationships:
@@ -320,6 +653,10 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.body'
+        - 'config:field.storage.node.field_people'
+        - 'config:field.storage.node.field_schedule_location'
+        - 'config:field.storage.node.field_track'
         - 'config:field.storage.user.user_picture'
   block_1:
     display_plugin: block
@@ -337,4 +674,8 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags:
+        - 'config:field.storage.node.body'
+        - 'config:field.storage.node.field_people'
+        - 'config:field.storage.node.field_schedule_location'
+        - 'config:field.storage.node.field_track'
         - 'config:field.storage.user.user_picture'

--- a/conf/drupal/config/views.view.random_session.yml
+++ b/conf/drupal/config/views.view.random_session.yml
@@ -1,0 +1,340 @@
+uuid: 57f5d7f2-8e51-40ea-9a00-11d6bda4e5db
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.user_picture
+    - image.style.schedule_presenter
+    - node.type.topic
+    - taxonomy.vocabulary.event
+  content:
+    - 'taxonomy_term:event:edb1c63f-3af1-4ce3-b9d0-55336993e692'
+  module:
+    - image
+    - node
+    - taxonomy
+    - user
+id: random_session
+label: 'Random Session'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 1
+          offset: 0
+      style:
+        type: default
+      row:
+        type: fields
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          entity_type: node
+          entity_field: title
+          label: ''
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            trim: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            html: false
+          hide_empty: false
+          empty_zero: false
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exclude: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        user_picture:
+          id: user_picture
+          table: user__user_picture
+          field: user_picture
+          relationship: field_people
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image
+          settings:
+            image_style: schedule_presenter
+            image_link: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            topic: topic
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            - 143
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: textfield
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        user_picture_target_id:
+          id: user_picture_target_id
+          table: user__user_picture
+          field: user_picture_target_id
+          relationship: field_people
+          group_type: group
+          admin_label: ''
+          operator: 'not empty'
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+            min_placeholder: ''
+            max_placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: numeric
+      sorts:
+        random:
+          id: random
+          table: views
+          field: random
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: random
+      title: 'Random Session'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships:
+        field_people:
+          id: field_people
+          table: node__field_people
+          field: field_people
+          relationship: none
+          group_type: group
+          admin_label: 'field_people: User'
+          required: true
+          plugin_id: standard
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.user.user_picture'
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: Block
+    position: 1
+    display_options:
+      display_extenders: {  }
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.user.user_picture'


### PR DESCRIPTION
Creates a display to showcase a random 2020 confirmed session with speaker image on the homepage.

https://nginx-midcamp-org-feature-random-session-block.us.amazee.io/

Currently styled after the schedule.  Do we want this to look different?