### PR TITLE
Tito integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require": {
         "brian-clement/eventbrite_events": "dev-master",
-        "brian-clement/tito": "dev-feature/api",
+        "brian-clement/tito": "dev-master",
         "composer/installers": "^1.0",
         "cweagans/composer-patches": "~1.0",
         "drupal-composer/drupal-scaffold": "^2.3",

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,10 @@
             "type": "vcs",
             "url": "https://github.com/Brian-Clement/eventbrite_events.git"
         },
+        "tito": {
+            "type": "vcs",
+            "url": "https://github.com/Brian-Clement/tito.git"
+        },
         "hatter-styleguide": {
             "type": "vcs",
             "url": "https://github.com/midcamp/hatter.git"
@@ -33,6 +37,7 @@
     },
     "require": {
         "brian-clement/eventbrite_events": "dev-master",
+        "brian-clement/tito": "dev-feature/api",
         "composer/installers": "^1.0",
         "cweagans/composer-patches": "~1.0",
         "drupal-composer/drupal-scaffold": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ad27279d11b2df6277cf91c6c654938",
+    "content-hash": "5115d2334a0417b5f07a56064395c8a5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -88,16 +88,16 @@
         },
         {
             "name": "brian-clement/tito",
-            "version": "dev-feature/api",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Brian-Clement/tito.git",
-                "reference": "58ab3cc1771d05b876d0dd6eb284bdde52f5c71b"
+                "reference": "b9d506bcb416c9b57b4d6456c0baca4957be8633"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Brian-Clement/tito/zipball/58ab3cc1771d05b876d0dd6eb284bdde52f5c71b",
-                "reference": "58ab3cc1771d05b876d0dd6eb284bdde52f5c71b",
+                "url": "https://api.github.com/repos/Brian-Clement/tito/zipball/b9d506bcb416c9b57b4d6456c0baca4957be8633",
+                "reference": "b9d506bcb416c9b57b4d6456c0baca4957be8633",
                 "shasum": ""
             },
             "type": "drupal-module",
@@ -109,7 +109,7 @@
                 "issues": "https://www.drupal.org/project/issues/tito",
                 "source": "http://cgit.drupalcode.org/tito"
             },
-            "time": "2019-10-27T15:14:37+00:00"
+            "time": "2020-02-12T19:44:50+00:00"
         },
         {
             "name": "brumann/polyfill-unserialize",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "568a110e489c1aaa103ee9ed3d5174dc",
+    "content-hash": "1ad27279d11b2df6277cf91c6c654938",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -85,6 +85,31 @@
                 "issues": "https://github.com/Brian-Clement/eventbrite_events/issues"
             },
             "time": "2019-10-21T23:02:13+00:00"
+        },
+        {
+            "name": "brian-clement/tito",
+            "version": "dev-feature/api",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Brian-Clement/tito.git",
+                "reference": "58ab3cc1771d05b876d0dd6eb284bdde52f5c71b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Brian-Clement/tito/zipball/58ab3cc1771d05b876d0dd6eb284bdde52f5c71b",
+                "reference": "58ab3cc1771d05b876d0dd6eb284bdde52f5c71b",
+                "shasum": ""
+            },
+            "type": "drupal-module",
+            "description": "Tito",
+            "keywords": [
+                "Drupal"
+            ],
+            "support": {
+                "issues": "https://www.drupal.org/project/issues/tito",
+                "source": "http://cgit.drupalcode.org/tito"
+            },
+            "time": "2019-10-27T15:14:37+00:00"
         },
         {
             "name": "brumann/polyfill-unserialize",
@@ -8480,6 +8505,7 @@
                 "psr",
                 "psr-7"
             ],
+            "abandoned": "laminas/laminas-diactoros",
             "time": "2019-08-06T17:53:53+00:00"
         },
         {
@@ -8525,6 +8551,7 @@
                 "escaper",
                 "zf"
             ],
+            "abandoned": "laminas/laminas-escaper",
             "time": "2019-09-05T20:03:20+00:00"
         },
         {
@@ -8588,6 +8615,7 @@
                 "feed",
                 "zf"
             ],
+            "abandoned": "laminas/laminas-feed",
             "time": "2019-03-05T20:08:49+00:00"
         },
         {
@@ -8634,6 +8662,7 @@
                 "stdlib",
                 "zf"
             ],
+            "abandoned": "laminas/laminas-stdlib",
             "time": "2018-08-28T21:34:05+00:00"
         }
     ],
@@ -11092,6 +11121,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "brian-clement/eventbrite_events": 20,
+        "brian-clement/tito": 20,
         "drupal/address": 20,
         "drupal/captcha": 20,
         "drupal/devel": 10,

--- a/composer.lock
+++ b/composer.lock
@@ -92,12 +92,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Brian-Clement/tito.git",
-                "reference": "b9d506bcb416c9b57b4d6456c0baca4957be8633"
+                "reference": "6e6dcf9c4ecf3a98b1a252f12bd2e78848c4f0f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Brian-Clement/tito/zipball/b9d506bcb416c9b57b4d6456c0baca4957be8633",
-                "reference": "b9d506bcb416c9b57b4d6456c0baca4957be8633",
+                "url": "https://api.github.com/repos/Brian-Clement/tito/zipball/6e6dcf9c4ecf3a98b1a252f12bd2e78848c4f0f0",
+                "reference": "6e6dcf9c4ecf3a98b1a252f12bd2e78848c4f0f0",
                 "shasum": ""
             },
             "type": "drupal-module",
@@ -109,7 +109,7 @@
                 "issues": "https://www.drupal.org/project/issues/tito",
                 "source": "http://cgit.drupalcode.org/tito"
             },
