### PR TITLE
Update site for 2021 event

### DIFF
--- a/conf/drupal/config/block.block.hatter_2019_addajobbutton.yml
+++ b/conf/drupal/config/block.block.hatter_2019_addajobbutton.yml
@@ -13,7 +13,7 @@ dependencies:
 id: hatter_2019_addajobbutton
 theme: hatter_2019
 region: content
-weight: -13
+weight: -14
 provider: null
 plugin: 'block_content:de1557a6-167f-41a3-945d-05e977e71f1c'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_content.yml
+++ b/conf/drupal/config/block.block.hatter_2019_content.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_2019_content
 theme: hatter_2019
 region: content
-weight: -11
+weight: -12
 provider: null
 plugin: system_main_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_eventlabelblock.yml
+++ b/conf/drupal/config/block.block.hatter_2019_eventlabelblock.yml
@@ -10,7 +10,7 @@ dependencies:
 id: hatter_2019_eventlabelblock
 theme: hatter_2019
 region: content
-weight: -15
+weight: -16
 provider: null
 plugin: event_label_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_help.yml
+++ b/conf/drupal/config/block.block.hatter_2019_help.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_2019_help
 theme: hatter_2019
 region: content
-weight: -18
+weight: -19
 provider: null
 plugin: help_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_local_actions.yml
+++ b/conf/drupal/config/block.block.hatter_2019_local_actions.yml
@@ -9,7 +9,7 @@ _core:
 id: hatter_2019_local_actions
 theme: hatter_2019
 region: content
-weight: -12
+weight: -13
 provider: null
 plugin: local_actions_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_messages.yml
+++ b/conf/drupal/config/block.block.hatter_2019_messages.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_2019_messages
 theme: hatter_2019
 region: content
-weight: -17
+weight: -18
 provider: null
 plugin: system_messages_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_page_title.yml
+++ b/conf/drupal/config/block.block.hatter_2019_page_title.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_2019_page_title
 theme: hatter_2019
 region: content
-weight: -14
+weight: -15
 provider: null
 plugin: page_title_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_tabs.yml
+++ b/conf/drupal/config/block.block.hatter_2019_tabs.yml
@@ -7,7 +7,7 @@ dependencies:
 id: hatter_2019_tabs
 theme: hatter_2019
 region: content
-weight: -16
+weight: -17
 provider: null
 plugin: local_tasks_block
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__attendees_block_2.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__attendees_block_2.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__attendees_block_2
 theme: hatter_2019
 region: content
-weight: 6
+weight: 5
 provider: null
 plugin: 'views_block:attendees-block_2'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_news_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_news_block_1.yml
@@ -11,7 +11,7 @@ dependencies:
 id: hatter_2019_views_block__event_news_block_1
 theme: hatter_2019
 region: content
-weight: -10
+weight: -11
 provider: null
 plugin: 'views_block:event_news-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_10.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_10.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_10
 theme: hatter_2019
 region: content
-weight: -4
+weight: -5
 provider: null
 plugin: 'views_block:event_sponsors-block_10'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_11.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_11.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_11
 theme: hatter_2019
 region: content
-weight: -3
+weight: -4
 provider: null
 plugin: 'views_block:event_sponsors-block_11'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_2.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_2.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_2
 theme: hatter_2019
 region: content
-weight: -6
+weight: -7
 provider: null
 plugin: 'views_block:event_sponsors-block_2'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_3.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_3.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_3
 theme: hatter_2019
 region: content
-weight: -5
+weight: -6
 provider: null
 plugin: 'views_block:event_sponsors-block_3'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_4.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_4.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_4
 theme: hatter_2019
 region: content
-weight: -9
+weight: -10
 provider: null
 plugin: 'views_block:event_sponsors-block_4'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_5.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_5.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_5
 theme: hatter_2019
 region: content
-weight: -7
+weight: -8
 provider: null
 plugin: 'views_block:event_sponsors-block_5'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_6.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_6.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_6
 theme: hatter_2019
 region: content
-weight: 4
+weight: 3
 provider: null
 plugin: 'views_block:event_sponsors-block_6'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_8.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_8.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_8
 theme: hatter_2019
 region: content
