### PR TITLE
Theme switching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -113,6 +113,9 @@
           },
           "drupal/switch_page_theme": {
               "Drupal 9 Readiness [#3145213]": "https://www.drupal.org/files/issues/2020-07-07/3145213-5.patch"
+          },
+          "drupal/libraries": {
+              "Missing global variable $base_theme_info [#3057777]": "https://www.drupal.org/files/issues/2019-06-26/missing_base_theme_info_global_variable-3057777-4.patch"
           }
         },
         "installer-types": ["butler-styleguide"],

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
         "drupal/redirect": "^1.0",
         "drupal/scheduler": "^1.0@RC",
         "drupal/simple_sitemap": "^3.3",
+        "drupal/switch_page_theme": "1.x-dev",
         "drupal/twig_extensions": "1.x-dev",
         "drupal/video_embed_field": "^2.2",
         "drupal/video_embed_media": "^2.2",
@@ -109,6 +110,9 @@
           },
           "drupal/config_installer": {
               "Fix config_install error (https://www.drupal.org/project/config_installer/issues/3039052)": "https://www.drupal.org/files/issues/2019-03-11/config_installer-generatepassword-missing-3039052-2-D8.patch"
+          },
+          "drupal/switch_page_theme": {
+              "Drupal 9 Readiness [#3145213]": "https://www.drupal.org/files/issues/2020-07-07/3145213-5.patch"
           }
         },
         "installer-types": ["butler-styleguide"],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d73e1841d4523d58fdbc030fd60d63ce",
+    "content-hash": "28ba80ca4cea4f6dbde856a37804dfd8",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3183,6 +3183,9 @@
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
                     }
+                },
+                "patches_applied": {
+                    "Missing global variable $base_theme_info [#3057777]": "https://www.drupal.org/files/issues/2019-06-26/missing_base_theme_info_global_variable-3057777-4.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "db9618bc1ccb644bdb4c3d395ca3f083",
+    "content-hash": "d73e1841d4523d58fdbc030fd60d63ce",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4081,6 +4081,51 @@
                 "issues": "https://drupal.org/project/issues/simple_sitemap",
                 "irc": "irc://irc.freenode.org/drupal-contribute"
             }
