### PR TITLE
Export prod config.

### DIFF
--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_10.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_10.yml
@@ -26,6 +26,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: /2020/sponsors
+    pages: "/2020/sponsors\r\n/2021/sponsors"
     negate: false
     context_mapping: {  }

--- a/conf/drupal/config/block.block.midcamp2021_2.yml
+++ b/conf/drupal/config/block.block.midcamp2021_2.yml
@@ -1,6 +1,6 @@
 uuid: 20197274-2705-4b17-b5b1-37eb8bb86e4f
 langcode: en
-status: true
+status: false
 dependencies:
   content:
     - 'block_content:basic:a54a0659-0ed4-46e8-afe3-55cdd97cd855'

--- a/conf/drupal/config/views.view.sponsor_company_field_filter.yml
+++ b/conf/drupal/config/views.view.sponsor_company_field_filter.yml
@@ -6,7 +6,7 @@ dependencies:
     - node.type.sponsor
     - taxonomy.vocabulary.event
   content:
-    - 'taxonomy_term:event:17285735-fe51-4f45-b481-321ae7af649f'
+    - 'taxonomy_term:event:5c03697f-f030-4408-bc96-aaca0ee62b55'
   module:
     - node
     - taxonomy
@@ -151,7 +151,7 @@ display:
           admin_label: ''
           operator: or
           value:
-            97: 97
+            234: 234
           group: 1
           exposed: false
           expose:
@@ -160,6 +160,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -167,8 +169,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''


### PR DESCRIPTION
Prod config includes:

- Defaulting to latest Event taxonomy term year in `field_sponsor_company` (by way of the View `sponsor_company_field_filter` which provides the filter for this field)
- Disables the MidCamp 2021 teaser block previously present on `<front>`
- Places the Community Sponsors block on the `/2021/sponsors` route