-weight: 3
+weight: 2
 provider: null
 plugin: 'views_block:event_sponsors-block_8'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_9.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_9.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__event_sponsors_block_9
 theme: hatter_2019
 region: content
-weight: -8
+weight: -9
 provider: null
 plugin: 'views_block:event_sponsors-block_9'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__jobs_board_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__jobs_board_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__jobs_board_block_1
 theme: hatter_2019
 region: content
-weight: 1
+weight: 0
 provider: null
 plugin: 'views_block:jobs_board-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__speakers_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__speakers_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__speakers_block_1
 theme: hatter_2019
 region: content
-weight: -1
+weight: -2
 provider: null
 plugin: 'views_block:speakers-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__summits_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__summits_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__summits_block_1
 theme: hatter_2019
 region: content
-weight: 2
+weight: 1
 provider: null
 plugin: 'views_block:summits-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_views_block__training_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__training_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_views_block__training_block_1
 theme: hatter_2019
 region: content
-weight: 0
+weight: -1
 provider: null
 plugin: 'views_block:training-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_2019_webform.yml
+++ b/conf/drupal/config/block.block.hatter_2019_webform.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_2019_webform
 theme: hatter_2019
 region: content
-weight: -2
+weight: -3
 provider: null
 plugin: webform_block
 settings:

--- a/conf/drupal/config/block.block.midcamp2021.yml
+++ b/conf/drupal/config/block.block.midcamp2021.yml
@@ -1,23 +1,23 @@
-uuid: 7991a2d1-dfef-4568-9e7d-22f253ef68eb
+uuid: 638df935-e43a-4745-9ca3-02d76b6fd01c
 langcode: en
 status: true
 dependencies:
   content:
-    - 'block_content:basic:718a2f09-3a75-462a-9c04-3e21f78a81bb'
+    - 'block_content:basic:a54a0659-0ed4-46e8-afe3-55cdd97cd855'
   module:
     - block_content
     - system
   theme:
     - hatter_2019
-id: hatter_2019_midcamp2019
+id: midcamp2021
 theme: hatter_2019
 region: content
-weight: -22
+weight: -21
 provider: null
-plugin: 'block_content:718a2f09-3a75-462a-9c04-3e21f78a81bb'
+plugin: 'block_content:a54a0659-0ed4-46e8-afe3-55cdd97cd855'
 settings:
-  id: 'block_content:718a2f09-3a75-462a-9c04-3e21f78a81bb'
-  label: 'MidCamp 2019'
+  id: 'block_content:a54a0659-0ed4-46e8-afe3-55cdd97cd855'
+  label: 'MidCamp 2021'
   provider: block_content
   label_display: '0'
   status: true
@@ -26,6 +26,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: /2020
+    pages: '<front>'
     negate: false
     context_mapping: {  }

--- a/conf/drupal/config/block.block.midcamp2021navigation.yml
+++ b/conf/drupal/config/block.block.midcamp2021navigation.yml
@@ -1,22 +1,22 @@
-uuid: f6dbc514-dea8-41c1-a592-79b84b74b48b
+uuid: de897245-0052-410d-841e-64024ffa49a3
 langcode: en
 status: true
 dependencies:
   config:
-    - system.menu.midcamp-2020-navigation
+    - system.menu.midcamp-2021-navigation
   module:
     - system
   theme:
     - hatter_2019
-id: hatter_2019_midcamp2020navigation
+id: midcamp2021navigation
 theme: hatter_2019
 region: header
 weight: 0
 provider: null
-plugin: 'system_menu_block:midcamp-2020-navigation'
+plugin: 'system_menu_block:midcamp-2021-navigation'
 settings:
-  id: 'system_menu_block:midcamp-2020-navigation'
-  label: 'Midcamp 2020 Navigation'
+  id: 'system_menu_block:midcamp-2021-navigation'
+  label: 'Midcamp 2021 Navigation'
   provider: system
   label_display: '0'
   level: 1
