### PR TITLE
Fix core sponsor block

### DIFF
--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_1.yml
@@ -5,7 +5,6 @@ dependencies:
   config:
     - views.view.event_sponsors
   module:
-    - system
     - views
   theme:
     - hatter
@@ -23,9 +22,4 @@ settings:
   views_label: ''
   items_per_page: none
   context_mapping: {  }
-visibility:
-  request_path:
-    id: request_path
-    pages: "2018*\r\n<front>"
-    negate: true
-    context_mapping: {  }
+visibility: {  }

--- a/web/modules/custom/midcamp_utility/midcamp_utility.module
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.module
@@ -37,7 +37,7 @@ function midcamp_utility_views_pre_view(ViewExecutable $view, $display_id, array
    * Ensure the Event Venue, Sponsors views get the correct argument when contextual filters not available.
    * Set `$event_default` to the current active event term ID.
    */
-  $event_default = '231';
+  $event_default = '234';
   $event_views = ['event_venue', 'event_sponsors'];
   if (in_array($view->id(), $event_views)) {
     // Determine what type of page we are on.
@@ -56,7 +56,7 @@ function midcamp_utility_views_pre_view(ViewExecutable $view, $display_id, array
         $tid = end($term_args);
         $view->setArguments([$tid]);
       } else {
-        // Otherwise default to the 2019 tid.
+        // Otherwise default to the 2021 tid.
         $view->setArguments([$event_default]);
       }
       return;


### PR DESCRIPTION
- Updates [custom code for targeting a default event tid](https://github.com/MidCamp/midcamp/wiki/Preparing-MidCamp.org-for-a-new-event-year#custom-code) to actually use the correct tid
- Updates the Core Sponsors block to display everywhere (this gets contextual args by year, so there shouldn't be any reason it can't display everywhere)