### PR TITLE
Update hard-coded term ID for prior event year.

### DIFF
--- a/web/modules/custom/midcamp_utility/midcamp_utility.module
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.module
@@ -37,7 +37,7 @@ function midcamp_utility_views_pre_view(ViewExecutable $view, $display_id, array
    * Ensure the Event Venue, Sponsors views get the correct argument when contextual filters not available.
    * Set `$event_default` to the current active event term ID.
    */
-  $event_default = '143';
+  $event_default = '231';
   $event_views = ['event_venue', 'event_sponsors'];
   if (in_array($view->id(), $event_views)) {
     // Determine what type of page we are on.
@@ -97,9 +97,9 @@ function midcamp_utility_entity_view_mode_alter(&$view_mode, Drupal\Core\Entity\
     if (isset($entity->_referringItem) && $parent_entity = $entity->_referringItem->getParent()->getEntity()) {
       $event = $parent_entity->get('field_event')->getValue();
       $event = reset($event);
-      // Check if we are on a 2020 Topic (identified by tid 143), and set the
+      // Check if we are on a 2021 Topic (identified by tid 231), and set the
       // view mode appropriately.
-      if ($event['target_id'] == '143') {
+      if ($event['target_id'] == '231') {
         $view_mode = 'topic_page';
       }
     }

--- a/web/modules/custom/midcamp_utility/midcamp_utility.module
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.module
@@ -97,9 +97,10 @@ function midcamp_utility_entity_view_mode_alter(&$view_mode, Drupal\Core\Entity\
     if (isset($entity->_referringItem) && $parent_entity = $entity->_referringItem->getParent()->getEntity()) {
       $event = $parent_entity->get('field_event')->getValue();
       $event = reset($event);
-      // Check if we are on a 2021 Topic (identified by tid 231), and set the
-      // view mode appropriately.
-      if ($event['target_id'] == '231') {
+      // Check if we are on a 2020 or 2021 Topic, and set the view mode
+      // appropriately.
+      $virtual_event_tids = ['143', '231'];
+      if (in_array($event['target_id'], $virtual_event_tids)) {
         $view_mode = 'topic_page';
       }
     }


### PR DESCRIPTION
# Description

- Updates `midcamp_utility.module`'s unfortunate instance of hard-coded contextual args to match the current event year's taxonomy term ID.
- Updates the hard-coded term ID controlling the `location` taxonomy's View Mode for virtual event years (which show a View mode containing the link to the room on Zoom or wherever)

Wiki updated at https://github.com/MidCamp/midcamp/wiki/Preparing-MidCamp.org-for-a-new-event-year#custom-code to ensure this doesn't get forgotten if it hasn't been refactored by next time.

# Test instructions

- Rebuild caches with `lando drush cr`
- Navigate to a page without contextual args, but with a year-based view, like http://midcamp-org.lndo.site/jobs.  Observe last year's sponsors are no longer displaying
- To test the `location` view mode logic, create a 2021 schedule and add some locations on the events, confirming the links to the Zoom meetings display here consistent with last year's display (see #340).