@@ -25,6 +25,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: "/2020/*\r\n/2020"
-    negate: false
+    pages: "/2018*\r\n/2019*\r\n/2020*"
+    negate: true
     context_mapping: {  }

--- a/conf/drupal/config/block.block.views_block__attendees_2020_block_1.yml
+++ b/conf/drupal/config/block.block.views_block__attendees_2020_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__attendees_2020_block_1
 theme: hatter_2019
 region: content
-weight: 5
+weight: 4
 provider: null
 plugin: 'views_block:attendees_2020-block_1'
 settings:

--- a/conf/drupal/config/block.block.views_block__session_feedback_block_1.yml
+++ b/conf/drupal/config/block.block.views_block__session_feedback_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__session_feedback_block_1
 theme: hatter_2019
 region: content
-weight: 7
+weight: 6
 provider: null
 plugin: 'views_block:session_feedback-block_1'
 settings:

--- a/conf/drupal/config/field.field.node.topic.field_event.yml
+++ b/conf/drupal/config/field.field.node.topic.field_event.yml
@@ -7,7 +7,7 @@ dependencies:
     - node.type.topic
     - taxonomy.vocabulary.event
   content:
-    - 'taxonomy_term:event:edb1c63f-3af1-4ce3-b9d0-55336993e692'
+    - 'taxonomy_term:event:5c03697f-f030-4408-bc96-aaca0ee62b55'
 id: node.topic.field_event
 field_name: field_event
 entity_type: node
@@ -18,7 +18,7 @@ required: false
 translatable: false
 default_value:
   -
-    target_uuid: edb1c63f-3af1-4ce3-b9d0-55336993e692
+    target_uuid: 5c03697f-f030-4408-bc96-aaca0ee62b55
 default_value_callback: ''
 settings:
   handler: 'default:taxonomy_term'

--- a/conf/drupal/config/node.type.page.yml
+++ b/conf/drupal/config/node.type.page.yml
@@ -11,6 +11,7 @@ third_party_settings:
       - main
       - midcamp-2019-navigation
       - midcamp-2020-navigation
+      - midcamp-2021-navigation
     parent: 'main:'
   scheduler:
     expand_fieldset: when_required

--- a/conf/drupal/config/system.menu.midcamp-2021-navigation.yml
+++ b/conf/drupal/config/system.menu.midcamp-2021-navigation.yml
@@ -1,0 +1,8 @@
+uuid: 86bb591a-b99a-4f24-8aa8-c7a1b91f6941
+langcode: en
+status: true
+dependencies: {  }
+id: midcamp-2021-navigation
+label: 'Midcamp 2021 Navigation'
+description: ''
+locked: false

--- a/conf/drupal/config/system.site.yml
+++ b/conf/drupal/config/system.site.yml
@@ -1,11 +1,11 @@
 uuid: 4e8b0d7f-53e9-45f1-9a7c-7188d45194bd
-name: 'MidCamp 2020'
+name: 'MidCamp 2021'
 mail: info@midcamp.org
-slogan: 'March 19th - 21st, 2020'
+slogan: 'March 24th - 27st, 2021'
 page:
   403: ''
   404: ''
-  front: /taxonomy/term/143
+  front: /taxonomy/term/234
 admin_compact_mode: false
 weight_select_max: 100
 langcode: en

--- a/conf/drupal/config/views.view.news.yml
+++ b/conf/drupal/config/views.view.news.yml
@@ -7,10 +7,12 @@ dependencies:
     - node.type.article
     - system.menu.main
     - system.menu.midcamp-2019-navigation
+    - system.menu.midcamp-2021-navigation
     - taxonomy.vocabulary.event
   content:
     - 'taxonomy_term:event:17285735-fe51-4f45-b481-321ae7af649f'
     - 'taxonomy_term:event:58ab979d-12f0-4b19-ab75-5625aa986afb'
+    - 'taxonomy_term:event:5c03697f-f030-4408-bc96-aaca0ee62b55'
     - 'taxonomy_term:event:edb1c63f-3af1-4ce3-b9d0-55336993e692'
   module:
     - node
