### PR TITLE
Update menu block templates for correct camp dates.

### DIFF
--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -140,5 +140,12 @@ function hatter_preprocess_block(&$variables) {
   if ($variables['plugin_id'] == 'views_block:attendees-block_2') {
     $variables['attributes']['class'][] = 'sponsor-group';
   }
+
+  switch ($variables['plugin_id']) {
+    case 'system_menu_block:account':
+      $site_config = \Drupal::config('system.site');
+      $variables['site_slogan'] = $site_config->get('slogan');
+      break;
+  }
 }
 

--- a/web/themes/custom/hatter/templates/block/block--hatter-account-menu.html.twig
+++ b/web/themes/custom/hatter/templates/block/block--hatter-account-menu.html.twig
@@ -35,7 +35,7 @@
     <div class="top-header">
         <div class="container">
                 <div class="l-2up--1 camp-dates">
-                    <a href="/">Midwest Drupal Camp 2020 March 18-21 &mdash; Chicago, IL</a>
+                    <a href="/">Midwest Drupal Camp {{ site_slogan }}</a>
                 </div>
                 <div class="l-2up--2 user-menu">
                     <nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass(classes)|without('role', 'aria-labelledby') }}>

--- a/web/themes/custom/hatter_2019/templates/block/block--hatter-2019-account-menu.html.twig
+++ b/web/themes/custom/hatter_2019/templates/block/block--hatter-2019-account-menu.html.twig
@@ -35,7 +35,7 @@
     <div class="top-header">
         <div class="container">
                 <div class="l-2up--1 camp-dates">
-                    <a href="/">Midwest Drupal Camp 2020 March 19-21</a>
+                    <a href="/">Midwest Drupal Camp {{ site_slogan }}</a>
                 </div>
                 <div class="l-2up--2 user-menu">
                     <nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass(classes)|without('role', 'aria-labelledby') }}>

--- a/web/themes/custom/hatter_base/hatter_base.theme
+++ b/web/themes/custom/hatter_base/hatter_base.theme
@@ -150,4 +150,11 @@ function hatter_base_preprocess_block(&$variables) {
   if ($variables['plugin_id'] == 'views_block:attendees-block_2') {
     $variables['attributes']['class'][] = 'sponsor-group';
   }
+
+  switch ($variables['plugin_id']) {
+    case 'system_menu_block:account':
+      $site_config = \Drupal::config('system.site');
+      $variables['site_slogan'] = $site_config->get('slogan');
+      break;
+  }
 }

--- a/web/themes/custom/hatter_base/templates/block/block--hatter-account-menu.html.twig
+++ b/web/themes/custom/hatter_base/templates/block/block--hatter-account-menu.html.twig
@@ -35,7 +35,7 @@
     <div class="top-header">
         <div class="container">
                 <div class="l-2up--1 camp-dates">
-                    <a href="/">Midwest Drupal Camp 2020 March 19-21</a>
+                    <a href="/">Midwest Drupal Camp {{ site_slogan }}</a>
                 </div>
                 <div class="l-2up--2 user-menu">
                     <nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass(classes)|without('role', 'aria-labelledby') }}>


### PR DESCRIPTION
# Description

The `<front>` page uses the `site_slogan` to display the camp dates, whereas the region above header spelled this out in hard-coded twig markup.

This PR adds a twig variable `site_slogan` to these block templates and uses that to ensure we aren't hand entering dates in twig moving forward.

# To test

- Rebuild caches with `lando drush cr`
- Visit the following pages, and confirm they all show `Midwest Drupal Camp March 24 - 27, 2021`:
  - 2021 content: http://midcamp-org.lndo.site/2021/article/midcamp-back-march-24-27-2021
  - 2020 content: http://midcamp-org.lndo.site/2020
  - 2019 content: http://midcamp-org.lndo.site/2019

# Screenshots

![image](https://user-images.githubusercontent.com/4048700/106829767-6c953000-6652-11eb-9bd4-f148bf687b5e.png)

![image](https://user-images.githubusercontent.com/4048700/106829799-7d45a600-6652-11eb-8d0c-5fd228bc839d.png)

![image](https://user-images.githubusercontent.com/4048700/106829839-8c2c5880-6652-11eb-8212-bbc3489147a5.png)
