### PR TITLE
Update default event for 2021

### DIFF
--- a/web/modules/custom/midcamp_utility/midcamp_utility.module
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.module
@@ -37,7 +37,7 @@ function midcamp_utility_views_pre_view(ViewExecutable $view, $display_id, array
    * Ensure the Event Venue, Sponsors views get the correct argument when contextual filters not available.
    * Set `$event_default` to the current active event term ID.
    */
-  $event_default = '143';
+  $event_default = '234';
   $event_views = ['event_venue', 'event_sponsors'];
   if (in_array($view->id(), $event_views)) {
     // Determine what type of page we are on.


### PR DESCRIPTION
This should... theoretically... update the sponsor view on /jobs to reflect 2021's sponsors. (I've definitely not tested it yet)