@@ -529,6 +531,149 @@ display:
             reduce: false
             operator_limit_selection: false
             operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: textfield
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  page_4:
+    display_plugin: page
+    id: page_4
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: 2021/news
+      menu:
+        type: normal
+        title: News
+        description: ''
+        expanded: false
+        parent: ''
+        weight: -45
+        context: '0'
+        menu_name: midcamp-2021-navigation
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            article: article
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        field_article_news_value:
+          id: field_article_news_value
+          table: node__field_article_news
+          field: field_article_news_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            - 234
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
           is_grouped: false
           group_info:
             label: ''

--- a/conf/drupal/config/views.view.organizers.yml
+++ b/conf/drupal/config/views.view.organizers.yml
@@ -10,6 +10,7 @@ dependencies:
   content:
     - 'taxonomy_term:event:17285735-fe51-4f45-b481-321ae7af649f'
     - 'taxonomy_term:event:58ab979d-12f0-4b19-ab75-5625aa986afb'
+    - 'taxonomy_term:event:5c03697f-f030-4408-bc96-aaca0ee62b55'
     - 'taxonomy_term:event:edb1c63f-3af1-4ce3-b9d0-55336993e692'
   module:
     - taxonomy
@@ -414,6 +415,99 @@ display:
         weight: -43
         context: '0'
         menu_name: midcamp-2020-navigation
+      display_description: ''
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - user.permissions
+      tags: {  }
+  page_4:
+    display_plugin: page
+    id: page_4
+    display_title: '2021 Organizers'
+    position: 2
+    display_options:
+      display_extenders: {  }
+      path: 2021/organizers
+      filters:
+        status:
+          value: '1'
+          table: users_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: user
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+          group: 1
+        field_organizer_year_target_id:
+          id: field_organizer_year_target_id
+          table: user__field_organizer_year
+          field: field_organizer_year_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            234: 234
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      defaults:
+        filters: false
+        filter_groups: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      menu:
+        type: none
+        title: Organizers
+        description: ''
+        expanded: false
+        parent: ''
+        weight: -43
+        context: '0'
+        menu_name: midcamp-2021-navigation
       display_description: ''
     cache_metadata:
       max-age: -1

--- a/conf/drupal/config/views.view.sessions.yml
+++ b/conf/drupal/config/views.view.sessions.yml
@@ -16,6 +16,7 @@ dependencies:
   content:
     - 'taxonomy_term:event:17285735-fe51-4f45-b481-321ae7af649f'
     - 'taxonomy_term:event:58ab979d-12f0-4b19-ab75-5625aa986afb'
+    - 'taxonomy_term:event:5c03697f-f030-4408-bc96-aaca0ee62b55'
     - 'taxonomy_term:event:edb1c63f-3af1-4ce3-b9d0-55336993e692'
     - 'taxonomy_term:topic_type:39f8a394-f9fc-45ae-85a2-46aabfd3212f'
     - 'taxonomy_term:topic_type:f9f1e3ca-ad7f-4636-b8c2-bb5d29f7b35b'
