### PR TITLE
Updating Troubleshooting around SSH access issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ Apache is probably already running on port 80 for your system. Run `sudo apachec
 
 If this does not work, run `lsof -PiTCP -sTCP:LISTEN` and see what is using port 80. Kill it.
 
+### I get the 'Could not load API JWT Token, error was:                                  [warning]'lagoon@ssh.lagoon.amazeeio.cloud: Permission denied (publickey). Error: no alias record could be found for source @production'
+
+You will need someone on the Amazee Rocket Chat (https://amazeeio.rocket.chat/group/midcamp) to add your public SSH key on your account.  
+
+
 ### I can't see new things in the style guide
 
 Are you sure your changes got merged to [Hatter's](https://github.com/MidCamp/hatter-v2) `master`?


### PR DESCRIPTION
based on the interaction on MidCamp slack:
dwaynemcdaniel  2:38 PM
question:
Running drush sql-sync @production @self
Hitting this error:
Could not load API JWT Token, error was:                                  [warning]
'lagoon@ssh.lagoon.amazeeio.cloud: Permission denied (publickey).
Error: no alias record could be found for source @production                [error]
2:38
any suggestions?

brian_clement  2:46 PM
@dwaynemcdaniel I htink you need your ssh key added by the Amazee team.
2:47
Are you a member of the Amazee Rocket Chat (https://amazeeio.rocket.chat/group/midcamp)?

dwaynemcdaniel  2:47 PM
no I am not.
2:47
first I have heard of it to be honest

brian_clement  2:47 PM
That is the only way I know to get them to add you, let me see if I can send you an invite there.