-            "time": "2020-02-12T19:44:50+00:00"
+            "time": "2020-02-23T15:46:32+00:00"
         },
         {
             "name": "brumann/polyfill-unserialize",

--- a/conf/drupal/config/block.block.hatter_2019_addajobbutton.yml
+++ b/conf/drupal/config/block.block.hatter_2019_addajobbutton.yml
@@ -13,7 +13,7 @@ dependencies:
 id: hatter_2019_addajobbutton
 theme: hatter_2019
 region: content
-weight: -13
+weight: -14
 provider: null
 plugin: 'block_content:de1557a6-167f-41a3-945d-05e977e71f1c'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_content.yml
+++ b/conf/drupal/config/block.block.hatter_2019_content.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_2019_content
 theme: hatter_2019
 region: content
-weight: -11
+weight: -12
 provider: null
 plugin: system_main_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_eventlabelblock.yml
+++ b/conf/drupal/config/block.block.hatter_2019_eventlabelblock.yml
@@ -10,7 +10,7 @@ dependencies:
 id: hatter_2019_eventlabelblock
 theme: hatter_2019
 region: content
-weight: -15
+weight: -16
 provider: null
 plugin: event_label_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_help.yml
+++ b/conf/drupal/config/block.block.hatter_2019_help.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_2019_help
 theme: hatter_2019
 region: content
-weight: -18
+weight: -19
 provider: null
 plugin: help_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_local_actions.yml
+++ b/conf/drupal/config/block.block.hatter_2019_local_actions.yml
@@ -9,7 +9,7 @@ _core:
 id: hatter_2019_local_actions
 theme: hatter_2019
 region: content
-weight: -12
+weight: -13
 provider: null
 plugin: local_actions_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_messages.yml
+++ b/conf/drupal/config/block.block.hatter_2019_messages.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_2019_messages
 theme: hatter_2019
 region: content
-weight: -17
+weight: -18
 provider: null
 plugin: system_messages_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_midcamp2019.yml
+++ b/conf/drupal/config/block.block.hatter_2019_midcamp2019.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_midcamp2019
 theme: hatter_2019
 region: content
-weight: -20
+weight: -21
 provider: null
 plugin: 'block_content:718a2f09-3a75-462a-9c04-3e21f78a81bb'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_page_title.yml
+++ b/conf/drupal/config/block.block.hatter_2019_page_title.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_2019_page_title
 theme: hatter_2019
 region: content
-weight: -14
+weight: -15
 provider: null
 plugin: page_title_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_tabs.yml
+++ b/conf/drupal/config/block.block.hatter_2019_tabs.yml
@@ -7,7 +7,7 @@ dependencies:
 id: hatter_2019_tabs
 theme: hatter_2019
 region: content
-weight: -16
+weight: -17
 provider: null
 plugin: local_tasks_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_news_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_news_block_1.yml
@@ -11,7 +11,7 @@ dependencies:
 id: hatter_2019_views_block__event_news_block_1
 theme: hatter_2019
 region: content
-weight: -10
+weight: -11
 provider: null
 plugin: 'views_block:event_news-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_10.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_10.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_10
 theme: hatter_2019
 region: content
-weight: -4
+weight: -5
 provider: null
 plugin: 'views_block:event_sponsors-block_10'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_11.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_11.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_11
 theme: hatter_2019
 region: content
-weight: -3
+weight: -4
 provider: null
 plugin: 'views_block:event_sponsors-block_11'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_3.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_3.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_3
 theme: hatter_2019
 region: content
-weight: -5
+weight: -6
 provider: null
 plugin: 'views_block:event_sponsors-block_3'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_4.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_4.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_4
 theme: hatter_2019
 region: content
-weight: -9
+weight: -10
 provider: null
 plugin: 'views_block:event_sponsors-block_4'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_5.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_5.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_5
 theme: hatter_2019
 region: content
-weight: -7
+weight: -8
 provider: null
 plugin: 'views_block:event_sponsors-block_5'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_6.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_6.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_6
 theme: hatter_2019
 region: content
-weight: 4
+weight: 3
 provider: null
 plugin: 'views_block:event_sponsors-block_6'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_8.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_8.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_8
 theme: hatter_2019
 region: content
-weight: 3
+weight: 2
 provider: null
 plugin: 'views_block:event_sponsors-block_8'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_9.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_9.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_9
 theme: hatter_2019
 region: content
-weight: -8
+weight: -9
 provider: null
 plugin: 'views_block:event_sponsors-block_9'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__jobs_board_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__jobs_board_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__jobs_board_block_1
 theme: hatter_2019
 region: content
-weight: 1
+weight: 0
 provider: null
 plugin: 'views_block:jobs_board-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__speakers_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__speakers_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__speakers_block_1
 theme: hatter_2019
 region: content
-weight: -1
+weight: -2
 provider: null
 plugin: 'views_block:speakers-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__summits_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__summits_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__summits_block_1
 theme: hatter_2019
 region: content
-weight: 2
+weight: 1
 provider: null
 plugin: 'views_block:summits-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__training_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__training_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__training_block_1
 theme: hatter_2019
 region: content
-weight: 0
+weight: -1
 provider: null
 plugin: 'views_block:training-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_webform.yml
+++ b/conf/drupal/config/block.block.hatter_2019_webform.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_webform
 theme: hatter_2019
 region: content
-weight: -2
+weight: -3
 provider: null
 plugin: webform_block
 settings:

--- a/conf/drupal/config/block.block.views_block__attendees_2020_block_1.yml
+++ b/conf/drupal/config/block.block.views_block__attendees_2020_block_1.yml
@@ -1,31 +1,30 @@
-uuid: 3a234436-0daa-464e-a2e0-d53a7af61331
+uuid: e8af6cc5-2038-4d24-82ec-2e0b3e6d004a
 langcode: en
 status: true
 dependencies:
   config:
-    - views.view.event_sponsors
+    - views.view.attendees_2020
   module:
     - system
     - views
   theme:
     - hatter_2019
-id: hatter_2019_views_block__event_sponsors_block_2
+id: views_block__attendees_2020_block_1
 theme: hatter_2019
 region: content
-weight: -7
+weight: 4
 provider: null
-plugin: 'views_block:event_sponsors-block_2'
+plugin: 'views_block:attendees_2020-block_1'
 settings:
-  id: 'views_block:event_sponsors-block_2'
+  id: 'views_block:attendees_2020-block_1'
   label: ''
   provider: views
   label_display: visible
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/sponsors\r\n/2019/sponsors"
+    pages: /2020/sponsors
     negate: false
     context_mapping: {  }

--- a/conf/drupal/config/block.block.views_block__random_session_block_1.yml
+++ b/conf/drupal/config/block.block.views_block__random_session_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__random_session_block_1
 theme: hatter_2019
 region: content
-weight: -19
+weight: -20
 provider: null
 plugin: 'views_block:random_session-block_1'
 settings:

--- a/conf/drupal/config/config_ignore.settings.yml
+++ b/conf/drupal/config/config_ignore.settings.yml
@@ -6,5 +6,6 @@ ignored_config_entities:
   8: google_analytics.settings
   10: 'recaptcha.settings:site_key'
   12: 'recaptcha.settings:secret_key'
+  14: 'tito.settings:tito_api_token'
 _core:
   default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/conf/drupal/config/core.base_field_override.node.attendee.promote.yml
+++ b/conf/drupal/config/core.base_field_override.node.attendee.promote.yml
@@ -1,0 +1,22 @@
+uuid: aa0fc96d-c810-43b2-aec6-ab134a1e2b43
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.attendee
+id: node.attendee.promote
+field_name: promote
+entity_type: node
+bundle: attendee
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/drupal/config/core.base_field_override.node.attendee.title.yml
+++ b/conf/drupal/config/core.base_field_override.node.attendee.title.yml
@@ -1,0 +1,18 @@
+uuid: 36ae1236-55b0-44d9-b204-c496a50d045f
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.attendee
+id: node.attendee.title
+field_name: title
+entity_type: node
+bundle: attendee
+label: Name
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/drupal/config/core.entity_form_display.node.attendee.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.attendee.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.attendee.field_attendee_id
     - field.field.node.attendee.field_display_on_site
+    - field.field.node.attendee.field_drupal_user_account
     - field.field.node.attendee.field_email
     - field.field.node.attendee.field_event
     - field.field.node.attendee.field_first_name
@@ -43,6 +44,15 @@ content:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
+    region: content
+  field_drupal_user_account:
+    weight: 132
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
     region: content
   field_email:
     weight: 121

--- a/conf/drupal/config/core.entity_form_display.node.attendee.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.attendee.default.yml
@@ -1,0 +1,169 @@
+uuid: cc5e31d9-0c86-4fd7-b3c9-fdd1ca1294f3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.attendee.field_attendee_id
+    - field.field.node.attendee.field_display_on_site
+    - field.field.node.attendee.field_email
+    - field.field.node.attendee.field_first_name
+    - field.field.node.attendee.field_job_title
+    - field.field.node.attendee.field_last_name
+    - field.field.node.attendee.field_name
+    - field.field.node.attendee.field_organization
+    - field.field.node.attendee.field_ticket_state
+    - node.type.attendee
+  module:
+    - content_moderation
+    - path
+    - scheduler
+id: node.attendee.default
+targetEntityType: node
+bundle: attendee
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_attendee_id:
+    weight: 122
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_display_on_site:
+    weight: 125
+    settings:
+      display_label: true
+    third_party_settings: {  }
+    type: boolean_checkbox
+    region: content
+  field_email:
+    weight: 121
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: email_default
+    region: content
+  field_first_name:
+    weight: 127
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_job_title:
+    weight: 126
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_last_name:
+    weight: 128
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_name:
+    weight: 123
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_organization:
+    weight: 124
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_ticket_state:
+    weight: 129
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  moderation_state:
+    type: moderation_state_default
+    weight: 100
+    settings: {  }
+    region: content
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    region: content
+    third_party_settings: {  }
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 120
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  url_redirects:
+    weight: 50
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/conf/drupal/config/core.entity_form_display.node.attendee.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.attendee.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.attendee.field_attendee_id
     - field.field.node.attendee.field_display_on_site
     - field.field.node.attendee.field_email
+    - field.field.node.attendee.field_event
     - field.field.node.attendee.field_first_name
     - field.field.node.attendee.field_job_title
     - field.field.node.attendee.field_last_name
@@ -50,6 +51,15 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: email_default
+    region: content
+  field_event:
+    weight: 130
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
     region: content
   field_first_name:
     weight: 127

--- a/conf/drupal/config/core.entity_form_display.node.attendee.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.attendee.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.attendee.field_name
     - field.field.node.attendee.field_organization
     - field.field.node.attendee.field_ticket_state
+    - field.field.node.attendee.field_ticket_type
     - node.type.attendee
   module:
     - content_moderation
@@ -103,6 +104,14 @@ content:
     region: content
   field_ticket_state:
     weight: 129
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_ticket_type:
+    weight: 131
     settings:
       size: 60
       placeholder: ''

--- a/conf/drupal/config/core.entity_form_display.node.attendee.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.attendee.default.yml
@@ -16,7 +16,6 @@ dependencies:
     - field.field.node.attendee.field_ticket_type
     - node.type.attendee
   module:
-    - content_moderation
     - path
     - scheduler
 id: node.attendee.default

--- a/conf/drupal/config/core.entity_form_display.taxonomy_term.event.default.yml
+++ b/conf/drupal/config/core.entity_form_display.taxonomy_term.event.default.yml
@@ -11,14 +11,32 @@ dependencies:
     - field.field.taxonomy_term.event.field_event_status
     - field.field.taxonomy_term.event.field_image
     - field.field.taxonomy_term.event.field_social_media
+    - field.field.taxonomy_term.event.field_tito_slug
     - image.style.thumbnail
     - taxonomy.vocabulary.event
   module:
     - datetime_range
+    - field_group
     - image
     - link
     - path
     - text
+third_party_settings:
+  field_group:
+    group_tito:
+      children:
+        - field_tito_slug
+        - field_event_id
+        - field_event_status
+      parent_name: ''
+      weight: 9
+      format_type: fieldset
+      format_settings:
+        id: ''
+        classes: ''
+        description: 'Enter the event "slug" from Tito.  The rest of the fields will be populated automatically. '
+        required_fields: false
+      label: Tito
 id: taxonomy_term.event.default
 targetEntityType: taxonomy_term
 bundle: event
@@ -33,7 +51,7 @@ content:
     third_party_settings: {  }
     region: content
   field_banner_cta_anonymous:
-    weight: 6
+    weight: 7
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -41,7 +59,7 @@ content:
     type: link_default
     region: content
   field_banner_cta_authenticated:
-    weight: 7
+    weight: 8
     settings:
       placeholder_url: ''
       placeholder_title: ''
@@ -62,7 +80,7 @@ content:
     type: boolean_checkbox
     region: content
   field_event_id:
-    weight: 8
+    weight: 11
     settings:
       size: 60
       placeholder: ''
@@ -70,7 +88,7 @@ content:
     type: string_textfield
     region: content
   field_event_status:
-    weight: 9
+    weight: 12
     settings:
       size: 60
       placeholder: ''
@@ -86,12 +104,20 @@ content:
     type: image_image
     region: content
   field_social_media:
-    weight: 5
+    weight: 6
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
     type: link_default
+    region: content
+  field_tito_slug:
+    weight: 10
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   name:
     type: string_textfield

--- a/conf/drupal/config/core.entity_form_display.taxonomy_term.event.default.yml
+++ b/conf/drupal/config/core.entity_form_display.taxonomy_term.event.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.taxonomy_term.event.field_banner_cta_authenticated
     - field.field.taxonomy_term.event.field_date
     - field.field.taxonomy_term.event.field_date_has_time
+    - field.field.taxonomy_term.event.field_event_id
     - field.field.taxonomy_term.event.field_image
     - field.field.taxonomy_term.event.field_social_media
     - image.style.thumbnail
@@ -58,6 +59,14 @@ content:
       display_label: true
     third_party_settings: {  }
     type: boolean_checkbox
+    region: content
+  field_event_id:
+    weight: 8
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
     region: content
   field_image:
     weight: 5

--- a/conf/drupal/config/core.entity_form_display.taxonomy_term.event.default.yml
+++ b/conf/drupal/config/core.entity_form_display.taxonomy_term.event.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.taxonomy_term.event.field_date
     - field.field.taxonomy_term.event.field_date_has_time
     - field.field.taxonomy_term.event.field_event_id
+    - field.field.taxonomy_term.event.field_event_status
     - field.field.taxonomy_term.event.field_image
     - field.field.taxonomy_term.event.field_social_media
     - image.style.thumbnail
@@ -62,6 +63,14 @@ content:
     region: content
   field_event_id:
     weight: 8
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_event_status:
+    weight: 9
     settings:
       size: 60
       placeholder: ''

--- a/conf/drupal/config/core.entity_view_display.node.attendee.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.attendee.default.yml
@@ -23,106 +23,49 @@ targetEntityType: node
 bundle: attendee
 mode: default
 content:
-  field_attendee_id:
-    weight: 102
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
-    region: content
-  field_display_on_site:
-    weight: 105
-    label: above
-    settings:
-      format: default
-      format_custom_false: ''
-      format_custom_true: ''
-    third_party_settings: {  }
-    type: boolean
-    region: content
-  field_drupal_user_account:
-    weight: 112
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
-  field_email:
-    weight: 101
-    label: above
-    settings: {  }
-    third_party_settings: {  }
-    type: basic_string
-    region: content
   field_event:
-    weight: 110
-    label: above
+    weight: 4
+    label: inline
     settings:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
-    region: content
-  field_first_name:
-    weight: 107
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
     region: content
   field_job_title:
-    weight: 106
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
-    region: content
-  field_last_name:
-    weight: 108
-    label: above
+    weight: 2
+    label: inline
     settings:
       link_to_entity: false
     third_party_settings: {  }
     type: string
     region: content
   field_name:
-    weight: 103
-    label: above
+    weight: 1
+    label: inline
     settings:
       link_to_entity: false
     third_party_settings: {  }
     type: string
     region: content
   field_organization:
-    weight: 104
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
-    region: content
-  field_ticket_state:
-    weight: 109
-    label: above
-    settings:
-      link_to_entity: false
-    third_party_settings: {  }
-    type: string
-    region: content
-  field_ticket_type:
-    weight: 111
-    label: above
+    weight: 3
+    label: inline
     settings:
       link_to_entity: false
     third_party_settings: {  }
     type: string
     region: content
   links:
-    weight: 100
+    weight: 0
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
-hidden: {  }
+hidden:
+  field_attendee_id: true
+  field_display_on_site: true
+  field_drupal_user_account: true
+  field_email: true
+  field_first_name: true
+  field_last_name: true
+  field_ticket_state: true
+  field_ticket_type: true

--- a/conf/drupal/config/core.entity_view_display.node.attendee.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.attendee.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.attendee.field_attendee_id
     - field.field.node.attendee.field_display_on_site
     - field.field.node.attendee.field_email
+    - field.field.node.attendee.field_event
     - field.field.node.attendee.field_first_name
     - field.field.node.attendee.field_job_title
     - field.field.node.attendee.field_last_name
@@ -44,6 +45,14 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: basic_string
+    region: content
+  field_event:
+    weight: 110
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   field_first_name:
     weight: 107

--- a/conf/drupal/config/core.entity_view_display.node.attendee.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.attendee.default.yml
@@ -1,0 +1,101 @@
+uuid: caad2c28-42e9-4bdb-a3ce-df8cf31a3656
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.attendee.field_attendee_id
+    - field.field.node.attendee.field_display_on_site
+    - field.field.node.attendee.field_email
+    - field.field.node.attendee.field_first_name
+    - field.field.node.attendee.field_job_title
+    - field.field.node.attendee.field_last_name
+    - field.field.node.attendee.field_name
+    - field.field.node.attendee.field_organization
+    - field.field.node.attendee.field_ticket_state
+    - node.type.attendee
+  module:
+    - user
+id: node.attendee.default
+targetEntityType: node
+bundle: attendee
+mode: default
+content:
+  field_attendee_id:
+    weight: 102
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_display_on_site:
+    weight: 105
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    type: boolean
+    region: content
+  field_email:
+    weight: 101
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_first_name:
+    weight: 107
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_job_title:
+    weight: 106
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_last_name:
+    weight: 108
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_name:
+    weight: 103
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_organization:
+    weight: 104
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_ticket_state:
+    weight: 109
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/conf/drupal/config/core.entity_view_display.node.attendee.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.attendee.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.attendee.field_attendee_id
     - field.field.node.attendee.field_display_on_site
+    - field.field.node.attendee.field_drupal_user_account
     - field.field.node.attendee.field_email
     - field.field.node.attendee.field_event
     - field.field.node.attendee.field_first_name
@@ -39,6 +40,14 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     type: boolean
+    region: content
+  field_drupal_user_account:
+    weight: 112
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
     region: content
   field_email:
     weight: 101

--- a/conf/drupal/config/core.entity_view_display.node.attendee.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.attendee.default.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.field.node.attendee.field_name
     - field.field.node.attendee.field_organization
     - field.field.node.attendee.field_ticket_state
+    - field.field.node.attendee.field_ticket_type
     - node.type.attendee
   module:
     - user
@@ -96,6 +97,14 @@ content:
     region: content
   field_ticket_state:
     weight: 109
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_ticket_type:
+    weight: 111
     label: above
     settings:
       link_to_entity: false

--- a/conf/drupal/config/core.entity_view_display.node.attendee.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.attendee.teaser.yml
@@ -21,6 +21,7 @@ hidden:
   field_attendee_id: true
   field_display_on_site: true
   field_email: true
+  field_event: true
   field_first_name: true
   field_job_title: true
   field_last_name: true

--- a/conf/drupal/config/core.entity_view_display.node.attendee.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.attendee.teaser.yml
@@ -17,4 +17,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
-hidden: {  }
+hidden:
+  field_attendee_id: true
+  field_display_on_site: true
+  field_email: true
+  field_first_name: true
+  field_job_title: true
+  field_last_name: true
+  field_name: true
+  field_organization: true
+  field_ticket_state: true

--- a/conf/drupal/config/core.entity_view_display.node.attendee.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.attendee.teaser.yml
@@ -1,0 +1,20 @@
+uuid: 67b1d5b7-e3be-40c2-810b-13efaddc84af
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - node.type.attendee
+  module:
+    - user
+id: node.attendee.teaser
+targetEntityType: node
+bundle: attendee
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/conf/drupal/config/core.entity_view_display.node.attendee.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.attendee.teaser.yml
@@ -28,3 +28,4 @@ hidden:
   field_name: true
   field_organization: true
   field_ticket_state: true
+  field_ticket_type: true

--- a/conf/drupal/config/core.entity_view_display.taxonomy_term.event.default.yml
+++ b/conf/drupal/config/core.entity_view_display.taxonomy_term.event.default.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.taxonomy_term.event.field_banner_cta_authenticated
     - field.field.taxonomy_term.event.field_date
     - field.field.taxonomy_term.event.field_date_has_time
+    - field.field.taxonomy_term.event.field_event_id
     - field.field.taxonomy_term.event.field_image
     - field.field.taxonomy_term.event.field_social_media
     - taxonomy.vocabulary.event
@@ -70,6 +71,14 @@ content:
       format_custom_true: ''
     third_party_settings: {  }
     type: boolean
+    region: content
+  field_event_id:
+    weight: 7
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
     region: content
   field_image:
     weight: 1

--- a/conf/drupal/config/core.entity_view_display.taxonomy_term.event.default.yml
+++ b/conf/drupal/config/core.entity_view_display.taxonomy_term.event.default.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.taxonomy_term.event.field_event_status
     - field.field.taxonomy_term.event.field_image
     - field.field.taxonomy_term.event.field_social_media
+    - field.field.taxonomy_term.event.field_tito_slug
     - taxonomy.vocabulary.event
   module:
     - datetime_range
@@ -97,6 +98,14 @@ content:
       image_link: ''
     third_party_settings: {  }
     type: image
+    region: content
+  field_tito_slug:
+    weight: 9
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
     region: content
 hidden:
   field_social_media: true

--- a/conf/drupal/config/core.entity_view_display.taxonomy_term.event.default.yml
+++ b/conf/drupal/config/core.entity_view_display.taxonomy_term.event.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.taxonomy_term.event.field_date
     - field.field.taxonomy_term.event.field_date_has_time
     - field.field.taxonomy_term.event.field_event_id
+    - field.field.taxonomy_term.event.field_event_status
     - field.field.taxonomy_term.event.field_image
     - field.field.taxonomy_term.event.field_social_media
     - taxonomy.vocabulary.event
@@ -74,6 +75,14 @@ content:
     region: content
   field_event_id:
     weight: 7
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_event_status:
+    weight: 8
     label: above
     settings:
       link_to_entity: false

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -51,6 +51,7 @@ module:
   metatag: 0
   metatag_open_graph: 0
   midcamp_event_label_block: 0
+  midcamp_tito: 0
   midcamp_utility: 0
   midcamp_vbo: 0
   name: 0

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -70,6 +70,7 @@ module:
   system: 0
   taxonomy: 0
   text: 0
+  tito: 0
   token: 0
   toolbar: 0
   tour: 0

--- a/conf/drupal/config/field.field.node.attendee.field_attendee_id.yml
+++ b/conf/drupal/config/field.field.node.attendee.field_attendee_id.yml
@@ -1,0 +1,19 @@
+uuid: 00a29734-ac44-4c55-be3b-f145be96bf01
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_attendee_id
+    - node.type.attendee
+id: node.attendee.field_attendee_id
+field_name: field_attendee_id
+entity_type: node
+bundle: attendee
+label: 'Attendee ID'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/drupal/config/field.field.node.attendee.field_display_on_site.yml
+++ b/conf/drupal/config/field.field.node.attendee.field_display_on_site.yml
@@ -1,0 +1,23 @@
+uuid: ace8e1f4-3d4e-4ea6-b896-9e408e416a1e
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_display_on_site
+    - node.type.attendee
+id: node.attendee.field_display_on_site
+field_name: field_display_on_site
+entity_type: node
+bundle: attendee
+label: 'Display Preference'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'Yes, it is okay to show me amongst the event attendees on the site.'
+  off_label: 'No, please do not list me amongst the event attendees on the site.'
+field_type: boolean

--- a/conf/drupal/config/field.field.node.attendee.field_drupal_user_account.yml
+++ b/conf/drupal/config/field.field.node.attendee.field_drupal_user_account.yml
@@ -1,0 +1,28 @@
+uuid: f1768f7f-5ec1-46e6-bca3-a222cba89730
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_drupal_user_account
+    - node.type.attendee
+id: node.attendee.field_drupal_user_account
+field_name: field_drupal_user_account
+entity_type: node
+bundle: attendee
+label: 'Drupal User Account'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:user'
+  handler_settings:
+    include_anonymous: false
+    filter:
+      type: _none
+    target_bundles: null
+    sort:
+      field: _none
+    auto_create: false
+field_type: entity_reference

--- a/conf/drupal/config/field.field.node.attendee.field_email.yml
+++ b/conf/drupal/config/field.field.node.attendee.field_email.yml
@@ -1,0 +1,19 @@
+uuid: 3e853f13-51a9-496e-987a-4d6846bff0e3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_email
+    - node.type.attendee
+id: node.attendee.field_email
+field_name: field_email
+entity_type: node
+bundle: attendee
+label: email
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: email

--- a/conf/drupal/config/field.field.node.attendee.field_event.yml
+++ b/conf/drupal/config/field.field.node.attendee.field_event.yml
@@ -1,0 +1,29 @@
+uuid: 92ad0014-c395-45bf-8fce-e2b64ff61737
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event
+    - node.type.attendee
+    - taxonomy.vocabulary.event
+id: node.attendee.field_event
+field_name: field_event
+entity_type: node
+bundle: attendee
+label: Event
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      event: event
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/drupal/config/field.field.node.attendee.field_first_name.yml
+++ b/conf/drupal/config/field.field.node.attendee.field_first_name.yml
@@ -1,0 +1,19 @@
+uuid: 48431120-3cfd-471a-8328-d107afff4eb6
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_first_name
+    - node.type.attendee
+id: node.attendee.field_first_name
+field_name: field_first_name
+entity_type: node
+bundle: attendee
+label: 'First Name'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/drupal/config/field.field.node.attendee.field_job_title.yml
+++ b/conf/drupal/config/field.field.node.attendee.field_job_title.yml
@@ -1,0 +1,19 @@
+uuid: 88bdf06b-d781-49c1-b3be-d7101e3fa6d1
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_job_title
+    - node.type.attendee
+id: node.attendee.field_job_title
+field_name: field_job_title
+entity_type: node
+bundle: attendee
+label: 'Job Title'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/drupal/config/field.field.node.attendee.field_last_name.yml
+++ b/conf/drupal/config/field.field.node.attendee.field_last_name.yml
@@ -1,0 +1,19 @@
+uuid: 64b89f82-024d-4059-a819-375538d28a10
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_last_name
+    - node.type.attendee
+id: node.attendee.field_last_name
+field_name: field_last_name
+entity_type: node
+bundle: attendee
+label: 'Last Name'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/drupal/config/field.field.node.attendee.field_name.yml
+++ b/conf/drupal/config/field.field.node.attendee.field_name.yml
@@ -1,0 +1,19 @@
+uuid: 4d9e1e29-95a7-4668-a567-4819b32eda09
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_name
+    - node.type.attendee
+id: node.attendee.field_name
+field_name: field_name
+entity_type: node
+bundle: attendee
+label: Name
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/drupal/config/field.field.node.attendee.field_organization.yml
+++ b/conf/drupal/config/field.field.node.attendee.field_organization.yml
@@ -1,0 +1,19 @@
+uuid: dae0b07b-7010-4e63-816b-11c3294b1dc4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_organization
+    - node.type.attendee
+id: node.attendee.field_organization
+field_name: field_organization
+entity_type: node
+bundle: attendee
+label: Organization
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/drupal/config/field.field.node.attendee.field_ticket_state.yml
+++ b/conf/drupal/config/field.field.node.attendee.field_ticket_state.yml
@@ -1,0 +1,19 @@
+uuid: fd2e5f13-ff3e-4cd4-bdb4-be07d85851f3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ticket_state
+    - node.type.attendee
+id: node.attendee.field_ticket_state
+field_name: field_ticket_state
+entity_type: node
+bundle: attendee
+label: 'Ticket State'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/drupal/config/field.field.node.attendee.field_ticket_type.yml
+++ b/conf/drupal/config/field.field.node.attendee.field_ticket_type.yml
@@ -1,0 +1,19 @@
+uuid: 2d99a0c8-19c3-45f5-9655-8f8a7e765957
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ticket_type
+    - node.type.attendee
+id: node.attendee.field_ticket_type
+field_name: field_ticket_type
+entity_type: node
+bundle: attendee
+label: 'Ticket Type'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/drupal/config/field.field.taxonomy_term.event.field_event_id.yml
+++ b/conf/drupal/config/field.field.taxonomy_term.event.field_event_id.yml
@@ -1,0 +1,19 @@
+uuid: c317f2ea-4c4d-4c92-8576-cc9a786a40f2
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_event_id
+    - taxonomy.vocabulary.event
+id: taxonomy_term.event.field_event_id
+field_name: field_event_id
+entity_type: taxonomy_term
+bundle: event
+label: 'Event ID'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/drupal/config/field.field.taxonomy_term.event.field_event_status.yml
+++ b/conf/drupal/config/field.field.taxonomy_term.event.field_event_status.yml
@@ -1,0 +1,19 @@
+uuid: d92e3d04-8b08-4ae0-a3ee-b33f10170ef4
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_event_status
+    - taxonomy.vocabulary.event
+id: taxonomy_term.event.field_event_status
+field_name: field_event_status
+entity_type: taxonomy_term
+bundle: event
+label: 'Event Status'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/drupal/config/field.field.taxonomy_term.event.field_tito_slug.yml
+++ b/conf/drupal/config/field.field.taxonomy_term.event.field_tito_slug.yml
@@ -1,0 +1,19 @@
+uuid: 52c93979-b7bc-4497-a917-4db3b686307a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_tito_slug
+    - taxonomy.vocabulary.event
+id: taxonomy_term.event.field_tito_slug
+field_name: field_tito_slug
+entity_type: taxonomy_term
+bundle: event
+label: 'Tito Slug'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/drupal/config/field.storage.node.field_attendee_id.yml
+++ b/conf/drupal/config/field.storage.node.field_attendee_id.yml
@@ -1,0 +1,25 @@
+uuid: ce2a80dd-bf7d-4b8f-ba04-f73876c5c018
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_attendee_id
+field_name: field_attendee_id
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/field.storage.node.field_display_on_site.yml
+++ b/conf/drupal/config/field.storage.node.field_display_on_site.yml
@@ -1,0 +1,22 @@
+uuid: 4d82e917-0b7e-496c-a085-81aac33423e4
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_display_on_site
+field_name: field_display_on_site
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/field.storage.node.field_drupal_user_account.yml
+++ b/conf/drupal/config/field.storage.node.field_drupal_user_account.yml
@@ -1,0 +1,24 @@
+uuid: 914675ad-da6b-4e35-a56e-c2edb3c1d9f6
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+    - user
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_drupal_user_account
+field_name: field_drupal_user_account
+entity_type: node
+type: entity_reference
+settings:
+  target_type: user
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/field.storage.node.field_email.yml
+++ b/conf/drupal/config/field.storage.node.field_email.yml
@@ -1,0 +1,22 @@
+uuid: 18c3b33b-ef0e-487e-b5a7-806e73314775
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_email
+field_name: field_email
+entity_type: node
+type: email
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/field.storage.node.field_first_name.yml
+++ b/conf/drupal/config/field.storage.node.field_first_name.yml
@@ -1,0 +1,25 @@
+uuid: 527ac87b-5512-4dfe-8f8e-236c8f29eec6
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_first_name
+field_name: field_first_name
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/field.storage.node.field_job_title.yml
+++ b/conf/drupal/config/field.storage.node.field_job_title.yml
@@ -1,0 +1,25 @@
+uuid: a3827724-f43d-4a0f-8a8c-b20a092e667a
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_job_title
+field_name: field_job_title
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/field.storage.node.field_last_name.yml
+++ b/conf/drupal/config/field.storage.node.field_last_name.yml
@@ -1,0 +1,25 @@
+uuid: 894c6531-99b2-4107-8a1c-576d0856eabe
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_last_name
+field_name: field_last_name
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/field.storage.node.field_name.yml
+++ b/conf/drupal/config/field.storage.node.field_name.yml
@@ -1,0 +1,25 @@
+uuid: 42e34486-b7a0-4024-ad53-9a696a265291
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_name
+field_name: field_name
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/field.storage.node.field_organization.yml
+++ b/conf/drupal/config/field.storage.node.field_organization.yml
@@ -1,0 +1,25 @@
+uuid: ac98fdd7-5023-4636-a53b-7bc0a3106dcf
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_organization
+field_name: field_organization
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/field.storage.node.field_ticket_state.yml
+++ b/conf/drupal/config/field.storage.node.field_ticket_state.yml
@@ -1,0 +1,25 @@
+uuid: 8a9f3736-7e39-430e-a3a1-3e91f176912a
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_ticket_state
+field_name: field_ticket_state
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/field.storage.node.field_ticket_type.yml
+++ b/conf/drupal/config/field.storage.node.field_ticket_type.yml
@@ -1,0 +1,25 @@
+uuid: da207f30-25ee-4dad-af73-09b57d80c2ac
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - node
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: node.field_ticket_type
+field_name: field_ticket_type
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/field.storage.taxonomy_term.field_event_id.yml
+++ b/conf/drupal/config/field.storage.taxonomy_term.field_event_id.yml
@@ -1,0 +1,25 @@
+uuid: f7a01be4-a484-402b-b61a-682fbec4452d
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - taxonomy
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: taxonomy_term.field_event_id
+field_name: field_event_id
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/field.storage.taxonomy_term.field_event_status.yml
+++ b/conf/drupal/config/field.storage.taxonomy_term.field_event_status.yml
@@ -1,0 +1,25 @@
+uuid: 06038210-129d-43e9-8a53-3df919c55c37
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - taxonomy
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: taxonomy_term.field_event_status
+field_name: field_event_status
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/field.storage.taxonomy_term.field_tito_slug.yml
+++ b/conf/drupal/config/field.storage.taxonomy_term.field_tito_slug.yml
@@ -1,0 +1,25 @@
+uuid: e258c275-99f2-4254-8464-e8bddf2f4620
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - taxonomy
+third_party_settings:
+  field_permissions:
+    permission_type: public
+id: taxonomy_term.field_tito_slug
+field_name: field_tito_slug
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/node.type.attendee.yml
+++ b/conf/drupal/config/node.type.attendee.yml
@@ -1,0 +1,31 @@
+uuid: c5fb47a6-46ed-428a-9f42-5fd06d01416a
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+    - scheduler
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_past_date_created: false
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
+name: Attendee
+type: attendee
+description: ''
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/conf/drupal/config/tito.settings.yml
+++ b/conf/drupal/config/tito.settings.yml
@@ -1,0 +1,2 @@
+tito_api_url: 'https://api.tito.io/v3/'
+tito_api_token: ''

--- a/conf/drupal/config/views.view.attendees_2020.yml
+++ b/conf/drupal/config/views.view.attendees_2020.yml
@@ -725,22 +725,7 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: string
-      sorts:
-        created:
-          id: created
-          table: node_field_data
-          field: created
-          order: DESC
-          entity_type: node
-          entity_field: created
-          plugin_id: date
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
+      sorts: {  }
       title: 'MidCamp 2020 Attendees'
       header: {  }
       footer: {  }

--- a/conf/drupal/config/views.view.attendees_2020.yml
+++ b/conf/drupal/config/views.view.attendees_2020.yml
@@ -1,0 +1,811 @@
+uuid: 2f550ee3-c8bd-4dbe-a5e0-1c8a21615849
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_job_title
+    - field.storage.node.field_organization
+    - field.storage.user.field_organization
+    - field.storage.user.field_title
+    - field.storage.user.user_picture
+    - node.type.attendee
+    - system.menu.midcamp-2020-navigation
+    - taxonomy.vocabulary.event
+  content:
+    - 'taxonomy_term:event:edb1c63f-3af1-4ce3-b9d0-55336993e692'
+  module:
+    - image
+    - node
+    - taxonomy
+    - user
+id: attendees_2020
+label: 'Attendees 2020'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: full
+        options:
+          items_per_page: 15
+          offset: 0
+          id: 0
+          total_pages: null
+          tags:
+            previous: '‹ Previous'
+            next: 'Next ›'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 5
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: 'speaker-item l-3up'
+          default_row_class: true
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      fields:
+        user_picture:
+          id: user_picture
+          table: user__user_picture
+          field: user_picture
+          relationship: field_drupal_user_account
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: '<img src="/themes/custom/hatter/imgs/hatter.jpg" height="250" width="250" />'
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: image
+          settings:
+            image_style: ''
+            image_link: ''
+          group_column: ''
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        field_job_title:
+          id: field_job_title
+          table: node__field_job_title
+          field: field_job_title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: '{{ field_job_title }} @'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_title:
+          id: field_title
+          table: user__field_title
+          field: field_title
+          relationship: field_drupal_user_account
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ field_title }} @'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: '{{ job_title }}'
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_organization:
+          id: field_organization
+          table: node__field_organization
+          field: field_organization
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_organization_1:
+          id: field_organization_1
+          table: user__field_organization
+          field: field_organization
+          relationship: field_drupal_user_account
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: '{{ field_organization }}'
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            attendee: attendee
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          group: 1
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            - 143
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: textfield
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_ticket_type_value:
+          id: field_ticket_type_value
+          table: node__field_ticket_type
+          field: field_ticket_type_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: 'The Worm'
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+        field_ticket_type_value_1:
+          id: field_ticket_type_value_1
+          table: node__field_ticket_type
+          field: field_ticket_type_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: Alice
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+        field_ticket_type_value_2:
+          id: field_ticket_type_value_2
+          table: node__field_ticket_type
+          field: field_ticket_type_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: 'The Rabbit'
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+        field_ticket_type_value_3:
+          id: field_ticket_type_value_3
+          table: node__field_ticket_type
+          field: field_ticket_type_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: Student
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+        field_ticket_type_value_4:
+          id: field_ticket_type_value_4
+          table: node__field_ticket_type
+          field: field_ticket_type_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: Sponsored
+          group: 2
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          order: DESC
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      title: 'MidCamp 2020 Attendees'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships:
+        field_drupal_user_account:
+          id: field_drupal_user_account
+          table: node__field_drupal_user_account
+          field: field_drupal_user_account
+          relationship: none
+          group_type: group
+          admin_label: User
+          required: false
+          plugin_id: standard
+      arguments: {  }
+      display_extenders: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_job_title'
+        - 'config:field.storage.node.field_organization'
+        - 'config:field.storage.user.field_organization'
+        - 'config:field.storage.user.field_title'
+        - 'config:field.storage.user.user_picture'
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: 2020/attendees
+      menu:
+        type: normal
+        title: Attendees
+        description: ''
+        expanded: false
+        parent: 'menu_link_content:8a08e9a9-1692-43db-8f38-b20ee4b9c7f0'
+        weight: 0
+        context: '0'
+        menu_name: midcamp-2020-navigation
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_job_title'
+        - 'config:field.storage.node.field_organization'
+        - 'config:field.storage.user.field_organization'
+        - 'config:field.storage.user.field_title'
+        - 'config:field.storage.user.user_picture'