@@ -2732,6 +2733,531 @@ display:
             reduce: false
             operator_limit_selection: false
             operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      sorts:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+      css_class: schedule
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_people'
+        - 'config:field.storage.node.field_track'
+  page_6:
+    display_plugin: page
+    id: page_6
+    display_title: 'Accepted 2021'
+    position: 4
+    display_options:
+      display_extenders: {  }
+      display_description: ''
+      title: 'Accepted Sessions'
+      defaults:
+        title: false
+        style: false
+        row: false
+        header: false
+        empty: false
+        fields: false
+        filters: false
+        filter_groups: false
+        sorts: false
+        css_class: false
+      style:
+        type: default
+        options:
+          row_class: schedule__teaser
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      path: 2021/accepted-sessions
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: '<p>Below is the list of accepted and confirmed sessions. We <!--still have a handful of sessions to confirm and -->will post the full session schedule shortly. Thanks to all who submitted!</p>'
+            format: full_html
+          plugin_id: text
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content:
+            value: 'Session selection and confirmation is still underway. Check back again soon.'
+            format: basic_html
+          plugin_id: text
+      fields:
+        field_track:
+          id: field_track
+          table: node__field_track
+          field: field_track
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: '0'
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: div
+          element_wrapper_class: schedule__track
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: '0'
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: h3
+          element_wrapper_class: schedule__title
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        field_people:
+          id: field_people
+          table: node__field_people
+          field: field_people
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: '0'
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: '0'
+          element_wrapper_class: ''
+          element_default_classes: false
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            topic: topic
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          group: 1
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        field_topic_type_target_id:
+          id: field_topic_type_target_id
+          table: node__field_topic_type
+          field: field_topic_type_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            14: 14
+          group: 1
+          exposed: false
+          expose:
+            operator_id: field_topic_type_target_id_op
+            label: 'Topic Type'
+            description: ''
+            use_operator: false
+            operator: field_topic_type_target_id_op
+            identifier: field_topic_type_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              speaker: '0'
+              content_editor: '0'
+              administrator: '0'
+            reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: topic_type
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_track_target_id:
+          id: field_track_target_id
+          table: node__field_track
+          field: field_track_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_track_target_id_op
+            label: 'Session Track'
+            description: ''
+            use_operator: false
+            operator: field_track_target_id_op
+            identifier: field_track_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              speaker: '0'
+              content_editor: '0'
+              administrator: '0'
+              sponsor: '0'
+            reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: session_tracks
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_accepted_confirmed_value:
+          id: field_accepted_confirmed_value
+          table: node__field_accepted_confirmed
+          field: field_accepted_confirmed_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: boolean
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            234: 234
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
           is_grouped: false
           group_info:
             label: ''

--- a/web/themes/custom/hatter_base/hatter_base.theme
+++ b/web/themes/custom/hatter_base/hatter_base.theme
@@ -45,7 +45,7 @@ function hatter_base_theme_suggestions_user_alter(&$suggestions, $vars, $hook) {
  */
 function hatter_base_theme_suggestions_menu_alter(&$suggestions, $vars, $hook) {
   // Let the new menus use the existing template for now.
-  $menus = ['midcamp-2019-navigation', 'midcamp-2020-navigation'];
+  $menus = ['midcamp-2019-navigation', 'midcamp-2020-navigation', 'midcamp-2021-navigation'];
   if (in_array($vars['menu_name'], $menus)) {
     array_unshift($suggestions, 'menu__main');
   }


### PR DESCRIPTION
# Description 

Updates the website to present the 2021 event year as standard.  I have created a Wiki page outlining this process for future reference at https://github.com/MidCamp/midcamp/wiki/Preparing-MidCamp.org-for-a-new-event-year.

# To Test

- Import config with `drush cim -y`
- Navigate to the home page.  Observe: 
  - You are not on the 2020 page any longer.
  - The page shows "MidCamp 2021 / March 24th - 27st, 2021"
  - The 2020 menu has been replaced with the 2021 menu (though it should be empty/mostly empty)
- Add some test `Article` content tagged to the `MidCamp 2021` event term.  Observe this appears on the homepage.
- Add some test `Sponsor` content tagged to the `MidCamp 2021` event term and the `Core Sponsors` Sponsorship Level.  Observe this appears on the homepage.
- Create new `Topic` content.  Confirm `field_event` defaults to `MidCamp 2021` now.
- Explore the previous year's site starting at the `/2020` route.  Confirm everything is in tact.
- Confirm `/2021/news`, `/2021/organizers` and `/2021/accepted-sessions` pages exist.  Create test content as needed to validate.

# To Do's

- [ ] **Site content.**  I have created some unpublished Basic pages for "About," "Sponsor," "Sponsors" and "Schedule."  Some of these will need to be populated with content and published prior to merging this work, and menu assignments will need to be made (these cannot yet be made because they are dependent on this config)
- [ ] **Theme decisions.**  We are currently in the green "O'MidCamp" theme.  I think we need to do things here, however I might suggest handling that as a separate effort
- [ ] **Determine timing.**  This will require a bit of manual intervention once deployed, primarily to get the menus set up, as they will be empty initially.  