### PR TITLE
Add tabindex to caption field item

### DIFF
--- a/web/themes/custom/hatter_base/templates/field/field--node--field-captions.html.twig
+++ b/web/themes/custom/hatter_base/templates/field/field--node--field-captions.html.twig
@@ -73,7 +73,7 @@
       <div class="field__items">
     {% endif %}
     {% for item in items %}
-      <div{{ item.attributes.addClass('field__item') }}>{{ item.content }}</div>
+      <div{{ item.attributes.addClass('field__item') }} tabindex="0">{{ item.content }}</div>
     {% endfor %}
     {% if multiple %}
       </div>


### PR DESCRIPTION
As per [this Slack message](https://midcamp.slack.com/archives/C0C4L7J0N/p1586189697021700), add `tabindex` to the transcript to make it keyboard accessible.

![midcamp-transcript](https://user-images.githubusercontent.com/238201/78697057-db381e80-78c5-11ea-88a9-b93ecb41213f.png)

To test:
- visit /2020/topic-proposal/build-it-better-stupid-using-design-systems-scalability
- tab through the page and observe the transcript area is tab-able.