--- a/conf/drupal/config/views.view.attendees_2020.yml
+++ b/conf/drupal/config/views.view.attendees_2020.yml
@@ -799,10 +799,189 @@ display:
         - 'config:field.storage.user.field_organization'
         - 'config:field.storage.user.field_title'
         - 'config:field.storage.user.user_picture'
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: 'Individual Sponsor Block'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      title: 'Individual Sponsors'
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+        pager: false
+        css_class: false
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            attendee: attendee
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          group: 1
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            - 143
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: textfield
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_first_name_value:
+          id: field_first_name_value
+          table: node__field_first_name
+          field: field_first_name_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+        field_ticket_type_value:
+          id: field_ticket_type_value
+          table: node__field_ticket_type
+          field: field_ticket_type_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: 'Individual Sponsor (add-on)'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      block_description: 'MidCamp 2020 Individual Sponsors'
+      pager:
+        type: none
+        options:
+          offset: 0
+      css_class: ''
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_job_title'
+        - 'config:field.storage.node.field_organization'
+        - 'config:field.storage.user.field_organization'
+        - 'config:field.storage.user.field_title'
+        - 'config:field.storage.user.user_picture'
   page_1:
     display_plugin: page
     id: page_1
-    display_title: Page
+    display_title: 'Attendee Page'
     position: 1
     display_options:
       display_extenders: {  }
