### PR TITLE
Add Session Feedback for speakers

### DIFF
--- a/conf/drupal/config/block.block.views_block__session_feedback_block_1.yml
+++ b/conf/drupal/config/block.block.views_block__session_feedback_block_1.yml
@@ -1,0 +1,33 @@
+uuid: afbdb440-7aaa-4c34-a91b-056602b06691
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.session_feedback
+  module:
+    - ctools
+    - views
+  theme:
+    - hatter_2019
+id: views_block__session_feedback_block_1
+theme: hatter_2019
+region: content
+weight: 7
+provider: null
+plugin: 'views_block:session_feedback-block_1'
+settings:
+  id: 'views_block:session_feedback-block_1'
+  label: ''
+  provider: views
+  label_display: '0'
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    bundles:
+      topic: topic
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'

--- a/conf/drupal/config/user.role.authenticated.yml
+++ b/conf/drupal/config/user.role.authenticated.yml
@@ -26,6 +26,7 @@ permissions:
   - 'use text format basic_html'
   - 'use text format basic_html'
   - 'use text format restricted_html'
+  - 'view any webform submission'
   - 'view field_accepted_confirmed'
   - 'view field_captions'
   - 'view field_feedback_form'

--- a/conf/drupal/config/user.role.authenticated.yml
+++ b/conf/drupal/config/user.role.authenticated.yml
@@ -26,7 +26,6 @@ permissions:
   - 'use text format basic_html'
   - 'use text format basic_html'
   - 'use text format restricted_html'
-  - 'view any webform submission'
   - 'view field_accepted_confirmed'
   - 'view field_captions'
   - 'view field_feedback_form'

--- a/conf/drupal/config/views.view.session_feedback.yml
+++ b/conf/drupal/config/views.view.session_feedback.yml
@@ -30,7 +30,7 @@ display:
       query:
         type: views_query
         options:
-          disable_sql_rewrite: false
+          disable_sql_rewrite: true
           distinct: false
           replica: false
           query_comment: ''

--- a/conf/drupal/config/views.view.session_feedback.yml
+++ b/conf/drupal/config/views.view.session_feedback.yml
@@ -1,0 +1,239 @@
+uuid: f76c0756-d40d-4ede-8fce-5c3534562c80
+langcode: en
+status: true
+dependencies:
+  config:
+    - webform.webform.session_feedback
+  module:
+    - webform
+id: session_feedback
+label: 'Session Feedback'
+module: views
+description: ''
+tag: ''
+base_table: webform_submission
+base_field: sid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 20
+          offset: 0
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            rendered_entity: rendered_entity
+          info:
+            rendered_entity:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: '-1'
+          empty_table: false
+      row:
+        type: 'entity:webform_submission'
+        options:
+          relationship: none
+          view_mode: default
+      fields:
+        rendered_entity:
+          table: webform_submission
+          field: rendered_entity
+          id: rendered_entity
+          entity_type: null
+          entity_field: null
+          plugin_id: rendered_entity
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          view_mode: default
+      filters:
+        webform_id:
+          id: webform_id
+          table: webform_submission
+          field: webform_id
+          value:
+            session_feedback: session_feedback
+          entity_type: webform_submission
+          entity_field: webform_id
+          plugin_id: bundle
+      sorts: {  }
+      title: 'Session Feedback'
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content:
+            value: '<h2>Session Feedback</h2>'
+            format: basic_html
+          plugin_id: text
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          content: 'Displaying @start - @end of @total responses.'
+          plugin_id: result
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments:
+        entity_id:
+          id: entity_id
+          table: webform_submission
+          field: entity_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: raw
+          default_argument_options:
+            index: 1
+            use_alias: false
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: false
+          entity_type: webform_submission
+          entity_field: entity_id
+          plugin_id: string
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - user
+      tags: {  }
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: Block
+    position: 1
+    display_options:
+      display_extenders: {  }
+      block_description: 'Session Feedback'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - url
+        - user
+      tags: {  }

--- a/conf/drupal/config/webform.webform.session_feedback.yml
+++ b/conf/drupal/config/webform.webform.session_feedback.yml
@@ -152,7 +152,8 @@ access:
     users: {  }
     permissions: {  }
   view_own:
-    roles: {  }
+    roles:
+      - authenticated
     users: {  }
     permissions: {  }
   update_own:

--- a/web/modules/custom/midcamp_utility/midcamp_utility.module
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.module
@@ -106,6 +106,43 @@ function midcamp_utility_entity_view_mode_alter(&$view_mode, Drupal\Core\Entity\
   }
 }
 
+// snippet: https://stefvanlooveren.me/node/75
+/**
+ * Implements hook_block_access().
+ */
+function midcamp_utility_block_access(Block $block, $operation, AccountInterface $account) {
+  // Determine what type of page we are on.
+  $current_route = \Drupal::routeMatch();
+
+  // If we're viewing the 'Session Feedback' block...
+  if ($operation == 'view' && $block->getPluginId() == 'views_block:session_feedback-block_1') {
+
+    // Always provide access if the user is admin.
+    if (in_array('administrator', $account->getRoles())) {
+      return AccessResult::allowed();
+    }
+    // Otherwise, check to see if we're on a node...
+    elseif ($current_route->getParameter('node')) {
+      $node = $current_route->getParameter('node');
+
+      // And the node has field_people (i.e. speakers)...
+      if ($node->hasField('field_people') && !$node->field_people->isEmpty()) {
+        $speakers = explode(', ', $node->field_people->getString());
+
+        // And the current user matches one of the speakers.
+        if (in_array($account->id(), $speakers)) {
+          // If so, show the block.
+          return AccessResult::allowed()->addCacheableDependency($account);
+        }
+      }
+    }
+
+    // Otherwise hide the block.
+    return AccessResult::forbidden();
+  }
+  return AccessResult::neutral();
+}
+
 /**
  * Implements hook_webform_submission_access().
  */