+        },
+        {
+            "name": "drupal/switch_page_theme",
+            "version": "dev-1.x",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/switch_page_theme.git",
+                "reference": "c1b84af3d4c50e15b61018e1b29306c61fc3a99b"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0+3-dev",
+                    "datestamp": "1558333985",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
+                    }
+                },
+                "patches_applied": {
+                    "Drupal 9 Readiness [#3145213]": "https://www.drupal.org/files/issues/2020-07-07/3145213-5.patch"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "deepali_agarwal",
+                    "homepage": "https://www.drupal.org/user/2438242"
+                }
+            ],
+            "description": "Switches active theme on specific pages.",
+            "homepage": "https://www.drupal.org/project/switch_page_theme",
+            "support": {
+                "source": "https://git.drupalcode.org/project/switch_page_theme"
+            },
+            "time": "2019-05-20T06:28:19+00:00"
         },
         {
             "name": "drupal/token",
@@ -13308,6 +13353,7 @@
         "drupal/name": 10,
         "drupal/r4032login": 20,
         "drupal/scheduler": 5,
+        "drupal/switch_page_theme": 20,
         "drupal/twig_extensions": 20,
         "drupal/viewsreference": 15,
         "drupal/webform": 5,

--- a/conf/drupal/config/block.block.hatter_account_menu.yml
+++ b/conf/drupal/config/block.block.hatter_account_menu.yml
@@ -1,0 +1,27 @@
+uuid: 3c78fee2-b61f-444d-ac6b-d2f372568fa1
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.account
+  module:
+    - system
+  theme:
+    - hatter
+_core:
+  default_config_hash: DweBpscQZdG0-fHkSpUzdYucrNH45G_KF7Z82V-oyQM
+id: hatter_account_menu
+theme: hatter
+region: branding
+weight: -9
+provider: null
+plugin: 'system_menu_block:account'
+settings:
+  id: 'system_menu_block:account'
+  label: 'User account menu'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 1
+  expand_all_items: false
+visibility: {  }

--- a/conf/drupal/config/block.block.hatter_addajobbutton.yml
+++ b/conf/drupal/config/block.block.hatter_addajobbutton.yml
@@ -1,0 +1,41 @@
+uuid: 268d37e3-bbde-45b1-bcb1-d42ed609f769
+langcode: en
+status: true
+dependencies:
+  content:
+    - 'block_content:basic:de1557a6-167f-41a3-945d-05e977e71f1c'
+  module:
+    - block_content
+    - system
+    - user
+  theme:
+    - hatter
+id: hatter_addajobbutton
+theme: hatter
+region: content
+weight: -14
+provider: null
+plugin: 'block_content:de1557a6-167f-41a3-945d-05e977e71f1c'
+settings:
+  id: 'block_content:de1557a6-167f-41a3-945d-05e977e71f1c'
+  label: 'Add a Job Button'
+  provider: block_content
+  label_display: '0'
+  status: true
+  info: ''
+  view_mode: full
+visibility:
+  request_path:
+    id: request_path
+    pages: /jobs
+    negate: false
+    context_mapping: {  }
+  user_role:
+    id: user_role
+    roles:
+      content_editor: content_editor
+      administrator: administrator
+      sponsor: sponsor
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'

--- a/conf/drupal/config/block.block.hatter_branding.yml
+++ b/conf/drupal/config/block.block.hatter_branding.yml
@@ -1,0 +1,30 @@
+uuid: 6c3f5c5a-846d-444e-a018-c8bfcfac4566
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - hatter
+_core:
+  default_config_hash: NDwadleLD3YVSbDUaakxyYZyINYtkFtOVGShfq4kWy8
+id: hatter_branding
+theme: hatter
+region: branding
+weight: -8
+provider: null
+plugin: system_branding_block
+settings:
+  id: system_branding_block
+  label: 'Site branding'
+  provider: system
+  label_display: '0'
+  use_site_logo: true
+  use_site_name: true
+  use_site_slogan: true
+visibility:
+  request_path:
+    id: request_path
+    pages: '<front>'
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_breadcrumbs.yml
+++ b/conf/drupal/config/block.block.hatter_breadcrumbs.yml
@@ -1,0 +1,22 @@
+uuid: 683fa3fe-f1c9-47ba-ab1d-034f262ac56b
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - hatter
+_core:
+  default_config_hash: oXUb3JZR2WW5VOdw4HrhRicCsq51mCgLfRyvheG68ck
+id: hatter_breadcrumbs
+theme: hatter
+region: breadcrumb
+weight: 0
+provider: null
+plugin: system_breadcrumb_block
+settings:
+  id: system_breadcrumb_block
+  label: Breadcrumbs
+  provider: system
+  label_display: '0'
+visibility: {  }

--- a/conf/drupal/config/block.block.hatter_content.yml
+++ b/conf/drupal/config/block.block.hatter_content.yml
@@ -1,0 +1,27 @@
+uuid: afe7c4fb-85db-48d4-a8a0-009ce234a951
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - hatter
+_core:
+  default_config_hash: 9EoWV2Lot6FVSr50t4hoKgiz1LIXYWNG-IIPYsWxBqo
+id: hatter_content
+theme: hatter
+region: content
+weight: -12
+provider: null
+plugin: system_main_block
+settings:
+  id: system_main_block
+  label: 'Main page content'
+  provider: system
+  label_display: '0'
+visibility:
+  request_path:
+    id: request_path
+    pages: '<front>'
+    negate: true
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_eventlabelblock.yml
+++ b/conf/drupal/config/block.block.hatter_eventlabelblock.yml
@@ -1,0 +1,35 @@
+uuid: c9679a5a-4666-4cd5-aa2f-ffd433e98976
+langcode: en
+status: true
+dependencies:
+  module:
+    - ctools
+    - midcamp_event_label_block
+  theme:
+    - hatter
+id: hatter_eventlabelblock
+theme: hatter
+region: content
+weight: -16
+provider: null
+plugin: event_label_block
+settings:
+  id: event_label_block
+  label: 'Event label block'
+  provider: midcamp_event_label_block
+  label_display: '0'
+visibility:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    bundles:
+      summit: summit
+      article: article
+      job: job
+      page: page
+      sponsor: sponsor
+      topic: topic
+      training: training
+      venue: venue
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'

--- a/conf/drupal/config/block.block.hatter_footer.yml
+++ b/conf/drupal/config/block.block.hatter_footer.yml
@@ -1,0 +1,25 @@
+uuid: ee51e657-a13d-4a41-bfcf-a227f237d3ac
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.footer
+  module:
+    - system
+  theme:
+    - hatter
+id: hatter_footer
+theme: hatter
+region: footer_right
+weight: 0
+provider: null
+plugin: 'system_menu_block:footer'
+settings:
+  id: 'system_menu_block:footer'
+  label: Footer
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 0
+  expand_all_items: false
+visibility: {  }

--- a/conf/drupal/config/block.block.hatter_footerbranding.yml
+++ b/conf/drupal/config/block.block.hatter_footerbranding.yml
@@ -1,0 +1,25 @@
+uuid: 0cd7d9c8-8b6e-4ee6-8fb4-da37fcc0af7c
+langcode: en
+status: true
+dependencies:
+  content:
+    - 'block_content:basic:2f35417b-1d83-40cb-a971-3683805002ae'
+  module:
+    - block_content
+  theme:
+    - hatter
+id: hatter_footerbranding
+theme: hatter
+region: footer_left
+weight: 0
+provider: null
+plugin: 'block_content:2f35417b-1d83-40cb-a971-3683805002ae'
+settings:
+  id: 'block_content:2f35417b-1d83-40cb-a971-3683805002ae'
+  label: 'Footer Branding'
+  provider: block_content
+  label_display: '0'
+  status: true
+  info: ''
+  view_mode: full
+visibility: {  }

--- a/conf/drupal/config/block.block.hatter_help.yml
+++ b/conf/drupal/config/block.block.hatter_help.yml
@@ -1,0 +1,22 @@
+uuid: 7e6d2d13-0ae7-4208-b15d-51f2757e60ca
+langcode: en
+status: true
+dependencies:
+  module:
+    - help
+  theme:
+    - hatter
+_core:
+  default_config_hash: 8I8iACSa0sKO3k3jlvUG1ge52rfcKX7USJAQYnzuBgg
+id: hatter_help
+theme: hatter
+region: content
+weight: -19
+provider: null
+plugin: help_block
+settings:
+  id: help_block
+  label: Help
+  provider: help
+  label_display: '0'
+visibility: {  }

--- a/conf/drupal/config/block.block.hatter_local_actions.yml
+++ b/conf/drupal/config/block.block.hatter_local_actions.yml
@@ -1,0 +1,20 @@
+uuid: 3e0cff13-3041-499d-8cc6-362c20c0df91
+langcode: en
+status: true
+dependencies:
+  theme:
+    - hatter
+_core:
+  default_config_hash: 13GQpeITIJsp1kyPniXtWZfyFH87vb1xxJCHifL4UeE
+id: hatter_local_actions
+theme: hatter
+region: content
+weight: -13
+provider: null
+plugin: local_actions_block
+settings:
+  id: local_actions_block
+  label: 'Primary admin actions'
+  provider: core
+  label_display: '0'
+visibility: {  }

--- a/conf/drupal/config/block.block.hatter_main_menu.yml
+++ b/conf/drupal/config/block.block.hatter_main_menu.yml
@@ -1,0 +1,32 @@
+uuid: 35f514e9-0902-49b7-9eef-1d8146cda0ec
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.main
+  module:
+    - system
+  theme:
+    - hatter
+_core:
+  default_config_hash: rx9IrdDv7Ldc4kpalZAxdhIPZfYIeOMh1N-qKoQZwHo
+id: hatter_main_menu
+theme: hatter
+region: header
+weight: -9
+provider: null
+plugin: 'system_menu_block:main'
+settings:
+  id: 'system_menu_block:main'
+  label: 'Main navigation'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 2
+  expand_all_items: false
+visibility:
+  request_path:
+    id: request_path
+    pages: "/2018/*\r\n/2018"
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_messages.yml
+++ b/conf/drupal/config/block.block.hatter_messages.yml
@@ -1,0 +1,22 @@
+uuid: d0b4e4d7-cbdf-46fb-9053-959f921aeba6
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - hatter
+_core:
+  default_config_hash: KHQIJ7Vfl25lTjzIc7qIvnuistt-Mw2O0kG4jCofmkI
+id: hatter_messages
+theme: hatter
+region: content
+weight: -18
+provider: null
+plugin: system_messages_block
+settings:
+  id: system_messages_block
+  label: 'Status messages'
+  provider: system
+  label_display: '0'
+visibility: {  }

--- a/conf/drupal/config/block.block.hatter_midcamp2019.yml
+++ b/conf/drupal/config/block.block.hatter_midcamp2019.yml
@@ -1,0 +1,31 @@
+uuid: 8bbc83e7-c702-4722-b6f5-d7bd90be08ce
+langcode: en
+status: true
+dependencies:
+  content:
+    - 'block_content:basic:718a2f09-3a75-462a-9c04-3e21f78a81bb'
+  module:
+    - block_content
+    - system
+  theme:
+    - hatter
+id: hatter_midcamp2019
+theme: hatter
+region: content
+weight: -20
+provider: null
+plugin: 'block_content:718a2f09-3a75-462a-9c04-3e21f78a81bb'
+settings:
+  id: 'block_content:718a2f09-3a75-462a-9c04-3e21f78a81bb'
+  label: 'MidCamp 2019'
+  provider: block_content
+  label_display: '0'
+  status: true
+  info: ''
+  view_mode: full
+visibility:
+  request_path:
+    id: request_path
+    pages: '<front>'
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_midcamp2019navigation.yml
+++ b/conf/drupal/config/block.block.hatter_midcamp2019navigation.yml
@@ -1,0 +1,30 @@
+uuid: b83efcae-6ab7-4657-a752-5f73d564e216
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.midcamp-2019-navigation
+  module:
+    - system
+  theme:
+    - hatter
+id: hatter_midcamp2019navigation
+theme: hatter
+region: header
+weight: 0
+provider: null
+plugin: 'system_menu_block:midcamp-2019-navigation'
+settings:
+  id: 'system_menu_block:midcamp-2019-navigation'
+  label: 'Midcamp 2019 Navigation'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 2
+  expand_all_items: false
+visibility:
+  request_path:
+    id: request_path
+    pages: "/2019/*\r\n/2019"
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_midcamp2020navigation.yml
+++ b/conf/drupal/config/block.block.hatter_midcamp2020navigation.yml
@@ -25,6 +25,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: "/2018*\r\n/2019*"
-    negate: true
+    pages: "/2020/*\r\n/2020"
+    negate: false
     context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_midcamp2020navigation.yml
+++ b/conf/drupal/config/block.block.hatter_midcamp2020navigation.yml
@@ -1,0 +1,30 @@
+uuid: 04a40916-f71b-4344-8a32-243362dd7e3e
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.midcamp-2020-navigation
+  module:
+    - system
+  theme:
+    - hatter
+id: hatter_midcamp2020navigation
+theme: hatter
+region: header
+weight: 0
+provider: null
+plugin: 'system_menu_block:midcamp-2020-navigation'
+settings:
+  id: 'system_menu_block:midcamp-2020-navigation'
+  label: 'Midcamp 2020 Navigation'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 2
+  expand_all_items: true
+visibility:
+  request_path:
+    id: request_path
+    pages: "/2018*\r\n/2019*"
+    negate: true
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_page_title.yml
+++ b/conf/drupal/config/block.block.hatter_page_title.yml
@@ -1,0 +1,27 @@
+uuid: 2582bbd1-14b1-4a8b-abd6-0a9f5a5832ec
+langcode: en
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - hatter
+_core:
+  default_config_hash: 7rR9chwXvdM2H8OYMAYx9Zj3GGlPMrZp_M3ZA4thYTk
+id: hatter_page_title
+theme: hatter
+region: content
+weight: -15
+provider: null
+plugin: page_title_block
+settings:
+  id: page_title_block
+  label: 'Page title'
+  provider: core
+  label_display: '0'
+visibility:
+  request_path:
+    id: request_path
+    pages: '<front>'
+    negate: true
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_powered.yml
+++ b/conf/drupal/config/block.block.hatter_powered.yml
@@ -1,0 +1,22 @@
+uuid: b981f122-a3b4-4d9c-8159-e753cb2363b0
+langcode: en
+status: false
+dependencies:
+  module:
+    - system
+  theme:
+    - hatter
+_core:
+  default_config_hash: jQQUUWN2Uxr5qZtc9zcJKBCxpKY8orN1u2HPqYYRQDI
+id: hatter_powered
+theme: hatter
+region: header
+weight: -8
+provider: null
+plugin: system_powered_by_block
+settings:
+  id: system_powered_by_block
+  label: 'Powered by Drupal'
+  provider: system
+  label_display: '0'
+visibility: {  }

--- a/conf/drupal/config/block.block.hatter_search.yml
+++ b/conf/drupal/config/block.block.hatter_search.yml
@@ -1,0 +1,23 @@
+uuid: b63aa753-f34b-4212-a41a-5be5ddb500fe
+langcode: en
+status: false
+dependencies:
+  module:
+    - search
+  theme:
+    - hatter
+_core:
+  default_config_hash: za-39d5WDUg6XvbyqSnuVYEeq6QM4qKJxW8MnoAha5A
+id: hatter_search
+theme: hatter
+region: header
+weight: -7
+provider: null
+plugin: search_form_block
+settings:
+  id: search_form_block
+  label: Search
+  provider: search
+  label_display: visible
+  page_id: ''
+visibility: {  }

--- a/conf/drupal/config/block.block.hatter_socialfooter.yml
+++ b/conf/drupal/config/block.block.hatter_socialfooter.yml
@@ -1,0 +1,25 @@
+uuid: bea246a4-937a-4710-89d8-6f6ab8eb288f
+langcode: en
+status: true
+dependencies:
+  content:
+    - 'block_content:basic:c87b75b7-23fd-45ac-ae17-af7efa9c87a8'
+  module:
+    - block_content
+  theme:
+    - hatter
+id: hatter_socialfooter
+theme: hatter
+region: footer_left
+weight: 0
+provider: null
+plugin: 'block_content:c87b75b7-23fd-45ac-ae17-af7efa9c87a8'
+settings:
+  id: 'block_content:c87b75b7-23fd-45ac-ae17-af7efa9c87a8'
+  label: 'Social Footer'
+  provider: block_content
+  label_display: '0'
+  status: true
+  info: ''
+  view_mode: full
+visibility: {  }

--- a/conf/drupal/config/block.block.hatter_tabs.yml
+++ b/conf/drupal/config/block.block.hatter_tabs.yml
@@ -1,0 +1,20 @@
+uuid: 94329b3f-6923-4e33-b2d8-a25e7c20fff7
+langcode: en
+status: true
+dependencies:
+  theme:
+    - hatter
+id: hatter_tabs
+theme: hatter
+region: content
+weight: -17
+provider: null
+plugin: local_tasks_block
+settings:
+  id: local_tasks_block
+  label: Tabs
+  provider: core
+  label_display: '0'
+  primary: true
+  secondary: true
+visibility: {  }

--- a/conf/drupal/config/block.block.hatter_tools.yml
+++ b/conf/drupal/config/block.block.hatter_tools.yml
@@ -1,0 +1,27 @@
+uuid: e8e04db6-1b1a-4fde-b223-9d034935d9d9
+langcode: en
+status: false
+dependencies:
+  config:
+    - system.menu.tools
+  module:
+    - system
+  theme:
+    - hatter
+_core:
+  default_config_hash: NeHSoqm4XFqA7_0bDmR429ZZQt3LRbZMNRJTMsFyOfI
+id: hatter_tools
+theme: hatter
+region: header
+weight: -6
+provider: null
+plugin: 'system_menu_block:tools'
+settings:
+  id: 'system_menu_block:tools'
+  label: Tools
+  provider: system
+  label_display: visible
+  level: 1
+  depth: 0
+  expand_all_items: false
+visibility: {  }

--- a/conf/drupal/config/block.block.hatter_training_feedback_form.yml
+++ b/conf/drupal/config/block.block.hatter_training_feedback_form.yml
@@ -1,0 +1,31 @@
+uuid: 91e782a8-6447-4967-94d3-8462bba9ddf3
+langcode: en
+status: true
+dependencies:
+  config:
+    - webform.webform.training_feedback_2019
+  module:
+    - system
+    - webform
+  theme:
+    - hatter
+id: hatter_training_feedback_form
+theme: hatter
+region: content
+weight: 0
+provider: null
+plugin: webform_block
+settings:
+  id: webform_block
+  label: 'Provide feedback on this training'
+  provider: webform
+  label_display: visible
+  webform_id: training_feedback_2019
+  default_data: ''
+  redirect: false
+visibility:
+  request_path:
+    id: request_path
+    pages: '/2019/training-proposal/*'
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__attendees_block_2.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__attendees_block_2.yml
@@ -1,0 +1,30 @@
+uuid: 3a159a59-24c5-4209-989e-4711aa050e48
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.attendees
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__attendees_block_2
+theme: hatter
+region: content
+weight: 5
+provider: null
+plugin: 'views_block:attendees-block_2'
+settings:
+  id: 'views_block:attendees-block_2'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility:
+  request_path:
+    id: request_path
+    pages: /2019/sponsors
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_news_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_news_block_1.yml
@@ -1,0 +1,24 @@
+uuid: 8f3c1b82-3371-44a1-bedd-b3b2de7b2da0
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.event_news
+  module:
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__event_news_block_1
+theme: hatter
+region: content
+weight: -11
+provider: null
+plugin: 'views_block:event_news-block_1'
+settings:
+  id: 'views_block:event_news-block_1'
+  label: ''
+  provider: views
+  label_display: '0'
+  views_label: ''
+  items_per_page: none
+visibility: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_1.yml
@@ -1,0 +1,31 @@
+uuid: cdde542a-c39f-4698-b02a-e6615aa130fc
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.event_sponsors
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__event_sponsors_block_1
+theme: hatter
+region: featured_bottom_second
+weight: -8
+provider: null
+plugin: 'views_block:event_sponsors-block_1'
+settings:
+  id: 'views_block:event_sponsors-block_1'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: "2018*\r\n<front>"
+    negate: true
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_10.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_10.yml
@@ -1,0 +1,31 @@
+uuid: 1acf7dcd-e933-4416-a89d-43c2521ef666
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.event_sponsors
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__event_sponsors_block_10
+theme: hatter
+region: content
+weight: -5
+provider: null
+plugin: 'views_block:event_sponsors-block_10'
+settings:
+  id: 'views_block:event_sponsors-block_10'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: /2020/sponsors
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_11.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_11.yml
@@ -1,0 +1,31 @@
+uuid: 899199a9-41ca-4dca-bd09-b101990af01b
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.event_sponsors
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__event_sponsors_block_11
+theme: hatter
+region: content
+weight: -4
+provider: null
+plugin: 'views_block:event_sponsors-block_11'
+settings:
+  id: 'views_block:event_sponsors-block_11'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: /2020/sponsors
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_2.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_2.yml
@@ -1,0 +1,31 @@
+uuid: bcd364d6-e7a7-4add-8453-a3d7386b89de
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.event_sponsors
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__event_sponsors_block_2
+theme: hatter
+region: content
+weight: -7
+provider: null
+plugin: 'views_block:event_sponsors-block_2'
+settings:
+  id: 'views_block:event_sponsors-block_2'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: "/2018/sponsors\r\n/2019/sponsors"
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_3.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_3.yml
@@ -1,0 +1,31 @@
+uuid: 446ba25a-294d-4f24-9a8c-e6b25c5fd0d4
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.event_sponsors
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__event_sponsors_block_3
+theme: hatter
+region: content
+weight: -6
+provider: null
+plugin: 'views_block:event_sponsors-block_3'
+settings:
+  id: 'views_block:event_sponsors-block_3'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: '/*/sponsors'
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_4.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_4.yml
@@ -1,0 +1,31 @@
+uuid: f3046b9e-1786-416b-9c23-3ba4fbe17cf9
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.event_sponsors
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__event_sponsors_block_4
+theme: hatter
+region: content
+weight: -10
+provider: null
+plugin: 'views_block:event_sponsors-block_4'
+settings:
+  id: 'views_block:event_sponsors-block_4'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: '/*/sponsors'
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_5.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_5.yml
@@ -1,0 +1,31 @@
+uuid: 14384ce3-51fd-4a61-85d2-227a4981a6d8
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.event_sponsors
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__event_sponsors_block_5
+theme: hatter
+region: content
+weight: -8
+provider: null
+plugin: 'views_block:event_sponsors-block_5'
+settings:
+  id: 'views_block:event_sponsors-block_5'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: "/2018/sponsors\r\n/2019/sponsors"
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_6.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_6.yml
@@ -1,0 +1,31 @@
+uuid: 63f53711-96ea-43eb-a883-6d99842c0b8f
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.event_sponsors
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__event_sponsors_block_6
+theme: hatter
+region: content
+weight: 4
+provider: null
+plugin: 'views_block:event_sponsors-block_6'
+settings:
+  id: 'views_block:event_sponsors-block_6'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: '/*/sponsors'
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_7.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_7.yml
@@ -1,0 +1,31 @@
+uuid: e0e0531e-56f4-4360-a987-a42d1e5fbf7d
+langcode: en
+status: false
+dependencies:
+  config:
+    - views.view.event_sponsors
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__event_sponsors_block_7
+theme: hatter
+region: content
+weight: 6
+provider: null
+plugin: 'views_block:event_sponsors-block_7'
+settings:
+  id: 'views_block:event_sponsors-block_7'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: '/*/sponsors'
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_8.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_8.yml
@@ -1,0 +1,31 @@
+uuid: 78112177-70ab-411d-94d7-baf556ba5aa4
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.event_sponsors
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__event_sponsors_block_8
+theme: hatter
+region: content
+weight: 3
+provider: null
+plugin: 'views_block:event_sponsors-block_8'
+settings:
+  id: 'views_block:event_sponsors-block_8'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: "/2018/sponsors\r\n/2019/sponsors"
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_9.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_9.yml
@@ -1,0 +1,31 @@
+uuid: 8ae4fcca-a1fa-4a4e-a528-144cbb9f8f37
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.event_sponsors
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__event_sponsors_block_9
+theme: hatter
+region: content
+weight: -9
+provider: null
+plugin: 'views_block:event_sponsors-block_9'
+settings:
+  id: 'views_block:event_sponsors-block_9'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: /2020/sponsors
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_sub_events_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sub_events_block_1.yml
@@ -1,0 +1,25 @@
+uuid: 4742a531-3d53-4cd0-baad-473e74c276ac
+langcode: en
+status: false
+dependencies:
+  config:
+    - views.view.event_sub_events
+  module:
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__event_sub_events_block_1
+theme: hatter
+region: featured_bottom_second
+weight: -9
+provider: null
+plugin: 'views_block:event_sub_events-block_1'
+settings:
+  id: 'views_block:event_sub_events-block_1'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_venue_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_venue_block_1.yml
@@ -1,0 +1,31 @@
+uuid: aa77c6dc-33de-45e3-91f0-c3d95d78bc36
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.event_venue
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__event_venue_block_1
+theme: hatter
+region: featured_bottom_first
+weight: 0
+provider: null
+plugin: 'views_block:event_venue-block_1'
+settings:
+  id: 'views_block:event_venue-block_1'
+  label: ''
+  provider: views
+  label_display: '0'
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: "/2019*\r\n<front>"
+    negate: true
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_venue_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_venue_block_1.yml
@@ -26,6 +26,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: "/2019*\r\n<front>"
+    pages: "/2019*\r\n/2020*\r\n/2021*\r\n<front>"
     negate: true
     context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__jobs_board_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__jobs_board_block_1.yml
@@ -1,0 +1,33 @@
+uuid: ed5b10cb-b80f-40cb-8a46-58aa2e716fec
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.jobs_board
+  module:
+    - ctools
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__jobs_board_block_1
+theme: hatter
+region: content
+weight: 1
+provider: null
+plugin: 'views_block:jobs_board-block_1'
+settings:
+  id: 'views_block:jobs_board-block_1'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    bundles:
+      sponsor: sponsor
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'

--- a/conf/drupal/config/block.block.hatter_views_block__speakers_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__speakers_block_1.yml
@@ -1,0 +1,30 @@
+uuid: 7d0e70f3-3c67-4f67-99de-37ac932fffa3
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.speakers
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__speakers_block_1
+theme: hatter
+region: content
+weight: -2
+provider: null
+plugin: 'views_block:speakers-block_1'
+settings:
+  id: 'views_block:speakers-block_1'
+  label: ''
+  provider: views
+  label_display: '0'
+  views_label: ''
+  items_per_page: none
+visibility:
+  request_path:
+    id: request_path
+    pages: '<front>'
+    negate: true
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__summits_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__summits_block_1.yml
@@ -1,0 +1,31 @@
+uuid: 67679fe0-0f2f-491b-a9a7-a7e578ccd36b
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.summits
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__summits_block_1
+theme: hatter
+region: content
+weight: 2
+provider: null
+plugin: 'views_block:summits-block_1'
+settings:
+  id: 'views_block:summits-block_1'
+  label: ''
+  provider: views
+  label_display: '0'
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: '/*/summits'
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__training_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__training_block_1.yml
@@ -1,0 +1,31 @@
+uuid: ac44576a-8cdf-456e-b16f-5984c8abd8af
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.training
+  module:
+    - system
+    - views
+  theme:
+    - hatter
+id: hatter_views_block__training_block_1
+theme: hatter
+region: content
+weight: -1
+provider: null
+plugin: 'views_block:training-block_1'
+settings:
+  id: 'views_block:training-block_1'
+  label: ''
+  provider: views
+  label_display: '0'
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  request_path:
+    id: request_path
+    pages: '/*/training'
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_webform.yml
+++ b/conf/drupal/config/block.block.hatter_webform.yml
@@ -1,0 +1,31 @@
+uuid: 3f7528fd-5c66-41eb-a583-c661ab7b58ce
+langcode: en
+status: true
+dependencies:
+  config:
+    - webform.webform.lightning_talk_sign_up
+  module:
+    - system
+    - webform
+  theme:
+    - hatter
+id: hatter_webform
+theme: hatter
+region: content
+weight: -3
+provider: null
+plugin: webform_block
+settings:
+  id: webform_block
+  label: 'Lightning Talk Sign Up'
+  provider: webform
+  label_display: visible
+  webform_id: lightning_talk_sign_up
+  default_data: ''
+  redirect: false
+visibility:
+  request_path:
+    id: request_path
+    pages: "/2018/topic-proposal/lightning-talks\r\n/2019/topic-proposal/lightning-talks"
+    negate: false
+    context_mapping: {  }

--- a/conf/drupal/config/block.block.midcamp2021_2.yml
+++ b/conf/drupal/config/block.block.midcamp2021_2.yml
@@ -19,7 +19,7 @@ settings:
   id: 'block_content:a54a0659-0ed4-46e8-afe3-55cdd97cd855'
   label: 'MidCamp 2021'
   provider: block_content
-  label_display: visible
+  label_display: '0'
   status: true
   info: ''
   view_mode: full

--- a/conf/drupal/config/block.block.midcamp2021_2.yml
+++ b/conf/drupal/config/block.block.midcamp2021_2.yml
@@ -1,31 +1,31 @@
-uuid: 8bbc83e7-c702-4722-b6f5-d7bd90be08ce
+uuid: 20197274-2705-4b17-b5b1-37eb8bb86e4f
 langcode: en
 status: true
 dependencies:
   content:
-    - 'block_content:basic:718a2f09-3a75-462a-9c04-3e21f78a81bb'
+    - 'block_content:basic:a54a0659-0ed4-46e8-afe3-55cdd97cd855'
   module:
     - block_content
     - system
   theme:
     - hatter
-id: hatter_midcamp2019
+id: midcamp2021_2
 theme: hatter
 region: content
-weight: -21
+weight: -20
 provider: null
-plugin: 'block_content:718a2f09-3a75-462a-9c04-3e21f78a81bb'
+plugin: 'block_content:a54a0659-0ed4-46e8-afe3-55cdd97cd855'
 settings:
-  id: 'block_content:718a2f09-3a75-462a-9c04-3e21f78a81bb'
-  label: 'MidCamp 2019'
+  id: 'block_content:a54a0659-0ed4-46e8-afe3-55cdd97cd855'
+  label: 'MidCamp 2021'
   provider: block_content
-  label_display: '0'
+  label_display: visible
   status: true
   info: ''
   view_mode: full
 visibility:
   request_path:
     id: request_path
-    pages: /2020
+    pages: '<front>'
     negate: false
     context_mapping: {  }

--- a/conf/drupal/config/block.block.midcamp2021navigation_2.yml
+++ b/conf/drupal/config/block.block.midcamp2021navigation_2.yml
@@ -1,0 +1,30 @@
+uuid: 7883d594-20a8-401d-980c-c04c6f3c9df1
+langcode: en
+status: true
+dependencies:
+  config:
+    - system.menu.midcamp-2021-navigation
+  module:
+    - system
+  theme:
+    - hatter
+id: midcamp2021navigation_2
+theme: hatter
+region: header
+weight: 0
+provider: null
+plugin: 'system_menu_block:midcamp-2021-navigation'
+settings:
+  id: 'system_menu_block:midcamp-2021-navigation'
+  label: 'Midcamp 2021 Navigation'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 2
+  expand_all_items: false
+visibility:
+  request_path:
+    id: request_path
+    pages: "/2018*\r\n/2019*\r\n/2020*"
+    negate: true
+    context_mapping: {  }

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -69,6 +69,7 @@ module:
   search: 0
   shortcut: 0
   simple_sitemap: 0
+  switch_page_theme: 0
   system: 0
   taxonomy: 0
   text: 0

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -97,4 +97,5 @@ theme:
   seven: 0
   hatter_base: 0
   hatter_2019: 0
+  hatter: 0
 profile: config_installer

--- a/conf/drupal/config/hatter.settings.yml
+++ b/conf/drupal/config/hatter.settings.yml
@@ -1,0 +1,10 @@
+features:
+  node_user_picture: 1
+  comment_user_picture: 1
+  comment_user_verification: 1
+  favicon: 1
+logo:
+  use_default: 0
+  path: themes/custom/hatter/logo.png
+favicon:
+  use_default: 1

--- a/conf/drupal/config/switch_page_theme.settings.yml
+++ b/conf/drupal/config/switch_page_theme.settings.yml
@@ -1,0 +1,16 @@
+spt_table:
+  -
+    status: '1'
+    pages: "/2020\r\n/2020*"
+    theme_key: ''
+    theme: hatter_2019
+    weight: '-10'
+    roles:
+      anonymous: 0
+      speaker: 0
+      content_editor: 0
+      administrator: 0
+      authenticated: 0
+      sponsor: 0
+      organizer: 0
+    remove: Remove

--- a/conf/drupal/config/system.theme.yml
+++ b/conf/drupal/config/system.theme.yml
@@ -1,4 +1,4 @@
 admin: seven
-default: hatter_2019
+default: hatter
 _core:
   default_config_hash: fOjer9hADYYnbCJVZMFZIIM1azTFWyg84ZkFDHfAbUg

--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -39,7 +39,7 @@ function hatter_theme_suggestions_user_alter(&$suggestions, $vars, $hook) {
  */
 function hatter_theme_suggestions_menu_alter(&$suggestions, $vars, $hook) {
   // Let the new menus use the existing template for now.
-  $menus = ['midcamp-2019-navigation', 'midcamp-2020-navigation'];
+  $menus = ['midcamp-2019-navigation', 'midcamp-2020-navigation', 'midcamp-2021-navigation'];
   if (in_array($vars['menu_name'], $menus)) {
     array_unshift($suggestions, 'menu__main');
   }

--- a/web/themes/custom/hatter/templates/block/block--system-branding-block.html.twig
+++ b/web/themes/custom/hatter/templates/block/block--system-branding-block.html.twig
@@ -27,8 +27,8 @@
             <h1 class="event__title">{{ site_name }}</h1>
           {% endif %}
           <h2 class="event__subtitle">{{ site_slogan }}</h2>
-          <a href="/submit-session" class="event__button button--primary">Submit a Session</a>
-          <a href="https://tickets.midcamp.org/" class="event__button button--primary">Buy a Ticket</a>
+          {# <a href="/submit-session" class="event__button button--primary">Submit a Session</a> #}
+          <a href="https://tickets.midcamp.org/" class="event__button button--primary">Donate</a>
         </div>
       </div>
     </div>

--- a/web/themes/custom/hatter/templates/block/block--system-branding-block.html.twig
+++ b/web/themes/custom/hatter/templates/block/block--system-branding-block.html.twig
@@ -28,7 +28,7 @@
           {% endif %}
           <h2 class="event__subtitle">{{ site_slogan }}</h2>
           {# <a href="/submit-session" class="event__button button--primary">Submit a Session</a> #}
-          <a href="https://tickets.midcamp.org/" class="event__button button--primary">Donate</a>
+          {# <a href="https://tickets.midcamp.org/" class="event__button button--primary">Donate</a> #}
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Description

Re-enables the old Hatter theme and sets it as the site default.  Introduces the [Switch Page Theme](https://www.drupal.org/project/switch_page_theme) module to leave the green "O'MidCamp" theme enabled on`/2020*` pages only.

# To test

- (Optional) Build locally
  - Install dependencies with `composer install`
  - Import configuration with `drush cim -y`
  - Follow the test instructions below with your local (using `midcamp.org.docker.amazee.io` URL)
- Visit the homepage (https://nginx.feature-theme-switching.midcamp-org.us2.amazee.io/) and observe the old theme is enabled.
- Visit 2021 event year pages like [`/2021/news`](https://nginx.feature-theme-switching.midcamp-org.us2.amazee.io/2021/news) or [`/2021/about`](https://nginx.feature-theme-switching.midcamp-org.us2.amazee.io/2021/about).  Observe the old theme is enabled.
- Visit 2020 event year pages like [`/2020/organizers`](https://nginx.feature-theme-switching.midcamp-org.us2.amazee.io/2020/organizers) or [`/2020/about`](https://nginx.feature-theme-switching.midcamp-org.us2.amazee.io/2020/about).  Observe the green theme is enabled.