@@ -816,6 +995,7 @@ display:
         weight: 0
         context: '0'
         menu_name: midcamp-2020-navigation
+      display_description: ''
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.attendees_2020.yml
+++ b/conf/drupal/config/views.view.attendees_2020.yml
@@ -725,6 +725,43 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: string
+        field_first_name_value:
+          id: field_first_name_value
+          table: node__field_first_name
+          field: field_first_name_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: 'not empty'
+          value: ''
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
       sorts: {  }
       title: 'MidCamp 2020 Attendees'
       header: {  }

--- a/conf/drupal/config/views.view.event_sponsors.yml
+++ b/conf/drupal/config/views.view.event_sponsors.yml
@@ -1257,7 +1257,7 @@ display:
           inline: {  }
           separator: ''
           hide_empty: true
-      css_class: sponsor-group
+      css_class: 'sponsor-group clearfix'
     cache_metadata:
       max-age: 0
       contexts:

--- a/web/modules/custom/midcamp_tito/midcamp_tito.info.yml
+++ b/web/modules/custom/midcamp_tito/midcamp_tito.info.yml
@@ -1,0 +1,7 @@
+name: 'MidCamp Tito'
+type: module
+description: 'Integrate with Tito API to sync event and attendee data'
+core: 8.x
+package: 'Custom'
+dependencies:
+  - tito