--- a/web/modules/custom/midcamp_utility/midcamp_utility.module
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.module
@@ -5,8 +5,12 @@
  * Contains midcamp_utility.module.
  */
 
-use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\block\Entity\Block;
 use Drupal\views\ViewExecutable;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+
 
 /**
  * Implements hook_help().
@@ -99,4 +103,41 @@ function midcamp_utility_entity_view_mode_alter(&$view_mode, Drupal\Core\Entity\
       }
     }
   }
+}
+
+// snippet: https://stefvanlooveren.me/node/75
+/**
+ * Implements hook_block_access().
+ */
+function midcamp_utility_block_access(Block $block, $operation, AccountInterface $account) {
+  // Determine what type of page we are on.
+  $current_route = \Drupal::routeMatch();
+
+  // If we're viewing the 'Session Feedback' block...
+  if ($operation == 'view' && $block->getPluginId() == 'views_block:session_feedback-block_1') {
+    
+    // Always provide access if the user is admin.
+    if (in_array('administrator', $account->getRoles())) {
+      return AccessResult::allowed();
+    }
+    // Otherwise, check to see if we're on a node...
+    elseif ($current_route->getParameter('node')) {
+      $node = $current_route->getParameter('node');
+
+      // And the node has field_people (i.e. speakers)...
+      if ($node->hasField('field_people') && !$node->field_people->isEmpty()) {
+        $speakers = explode(', ', $node->field_people->getString());
+
+        // And the current user matches one of the speakers.
+        if (in_array($account->id(), $speakers)) {
+          // If so, show the block.
+          return AccessResult::allowed()->addCacheableDependency($block);
+        }
+      }
+    }
+
+    // Otherwise hide the block.
+    return AccessResult::forbidden();
+  }
+  return AccessResult::neutral();
 }

--- a/web/modules/custom/midcamp_utility/midcamp_utility.module
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.module
@@ -10,6 +10,7 @@ use Drupal\views\ViewExecutable;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\webform\WebformSubmissionInterface;
 
 
 /**
@@ -105,39 +106,37 @@ function midcamp_utility_entity_view_mode_alter(&$view_mode, Drupal\Core\Entity\
   }
 }
 
-// snippet: https://stefvanlooveren.me/node/75
 /**
- * Implements hook_block_access().
+ * Implements hook_webform_submission_access().
  */
-function midcamp_utility_block_access(Block $block, $operation, AccountInterface $account) {
+function midcamp_utility_webform_submission_access(WebformSubmissionInterface $webform_submission, $operation, AccountInterface $account) {
+  // Do not adjust access for any other webforms.
+  if ($webform_submission->getWebform()->id() != 'session_feedback') {
+    return AccessResult::neutral();
+  }
+
   // Determine what type of page we are on.
   $current_route = \Drupal::routeMatch();
 
-  // If we're viewing the 'Session Feedback' block...
-  if ($operation == 'view' && $block->getPluginId() == 'views_block:session_feedback-block_1') {
-    
-    // Always provide access if the user is admin.
-    if (in_array('administrator', $account->getRoles())) {
-      return AccessResult::allowed();
-    }
-    // Otherwise, check to see if we're on a node...
-    elseif ($current_route->getParameter('node')) {
-      $node = $current_route->getParameter('node');
+  // Always provide access if the user is admin.
+  if (in_array('administrator', $account->getRoles())) {
+    return AccessResult::allowed();
+  }
+  // Otherwise, check to see if we're on a node...
+  elseif ($current_route->getParameter('node')) {
+    $node = $current_route->getParameter('node');
 
-      // And the node has field_people (i.e. speakers)...
-      if ($node->hasField('field_people') && !$node->field_people->isEmpty()) {
-        $speakers = explode(', ', $node->field_people->getString());
+    // And the node has field_people (i.e. speakers)...
+    if ($node->hasField('field_people') && !$node->field_people->isEmpty()) {
+      $speakers = explode(', ', $node->field_people->getString());
 
-        // And the current user matches one of the speakers.
-        if (in_array($account->id(), $speakers)) {
-          // If so, show the block.
-          return AccessResult::allowed()->addCacheableDependency($block);
-        }
+      // And the current user matches one of the speakers.
+      if (in_array($account->id(), $speakers)) {
+        // If so, show the results.
+        return AccessResult::allowed()->addCacheableDependency($account);
       }
     }
-
-    // Otherwise hide the block.
-    return AccessResult::forbidden();
   }
+
   return AccessResult::neutral();
 }


### PR DESCRIPTION
This creates a new view (that's not super well styled, but it should work for now) to display session feedback on session nodes. The block should only be visible to admins and users listed as speakers on the session.

To test:
- visit http://nginx-midcamp-org-feature-session-feedback.us.amazee.io/2020/topic-proposal/build-it-better-stupid-using-design-systems-scalability as anon and observe there's nothing between the Captions and the footer.
- Submit some feedback.
- login as admin and see the block
- login as a speaker on the node: `drush uli 1366` and observe the block is still there
- login as another user: `drush uli 123` and observe the block is hidden.

To do:
- Getting results to display required giving all Authenticated users "View all webform results" permission. This might... not be optimal, but I didn't get to test the implications.