--- a/web/modules/custom/midcamp_tito/midcamp_tito.module
+++ b/web/modules/custom/midcamp_tito/midcamp_tito.module
@@ -35,10 +35,11 @@ function midcamp_tito_entity_presave(EntityInterface $entity) {
     $fields = $entity->getFields();
     if (!$fields['field_event_id']->isEmpty()) {
       $eventId = $fields['field_event_id']->getString();
+      $slug = $fields['field_tito_slug']->getString();
 
       // Check event status, save to entity.
       $status_checker = \Drupal::service('midcamp_tito.status');
-      $event_status = $status_checker->check($eventId);
+      $event_status = $status_checker->check($slug);
 
       $entity->set('field_event_status', $event_status);
     }
@@ -52,8 +53,7 @@ function midcamp_tito_entity_presave(EntityInterface $entity) {
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
  */
-function midcamp_tito_entity_insert(EntityInterface $entity)
-{
+function midcamp_tito_entity_insert(EntityInterface $entity) {
   if ($entity->bundle() == 'event') {
 
     // If field_event_id is set, sync attendees.
@@ -61,10 +61,63 @@ function midcamp_tito_entity_insert(EntityInterface $entity)
 
     if (!$fields['field_event_id']->isEmpty()) {
       $event_id = $fields['field_event_id']->getString();
+      $slug = $fields['field_tito_slug']->getString();
       $event_status = $fields['field_event_status']->getString();
 
-      $sync_service = \Drupal::service('eventbrite_events.sync_attendees'); // @todo build this service
+      $sync_service = \Drupal::service('midcamp_tito.attendees');
+      $sync_service->sync($slug, $event_status);
+    }
+  }
+}
+
+/**
+ * Implements hook_entity_update().
+ *
+ * Check for attendees when updating an `eventbrite_event` node.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ */
+function midcamp_tito_entity_update(EntityInterface $entity) {
+  if ($entity->bundle() == 'event') {
+
+    // If eventbrite_event_id is set, sync attendees.
+    $fields = $entity->getFields();
+
+    if (!$fields['field_event_id']->isEmpty()) {
+      $event_id = $fields['field_event_id']->getString();
+      $event_status = $fields['field_event_status']->getString();
+
+      $sync_service = \Drupal::service('midcamp_tito.attendees');
       $sync_service->sync($event_id, $event_status);
     }
   }
 }
+
+/**
+ * Implements hook_cron().
+ *
+ * Periodically update the attendee list by refreshing on cron.
+ */
+//function midcamp_tito_cron() {
+//
+//  // Load all event nodes with an event ID.
+//  $event_nids = \Drupal::entityQuery('taxonomy_term')
+//    ->condition('status',1)
+//    ->condition('type','event')
+//    ->condition('field_event_id',NULL, 'IS NOT NULL')
+//    ->execute();
+//
+//  $event_nodes =  \Drupal\node\Entity\Node::loadMultiple($event_nids);
+//
+//  foreach ($event_nodes as $event) {
+//    // Update event status.
+//    $status_service = \Drupal::service('midcamp_tito.status');
+//    $status_service->update($event);
+//
+//    // Get the event ID and status and run the sync_attendees service.
+//    $event_id = $event->get('field_event_id')->value;
+//    $event_status = $event->get('eventbrite_event_status')->value;
+//    $sync_service = \Drupal::service('midcamp_tito.attendees');
+//    $sync_service->sync($event_id, $event_status);
+//  }
+//}

--- a/web/modules/custom/midcamp_tito/midcamp_tito.module
+++ b/web/modules/custom/midcamp_tito/midcamp_tito.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\taxonomy\Entity\Term;
 
 /**
  * Implements hook_help().
@@ -31,15 +32,15 @@ function midcamp_tito_help($route_name, RouteMatchInterface $route_match) {
  */
 function midcamp_tito_entity_presave(EntityInterface $entity) {
   if ($entity->bundle() == 'event') {
-    // If field_event_id is set, atempt to sync attendees.
+    // If field_event_id is set, attempt to sync attendees.
     $fields = $entity->getFields();
-    if (!$fields['field_event_id']->isEmpty()) {
-      $eventId = $fields['field_event_id']->getString();
+    if (!$fields['field_tito_slug']->isEmpty() && !$fields['field_event_id']->isEmpty()) {
       $slug = $fields['field_tito_slug']->getString();
+      $eventId = $fields['field_event_id']->getString();
 
       // Check event status, save to entity.
       $status_checker = \Drupal::service('midcamp_tito.status');
-      $event_status = $status_checker->check($slug);
+      $event_status = $status_checker->check($slug, $eventId);
 
       $entity->set('field_event_status', $event_status);
     }
@@ -59,13 +60,16 @@ function midcamp_tito_entity_insert(EntityInterface $entity) {
     // If field_event_id is set, sync attendees.
     $fields = $entity->getFields();
 
-    if (!$fields['field_event_id']->isEmpty()) {
-      $event_id = $fields['field_event_id']->getString();
+    if (!$fields['field_tito_slug']->isEmpty() && !$fields['field_event_id']->isEmpty()) {
       $slug = $fields['field_tito_slug']->getString();
+      $event_id = $fields['field_event_id']->getString();
       $event_status = $fields['field_event_status']->getString();
 
-      $sync_service = \Drupal::service('midcamp_tito.attendees');
-      $sync_service->sync($slug, $event_status);
+      // Only sync for events that are live.
+      if ($event_status == 'live') {
+        $sync_service = \Drupal::service('midcamp_tito.attendees');
+        $sync_service->sync($slug, $event_id, $event_status);
+      }
     }
   }
 }
@@ -84,11 +88,12 @@ function midcamp_tito_entity_update(EntityInterface $entity) {
     $fields = $entity->getFields();
 
     if (!$fields['field_event_id']->isEmpty()) {
+      $slug = $fields['field_tito_slug']->getString();
       $event_id = $fields['field_event_id']->getString();
       $event_status = $fields['field_event_status']->getString();
 
       $sync_service = \Drupal::service('midcamp_tito.attendees');
-      $sync_service->sync($event_id, $event_status);
+      $sync_service->sync($slug, $event_id, $event_status);
     }
   }
 }
@@ -98,26 +103,26 @@ function midcamp_tito_entity_update(EntityInterface $entity) {
  *
  * Periodically update the attendee list by refreshing on cron.
  */
-//function midcamp_tito_cron() {
-//
-//  // Load all event nodes with an event ID.
-//  $event_nids = \Drupal::entityQuery('taxonomy_term')
-//    ->condition('status',1)
-//    ->condition('type','event')
-//    ->condition('field_event_id',NULL, 'IS NOT NULL')
-//    ->execute();
-//
-//  $event_nodes =  \Drupal\node\Entity\Node::loadMultiple($event_nids);
-//
-//  foreach ($event_nodes as $event) {
-//    // Update event status.
-//    $status_service = \Drupal::service('midcamp_tito.status');
-//    $status_service->update($event);
-//
-//    // Get the event ID and status and run the sync_attendees service.
-//    $event_id = $event->get('field_event_id')->value;
-//    $event_status = $event->get('eventbrite_event_status')->value;
-//    $sync_service = \Drupal::service('midcamp_tito.attendees');
-//    $sync_service->sync($event_id, $event_status);
-//  }
-//}
+function midcamp_tito_cron() {
+
+  // Load all event terms with an event ID.
+  $event_tids = \Drupal::entityQuery('taxonomy_term')
+    ->condition('vid','event')
+    ->condition('field_event_id',NULL, 'IS NOT NULL')
+    ->execute();
+
+  $event_terms =  Term::loadMultiple($event_tids);
+
+  foreach ($event_terms as $event) {
+    // Update event status.
+    $status_service = \Drupal::service('midcamp_tito.status');
+    $status_service->update($event);
+
+    // Get the event ID and status and run the sync_attendees service.
+    $slug = $event->get('field_tito_slug')->value;
+    $event_id = $event->get('field_event_id')->value;
+    $event_status = $event->get('field_event_status')->value;
+    $sync_service = \Drupal::service('midcamp_tito.attendees');
+    $sync_service->sync($slug, $event_id, $event_status);
+  }
+}

--- a/web/modules/custom/midcamp_tito/midcamp_tito.module
+++ b/web/modules/custom/midcamp_tito/midcamp_tito.module
@@ -84,7 +84,7 @@ function midcamp_tito_entity_insert(EntityInterface $entity) {
 function midcamp_tito_entity_update(EntityInterface $entity) {
   if ($entity->bundle() == 'event') {
 
-    // If eventbrite_event_id is set, sync attendees.
+    // If field_event_id is set, sync attendees.
     $fields = $entity->getFields();
 
     if (!$fields['field_event_id']->isEmpty()) {

--- a/web/modules/custom/midcamp_tito/midcamp_tito.module
+++ b/web/modules/custom/midcamp_tito/midcamp_tito.module
@@ -44,3 +44,27 @@ function midcamp_tito_entity_presave(EntityInterface $entity) {
     }
   }
 }
+
+/**
+ * Implements hook_entity_insert().
+ *
+ * Check for attendees when creating an `event` term.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ */
+function midcamp_tito_entity_insert(EntityInterface $entity)
+{
+  if ($entity->bundle() == 'event') {
+
+    // If field_event_id is set, sync attendees.
+    $fields = $entity->getFields();
+
+    if (!$fields['field_event_id']->isEmpty()) {
+      $event_id = $fields['field_event_id']->getString();
+      $event_status = $fields['field_event_status']->getString();
+
+      $sync_service = \Drupal::service('eventbrite_events.sync_attendees'); // @todo build this service
+      $sync_service->sync($event_id, $event_status);
+    }
+  }
+}

--- a/web/modules/custom/midcamp_tito/midcamp_tito.module
+++ b/web/modules/custom/midcamp_tito/midcamp_tito.module
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @file
+ * Contains midcamp_tito.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Implements hook_help().
+ */
+function midcamp_tito_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the midcamp_tito module.
+    case 'help.page.midcamp_tito':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Integrate with Tito API to sync event and attendee data') . '</p>';
+      return $output;
+  }
+}
+
+/**
+ * Implements hook_entity_presave().
+ *
+ * Store the event status on the event entity.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ */
+function midcamp_tito_entity_presave(EntityInterface $entity) {
+  if ($entity->bundle() == 'event') {
+    // If field_event_id is set, atempt to sync attendees.
+    $fields = $entity->getFields();
+    if (!$fields['field_event_id']->isEmpty()) {
+      $eventId = $fields['field_event_id']->getString();
+
+      // Check event status, save to entity.
+      $status_checker = \Drupal::service('midcamp_tito.status');
+      $event_status = $status_checker->check($eventId);
+
+      $entity->set('field_event_status', $event_status);
+    }
+  }
+}

--- a/web/modules/custom/midcamp_tito/midcamp_tito.services.yml
+++ b/web/modules/custom/midcamp_tito/midcamp_tito.services.yml
@@ -4,4 +4,7 @@ services:
     arguments: ['@tito.client']
   midcamp_tito.attendees:
     class: Drupal\midcamp_tito\Attendees
+    arguments: ['@tito.client', '@entity_type.manager']
+  midcamp_tito.id:
+    class: Drupal\midcamp_tito\Id
     arguments: ['@tito.client']

--- a/web/modules/custom/midcamp_tito/midcamp_tito.services.yml
+++ b/web/modules/custom/midcamp_tito/midcamp_tito.services.yml
@@ -2,3 +2,6 @@ services:
   midcamp_tito.status:
     class: Drupal\midcamp_tito\Status
     arguments: ['@tito.client']
+  midcamp_tito.attendees:
+    class: Drupal\midcamp_tito\Attendees
+    arguments: ['@tito.client']

--- a/web/modules/custom/midcamp_tito/midcamp_tito.services.yml
+++ b/web/modules/custom/midcamp_tito/midcamp_tito.services.yml
@@ -1,0 +1,4 @@
+services:
+  midcamp_tito.status:
+    class: Drupal\midcamp_tito\Status
+    arguments: ['@tito.client']

--- a/web/modules/custom/midcamp_tito/src/Attendees.php
+++ b/web/modules/custom/midcamp_tito/src/Attendees.php
@@ -83,13 +83,16 @@ class Attendees {
       }
 
       // Check for existing attendee node so we can update existing.
-      $query = \Drupal::entityQuery('node')
+      $query = \Drupal::entityQuery('node');
+      $queryResult = $query
         ->condition('type', 'attendee')
-        ->condition('field_attendee_id', $attendee['id']);
+        ->condition('field_attendee_id', $attendee['id'])
+        ->execute();
 
-      $entity_nid = $query->execute();
+      $entityNid = is_array($queryResult) ? current($queryResult) : null;
+      $entity = is_numeric($entityNid) ? $entityStorage->load($entityNid) : null;
 
-      if (isset($entity_nid) && $entity = $entityStorage->load(current($entity_nid))) {
+      if ($entity) {
         $entity->set('field_attendee_id', $attendee['id']);
         $entity->set('field_name', $attendee['name']);
         $entity->set('field_first_name', $attendee['first_name']);

--- a/web/modules/custom/midcamp_tito/src/Attendees.php
+++ b/web/modules/custom/midcamp_tito/src/Attendees.php
@@ -123,6 +123,7 @@ class Attendees {
         $entity->save();
       }
     }
+    \Drupal::logger('midcamp_tito')->info('Syncing attendees for event "%event"', ['%event' => $tito_event_id]);
   }
 
   /**

--- a/web/modules/custom/midcamp_tito/src/Attendees.php
+++ b/web/modules/custom/midcamp_tito/src/Attendees.php
@@ -46,13 +46,11 @@ class Attendees {
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function sync($tito_slug, $tito_event_id, $event_status) {
-    // If the event is not active, to not attempt to sync attendees.
+    // If the event is not active, do not attempt to sync attendees.
     if ($this->activeEvent($event_status) == FALSE) {
       \Drupal::logger('midcamp_tito')->info('Event "%event" not active.', ['%event' => $tito_event_id]);
       return;
     }
-
-    $entityStorage = $this->entityTypeManager->getStorage('node');
 
     // Define an array to capture attendees.
     $attendees = [];
@@ -89,57 +87,23 @@ class Attendees {
     sleep(1);
     $attendeePreferences = $this->getQuestion($tito_slug, $tito_event_id, $question);
 
+    $batch = [
+      'title' => t('Bulk importing attendees'),
+      // Leave this empty for now, but maybe look to the Pathauto example and put a starter on here...
+      'operations' => [],
+      'finished' => 'Drupal\midcamp_tito\Attendees::batchFinished',
+    ];
+
     // Iterate over each page of response results to load user data.
     foreach ($attendees as $attendee) {
       if (!isset($attendee['id'])) {
-        return;
-      }
-
-      // Check for existing attendee node so we can update existing.
-      $query = \Drupal::entityQuery('node');
-      $queryResult = $query
-        ->condition('type', 'attendee')
-        ->condition('field_attendee_id', $attendee['id'])
-        ->execute();
-
-      $entityNid = is_array($queryResult) ? current($queryResult) : null;
-      $entity = is_numeric($entityNid) ? $entityStorage->load($entityNid) : null;
-
-      if ($entity) {
-        $entity->set('field_attendee_id', $attendee['id']);
-        $entity->set('field_name', $attendee['name']);
-        $entity->set('field_first_name', $attendee['first_name']);
-        $entity->set('field_last_name', $attendee['last_name']);
-        $entity->set('field_organization', isset($attendee['company_name']) ? $attendee['company_name'] : '');
-        $entity->set('field_ticket_type', $attendee['release_title']);
-        $entity->set('field_drupal_user_account', isset($attendee['email']) ? $this->getUserIdByEmail($attendee['email']) : '');
-        $entity->set('field_ticket_state', $attendee['state']);
-        $entity->set('field_display_on_site', isset($attendee['id']) ? $this->userDisplayPreference($attendee['id'], $attendeePreferences) : TRUE);
-        $entity->set('status', isset($attendee['id']) ? $this->userDisplayPreference($attendee['id'], $attendeePreferences) : TRUE);
-        $entity->save();
-      }
-      else {
-        // Create the attendee if one does not yet exist.
-        $entity = Node::create([
-          'type' => 'attendee',
-          'title' => !empty($attendee['name']) ? $attendee['name'] : $attendee['id'],
-          'field_attendee_id' => $attendee['id'],
-          'field_drupal_user_account' => isset($attendee['email']) ? $this->getUserIdByEmail($attendee['email']) : '',
-          'field_name' => $attendee['name'],
-          'field_first_name' => $attendee['first_name'],
-          'field_last_name' => $attendee['last_name'],
-          'field_email' => isset($attendee['email']) ? $attendee['email'] : '',
-          'field_organization' => isset($attendee['company_name']) ? $attendee['company_name'] : '',
-          'field_ticket_type' => $attendee['release_title'],
-          'field_ticket_state' => $attendee['state'],
-          'field_event' => $this->getEventById($tito_event_id),
-          'field_display_on_site' => isset($attendee['id']) ? $this->userDisplayPreference($attendee['id'], $attendeePreferences) : TRUE,
-          'status' => isset($attendee['id']) ? $this->userDisplayPreference($attendee['id'], $attendeePreferences) : TRUE,
-        ]);
-        $entity->save();
+        $batch['operations'][] = ['Drupal\midcamp_tito\Attendees::batchProcess', [$attendee, $attendeePreferences, $tito_event_id]];
       }
     }
+
     \Drupal::logger('midcamp_tito')->info('Syncing attendees for event "%event"', ['%event' => $tito_event_id]);
+
+    batch_set($batch);
   }
 
   /**
@@ -245,6 +209,88 @@ class Attendees {
 
     // No answer or Yes answer returns TRUE.
     return TRUE;
+  }
+
+  /**
+   * Batch processing callback for event attendee sync.
+   *
+   * @param $attendee
+   * @param $attendeePreferences
+   * @param $tito_event_id
+   * @param $context
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  protected function batchProcess($attendee, $attendeePreferences, $tito_event_id, &$context) {
+    // Check for existing attendee node so we can update existing.
+    $query = \Drupal::entityQuery('node');
+    $queryResult = $query
+      ->condition('type', 'attendee')
+      ->condition('field_attendee_id', $attendee['id'])
+      ->execute();
+
+    $entityNid = is_array($queryResult) ? current($queryResult) : null;
+    $entity = is_numeric($entityNid) ? $this->entityTypeManager->getStorage('node')->load($entityNid) : null;
+
+    if ($entity) {
+      $entity->set('field_attendee_id', $attendee['id']);
+      $entity->set('field_name', $attendee['name']);
+      $entity->set('field_first_name', $attendee['first_name']);
+      $entity->set('field_last_name', $attendee['last_name']);
+      $entity->set('field_organization', isset($attendee['company_name']) ? $attendee['company_name'] : '');
+      $entity->set('field_ticket_type', $attendee['release_title']);
+      $entity->set('field_drupal_user_account', isset($attendee['email']) ? $this->getUserIdByEmail($attendee['email']) : '');
+      $entity->set('field_ticket_state', $attendee['state']);
+      $entity->set('field_display_on_site', isset($attendee['id']) ? $this->userDisplayPreference($attendee['id'], $attendeePreferences) : TRUE);
+      $entity->set('status', isset($attendee['id']) ? $this->userDisplayPreference($attendee['id'], $attendeePreferences) : TRUE);
+      $entity->save();
+    }
+    else {
+      // Create the attendee if one does not yet exist.
+      $entity = Node::create([
+        'type' => 'attendee',
+        'title' => !empty($attendee['name']) ? $attendee['name'] : $attendee['id'],
+        'field_attendee_id' => $attendee['id'],
+        'field_drupal_user_account' => isset($attendee['email']) ? $this->getUserIdByEmail($attendee['email']) : '',
+        'field_name' => $attendee['name'],
+        'field_first_name' => $attendee['first_name'],
+        'field_last_name' => $attendee['last_name'],
+        'field_email' => isset($attendee['email']) ? $attendee['email'] : '',
+        'field_organization' => isset($attendee['company_name']) ? $attendee['company_name'] : '',
+        'field_ticket_type' => $attendee['release_title'],
+        'field_ticket_state' => $attendee['state'],
+        'field_event' => $this->getEventById($tito_event_id),
+        'field_display_on_site' => isset($attendee['id']) ? $this->userDisplayPreference($attendee['id'], $attendeePreferences) : TRUE,
+        'status' => isset($attendee['id']) ? $this->userDisplayPreference($attendee['id'], $attendeePreferences) : TRUE,
+      ]);
+      $entity->save();
+    }
+  }
+
+  /**
+   * Batch finished callback.
+   */
+  public function batchFinished($success, $results, $operations) {
+    if ($success) {
+      if ($results['updates']) {
+        \Drupal::service('messenger')->addMessage(\Drupal::translation()
+          ->formatPlural($results['updates'], 'Generated 1 attendee.', 'Generated @count attendees.'));
+      }
+      else {
+        \Drupal::service('messenger')
+          ->addMessage(t('No attendees to generate.'));
+      }
+    }
+    else {
+      $error_operation = reset($operations);
+      \Drupal::service('messenger')
+        ->addMessage(t('An error occurred while processing @operation with arguments : @args'), [
+          '@operation' => $error_operation[0],
+          '@args' => print_r($error_operation[0]),
+        ]);
+    }
   }
 
 }

--- a/web/modules/custom/midcamp_tito/src/Attendees.php
+++ b/web/modules/custom/midcamp_tito/src/Attendees.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\midcamp_tito;
+use Drupal\tito\Client;
+
+/**
+ * Class Attendees.
+ */
+class Attendees {
+
+  /**
+   * Drupal\tito\Client definition.
+   *
+   * @var \Drupal\tito\Client
+   */
+  protected $titoClient;
+  /**
+   * Constructs a new Attendees object.
+   */
+  public function __construct(Client $tito_client) {
+    $this->titoClient = $tito_client;
+  }
+
+}

--- a/web/modules/custom/midcamp_tito/src/Attendees.php
+++ b/web/modules/custom/midcamp_tito/src/Attendees.php
@@ -85,6 +85,8 @@ class Attendees {
     // Gather user preferences on site display. This is ugly, but the API is
     // very limited in this area.
     $question = 'show-on-the-public-attendees-listing';
+    // Honor the rate limit.
+    sleep(1);
     $attendeePreferences = $this->getQuestion($tito_slug, $tito_event_id, $question);
 
     // Iterate over each page of response results to load user data.

--- a/web/modules/custom/midcamp_tito/src/Attendees.php
+++ b/web/modules/custom/midcamp_tito/src/Attendees.php
@@ -83,8 +83,6 @@ class Attendees {
     // Gather user preferences on site display. This is ugly, but the API is
     // very limited in this area.
     $question = 'show-on-the-public-attendees-listing';
-    // Honor the rate limit.
-    sleep(1);
     $attendeePreferences = $this->getQuestion($tito_slug, $tito_event_id, $question);
 
     $batch = [
@@ -181,6 +179,8 @@ class Attendees {
         $query = $query . "&page=$page";
       }
       $results[] = $this->titoClient->request('get', "$tito_slug/$tito_event_id/questions/$question/answers", '', []);
+      // Honor the rate limit.
+      sleep(1);
     }
     while ($page = end($results)['meta']['next_page']);
 

--- a/web/modules/custom/midcamp_tito/src/Attendees.php
+++ b/web/modules/custom/midcamp_tito/src/Attendees.php
@@ -48,6 +48,7 @@ class Attendees {
   public function sync($tito_slug, $tito_event_id, $event_status) {
     // If the event is not active, to not attempt to sync attendees.
     if ($this->activeEvent($event_status) == FALSE) {
+      \Drupal::logger('midcamp_tito')->info('Event "%event" not active.', ['%event' => $tito_event_id]);
       return;
     }
 
@@ -67,8 +68,18 @@ class Attendees {
     }
     while ($page = end($results)['meta']['next_page']);
 
+    if (empty($results)) {
+      \Drupal::logger('midcamp_tito')->info('No attendees returned for event "%event"', ['%event' => $tito_event_id]);
+      return;
+    }
+
     foreach ($results as $result) {
       $attendees = array_merge($attendees, $result['tickets']);
+    }
+
+    if (!$attendees) {
+      \Drupal::logger('midcamp_tito')->info('No attendees returned for event "%event"', ['%event' => $tito_event_id]);
+      return;
     }
 
     // Gather user preferences on site display. This is ugly, but the API is

--- a/web/modules/custom/midcamp_tito/src/Attendees.php
+++ b/web/modules/custom/midcamp_tito/src/Attendees.php
@@ -2,6 +2,9 @@
 
 namespace Drupal\midcamp_tito;
 use Drupal\tito\Client;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\Entity\Node;
 
 /**
  * Class Attendees.
@@ -14,11 +17,165 @@ class Attendees {
    * @var \Drupal\tito\Client
    */
   protected $titoClient;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
   /**
    * Constructs a new Attendees object.
+   *
+   * @param \Drupal\tito\Client $tito_client
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    */
-  public function __construct(Client $tito_client) {
+  public function __construct(Client $tito_client, EntityTypeManagerInterface $entity_type_manager) {
     $this->titoClient = $tito_client;
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * Create attendee entities for the given event.
+   *
+   * @param int $tito_event_id
+   * @param string $event_status
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function sync($tito_event_id, $event_status) {
+    // If the event is not active, to not attempt to sync attendees.
+    if ($this->activeEvent($event_status) == FALSE) {
+      return;
+    }
+
+    $entityStorage = $this->entityTypeManager->getStorage('node');
+
+    // Define an array to capture attendees.
+    $attendees = [];
+
+    // No query parameters for now.
+    $query = '?search[states][]=complete';
+
+    // Get the attendees response for the given event ID.
+    $results = $this->titoClient->request('get', "midcamp/$tito_event_id/tickets/", $query, []);
+    dump("Look at the ticket results");
+    dump($results);
+//    die();
+
+    // Iterate over each page of response results to load user data.
+    foreach ($results['tickets'] as $attendee) {
+      dump("RESULTS AS RESULT");
+      dump($attendee);
+//      die();
+//      foreach ($result['tickets'] as $attendee) {
+        $attendees[] = $attendee['name'];
+
+        // Check for existing attendee node so we can update existing.
+        // Need to load an "Attendee" node.  Prob need to map to a `field_attendee_id`.  Figure this out.
+        $query = \Drupal::entityQuery('node')
+          ->condition('type', 'attendee')
+          ->condition('field_attendee_id', $attendee['id']);
+        $entity_nid = $query->execute();
+        $entity = $entityStorage->load(current($entity_nid));
+
+        if ($entity) {
+          $entity->set('field_attendee_id', $attendee['id']);
+          $entity->set('field_name', $attendee['name']);
+          $entity->set('field_first_name', $attendee['first_name']);
+          $entity->set('field_last_name', $attendee['last_name']);
+//          $entity->set('field_job_title', isset($attendee['profile']['job_title']) ? $attendee['profile']['job_title'] : '');
+          $entity->set('field_organization', isset($attendee['company_name']) ? $attendee['company_name'] : '');
+          $entity->set('field_ticket_type', $attendee['release_title']);
+//          $entity->set('ticket_class_id', $attendee['ticket_class_id']); // @TODO - do we need this?
+          $entity->set('assoc_drupal_user', isset($attendee['email']) ? $this->getUserIdByEmail($attendee['email']) : '');
+//          $entity->set('field_event', $this->getEventById($attendee['event_id'])); // @TODO - figure this out
+//          $entity->set('ticket_cancelled', $attendee['cancelled']); // @TODO - do we need this?
+          $entity->set('field_ticket_state', $attendee['state']);
+          $entity->save();
+        }
+        else {
+          // Create the attendee if one does not yet exist.
+          $entity = Node::create([
+            'type' => 'attendee',
+            'title' => $attendee['name'],
+            'field_attendee_id' => $attendee['id'],
+            'assoc_drupal_user' => isset($attendee['email']) ? $this->getUserIdByEmail($attendee['email']) : '',
+//            'field_event' => $this->getEventById($attendee['event_id']), // @TODO - figure this out
+            'field_name' => $attendee['name'],
+            'field_first_name' => $attendee['first_name'],
+            'field_last_name' => $attendee['last_name'],
+            'field_email' => isset($attendee['email']) ? $attendee['email'] : '',
+//            'field_job_title' => isset($attendee['profile']['job_title']) ? $attendee['profile']['job_title'] : '',
+            'field_organization' => isset($attendee['company_name']) ? $attendee['company_name'] : '',
+            'field_ticket_type' => $attendee['release_title'],
+//            'ticket_class_id' => $attendee['ticket_class_id'], // @TODO - do we need this?
+//            'ticket_cancelled' => $attendee['cancelled'], // @TODO - do we need this?
+            'field_ticket_state' => $attendee['state'],
+          ]);
+          $entity->save();
+        }
+//      }
+    }
+    die();
+  }
+
+  /**
+   * Determine whether the event is still active.
+   *
+   * @param string $event_status
+   * @return bool
+   */
+  protected function activeEvent($event_status) {
+    $inactive_states = ['archived'];
+    if (in_array($event_status, $inactive_states)) {
+      return FALSE;
+    }
+    return TRUE;
+  }
+
+  /**
+   * Look up Drupal user ID by email.
+   * @param $email
+   * @return bool
+   */
+  protected function getUserIdByEmail($email) {
+    $uid = FALSE;
+
+    $user = user_load_by_mail($email);
+
+    if ($user) {
+      $uid = $user->id();
+    }
+
+    return $uid;
+  }
+
+  /**
+   * Look up Event by Tito ID value.
+   * @param $id
+   * @return bool|int|string|null
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  protected function getEventById($id) {
+    $entity_id = FALSE;
+
+    $entities = \Drupal::entityTypeManager()
+      ->getStorage('node')
+      ->loadByProperties([
+        'type' => 'event',
+        'field_event_id' => $id,
+      ]);
+
+    if ($entities) {
+      // For now, assume one Tito Event node.
+      $entity = reset($entities);
+      $entity_id = $entity->id();
+    }
+    return $entity_id;
   }
 
 }

--- a/web/modules/custom/midcamp_tito/src/Attendees.php
+++ b/web/modules/custom/midcamp_tito/src/Attendees.php
@@ -63,6 +63,8 @@ class Attendees {
         $query = $query . "&page=$page";
       }
       $results[] = $this->titoClient->request('get', "$tito_slug/$tito_event_id/tickets/", $query, []);
+      // Honor the rate limit.
+      sleep(1);
     }
     while ($page = end($results)['meta']['next_page']);
 

--- a/web/modules/custom/midcamp_tito/src/Attendees.php
+++ b/web/modules/custom/midcamp_tito/src/Attendees.php
@@ -178,7 +178,7 @@ class Attendees {
       if (isset($page)) {
         $query = $query . "&page=$page";
       }
-      $results[] = $this->titoClient->request('get', "$tito_slug/$tito_event_id/questions/$question/answers", '', []);
+      $results[] = $this->titoClient->request('get', "$tito_slug/$tito_event_id/questions/$question/answers", $query, []);
       // Honor the rate limit.
       sleep(1);
     }

--- a/web/modules/custom/midcamp_tito/src/Status.php
+++ b/web/modules/custom/midcamp_tito/src/Status.php
@@ -20,6 +20,8 @@ class Status {
 
   /**
    * Constructs a new Status object.
+   *
+   * @param \Drupal\tito\Client $tito_client
    */
   public function __construct(Client $tito_client) {
     $this->titoClient = $tito_client;
@@ -54,6 +56,8 @@ class Status {
    * Update an Event Term.
    *
    * @param \Drupal\taxonomy\Entity\Term $event
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function update(Term $event) {
     // Call the API to check the event status

--- a/web/modules/custom/midcamp_tito/src/Status.php
+++ b/web/modules/custom/midcamp_tito/src/Status.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\midcamp_tito;
 
+use Drupal\node\Entity\Node;
 use Drupal\tito\Client;
 use Drupal\taxonomy\Entity\Term;
 
@@ -32,8 +33,7 @@ class Status {
    */
   public function check($tito_event_id) {
     // Get the status response for the given event ID.
-    // @todo Add config for setting orgnization.
-    $event = $this->titoClient->request('get', "exampleorganization/$tito_event_id/", '');
+    $event = $this->titoClient->request('get', "midcamp/$tito_event_id/", '');
 
     $event = reset($event);
 
@@ -43,6 +43,22 @@ class Status {
     elseif ($event['live'] == TRUE) {
       return 'live';
     }
+  }
+
+  /**
+   * Update an Event Term.
+   *
+   * @param \Drupal\taxonomy\Entity\Term $event
+   */
+  public function update(Term $event) {
+    // Call the API to check the event status
+//    $tito_event_id = $event->get('field_event_id')->value;
+    $tito_slug = $event->get('field_tito_slug')->value;
+    $status = $this->check($tito_slug);
+
+    // Set the status and save the node
+    $event->set('field_event_status', $status);
+    $event->save();
   }
 
 }

--- a/web/modules/custom/midcamp_tito/src/Status.php
+++ b/web/modules/custom/midcamp_tito/src/Status.php
@@ -28,14 +28,17 @@ class Status {
   /**
    * Check the status of the event.
    *
-   * @param int $tito_event_id
+   * @param string $tito_slug
+   * @param string $tito_event_id
    * @return string
    */
-  public function check($tito_event_id) {
+  public function check($tito_slug, $tito_event_id) {
     // Get the status response for the given event ID.
-    $event = $this->titoClient->request('get', "midcamp/$tito_event_id/", '');
+    $event = $this->titoClient->request('get', "$tito_slug/$tito_event_id/", '');
 
-    $event = reset($event);
+    if ($event) {
+      $event = reset($event);
+    }
 
     if ($event['archived'] == TRUE) {
       return 'archived';
@@ -43,6 +46,8 @@ class Status {
     elseif ($event['live'] == TRUE) {
       return 'live';
     }
+
+    return 'unknown';
   }
 
   /**
@@ -52,9 +57,9 @@ class Status {
    */
   public function update(Term $event) {
     // Call the API to check the event status
-//    $tito_event_id = $event->get('field_event_id')->value;
     $tito_slug = $event->get('field_tito_slug')->value;
-    $status = $this->check($tito_slug);
+    $tito_event_id = $event->get('field_event_id')->value;
+    $status = $this->check($tito_slug, $tito_event_id);
 
     // Set the status and save the node
     $event->set('field_event_status', $status);

--- a/web/modules/custom/midcamp_tito/src/Status.php
+++ b/web/modules/custom/midcamp_tito/src/Status.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Drupal\midcamp_tito;
+
+use Drupal\tito\Client;
+use Drupal\taxonomy\Entity\Term;
+
+/**
+ * Class Status.
+ */
+class Status {
+
+  /**
+   * Drupal\tito\Client definition.
+   *
+   * @var \Drupal\tito\Client
+   */
+  protected $titoClient;
+
+  /**
+   * Constructs a new Status object.
+   */
+  public function __construct(Client $tito_client) {
+    $this->titoClient = $tito_client;
+  }
+
+  /**
+   * Check the status of the event.
+   *
+   * @param int $tito_event_id
+   * @return string
+   */
+  public function check($tito_event_id) {
+    // Get the status response for the given event ID.
+    // @todo Add config for setting orgnization.
+    $event = $this->titoClient->request('get', "exampleorganization/$tito_event_id/", '');
+
+    $event = reset($event);
+
+    if ($event['archived'] == TRUE) {
+      return 'archived';
+    }
+    elseif ($event['live'] == TRUE) {
+      return 'live';
+    }
+  }
+
+}

--- a/web/themes/custom/hatter_base/templates/views/views-view-fields--attendees-2020.html.twig
+++ b/web/themes/custom/hatter_base/templates/views/views-view-fields--attendees-2020.html.twig
@@ -1,0 +1,19 @@
+{#
+/**
+ * @file
+ * Theme override to display all the fields in a row.
+ *
+ * @see template_preprocess_views_view_fields()
+ */
+#}
+
+{% if fields.user_picture %}
+  <div class="speaker-image">{{ fields.user_picture.content }}</div>
+{% endif %}
+<div class="speaker-item__block">
+  <h3 class="speaker-item__title">{{ fields.title.content }}</h3>
+  <p class="speaker-item__subtitle">
+    {{ fields.field_title.content }}
+    {{ fields.field_organization_1.content }}
+  </p>
+</div>


### PR DESCRIPTION
## Description

Reliant upon https://github.com/Brian-Clement/tito/pull/2

- Creates generic "Attendee" content type to store attendee data (future state: we'll kill Eventbrite Events module and move those attendees here)
- Requires `tito` (see link above), a generic API module
- Creates `midcamp_tito` module to do most of the business logic
- Creates "Attendees 2020" view to showcase this year's attendees.  This display is restricted to ticket types specific to session days and filters out tickets for users who have not yet filled out their user information, so we don't display a bunch of non-people on the site.
- Creates an Individual Sponsor display for 2020 and places it on the `/2020/sponsors` page.

## To Test

### Remote

https://nginx-midcamp-org-feature-tito-integration.us.amazee.io/2020/attendees
https://nginx-midcamp-org-feature-tito-integration.us.amazee.io/2020/sponsors

### Locally

- Run `composer install`
- Import configuration with `drush cim -y`
- Navigate to `/admin/config/tito/settings` and enter your Tito API key
- Navigate to the MidCamp 2020 event term and enter the following values from Tito:
    - Tito Slug: `midcamp`
    - Event ID: `2020`
- Save the Event term.  
- Validate the following attendee displays, bearing in mind ticket type and response to the "do you wish to appear on the website" question in Tito:
    - Navigate to `/admin/content` and observe Attendees have been created
    - Navigate to `/2020/attendees` and observe the Attendees are displaying
    - Navigate to `/2020/sponsors` and observe individual sponsors are displaying