### PR TITLE
Upgrade Webform per SA-CONTRIB-2021-004.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "drupal/video_embed_field": "^2.2",
         "drupal/video_embed_media": "^2.2",
         "drupal/viewsreference": "^1.0@alpha",
-        "drupal/webform": "^5.22",
+        "drupal/webform": "^5.25",
         "midcamp/hatter": "dev-master",
         "oomphinc/composer-installers-extender": "^1.1",
         "palantirnet/workbench_tabs": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "05069c108bf3d480d6903c942e5820f5",
+    "content-hash": "4faae867b0dd99970d6a162f716d61fc",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4424,17 +4424,17 @@
         },
         {
             "name": "drupal/webform",
-            "version": "5.22.0",
+            "version": "5.25.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/webform.git",
-                "reference": "8.x-5.22"
+                "reference": "8.x-5.25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/webform-8.x-5.22.zip",
-                "reference": "8.x-5.22",
-                "shasum": "807308bb8c57c3c66c7a839effc558ab2a76c1f5"
+                "url": "https://ftp.drupal.org/files/projects/webform-8.x-5.25.zip",
+                "reference": "8.x-5.25",
+                "shasum": "115f8bc21549abc080543eb772166eb4fd2a162e"
             },
             "require": {
                 "drupal/core": "^8.8"
@@ -4475,8 +4475,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-5.22",
-                    "datestamp": "1601919522",
+                    "version": "8.x-5.25",
+                    "datestamp": "1614873338",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -14209,12 +14209,12 @@
             "version": "1.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },

--- a/conf/drupal/config/webform.webform.contact.yml
+++ b/conf/drupal/config/webform.webform.contact.yml
@@ -145,6 +145,7 @@ settings:
   results_customize: false
   token_view: false
   token_update: false
+  token_delete: false
   serial_disabled: false
 access:
   create:
@@ -205,7 +206,7 @@ handlers:
     settings:
       states:
         - completed
-      to_mail: '[webform_submission:values:email:raw]'
+      to_mail: '[current-user:mail]'
       to_options: {  }
       cc_mail: ''
       cc_options: {  }

--- a/conf/drupal/config/webform.webform.lightning_talk_sign_up.yml
+++ b/conf/drupal/config/webform.webform.lightning_talk_sign_up.yml
@@ -142,6 +142,7 @@ settings:
   results_customize: false
   token_view: false
   token_update: false
+  token_delete: false
   serial_disabled: false
 access:
   create:

--- a/conf/drupal/config/webform.webform.midcamp_2018_survey.yml
+++ b/conf/drupal/config/webform.webform.midcamp_2018_survey.yml
@@ -142,6 +142,7 @@ settings:
   results_customize: false
   token_view: false
   token_update: false
+  token_delete: false
   serial_disabled: false
 access:
   create:

--- a/conf/drupal/config/webform.webform.midcamp_2019_survey.yml
+++ b/conf/drupal/config/webform.webform.midcamp_2019_survey.yml
@@ -142,6 +142,7 @@ settings:
   results_customize: false
   token_view: false
   token_update: false
+  token_delete: false
   serial_disabled: false
 access:
   create:

--- a/conf/drupal/config/webform.webform.midcamp_2020_survey.yml
+++ b/conf/drupal/config/webform.webform.midcamp_2020_survey.yml
@@ -142,6 +142,7 @@ settings:
   results_customize: false
   token_view: false
   token_update: false
+  token_delete: false
   serial_disabled: false
 access:
   create:

--- a/conf/drupal/config/webform.webform.midcamp_2021_survey.yml
+++ b/conf/drupal/config/webform.webform.midcamp_2021_survey.yml
@@ -142,6 +142,7 @@ settings:
   results_customize: false
   token_view: false
   token_update: false
+  token_delete: false
   serial_disabled: false
 access:
   create:

--- a/conf/drupal/config/webform.webform.movie_suggestions.yml
+++ b/conf/drupal/config/webform.webform.movie_suggestions.yml
@@ -142,6 +142,7 @@ settings:
   results_customize: false
   token_view: false
   token_update: false
+  token_delete: false
   serial_disabled: false
 access:
   create:

--- a/conf/drupal/config/webform.webform.room_monitor_checklist.yml
+++ b/conf/drupal/config/webform.webform.room_monitor_checklist.yml
@@ -142,6 +142,7 @@ settings:
   results_customize: false
   token_view: false
   token_update: false
+  token_delete: false
   serial_disabled: false
 access:
   create:

--- a/conf/drupal/config/webform.webform.session_feedback.yml
+++ b/conf/drupal/config/webform.webform.session_feedback.yml
@@ -144,6 +144,7 @@ settings:
   results_customize: false
   token_view: false
   token_update: false
+  token_delete: false
   serial_disabled: false
 access:
   create:

--- a/conf/drupal/config/webform.webform.tourism_quote.yml
+++ b/conf/drupal/config/webform.webform.tourism_quote.yml
@@ -142,6 +142,7 @@ settings:
   results_customize: false
   token_view: false
   token_update: false
+  token_delete: false
   serial_disabled: false
 access:
   create:

--- a/conf/drupal/config/webform.webform.training_feedback.yml
+++ b/conf/drupal/config/webform.webform.training_feedback.yml
@@ -142,6 +142,7 @@ settings:
   results_customize: false
   token_view: false
   token_update: false
+  token_delete: false
   serial_disabled: false
 access:
   create:

--- a/conf/drupal/config/webform.webform.training_feedback_2019.yml
+++ b/conf/drupal/config/webform.webform.training_feedback_2019.yml
@@ -142,6 +142,7 @@ settings:
   results_customize: false
   token_view: false
   token_update: false
+  token_delete: false
   serial_disabled: false
   form_login: false
   form_login_message: ''


### PR DESCRIPTION
# Description

Per https://www.drupal.org/sa-contrib-2021-004, upgrades the Webform module and exports updated configuration.

# Testing instructions

- Install dependencies with `lando composer install`
- Perform database updates with `lando drush updb -y`
- Import configuration with `lando drush cim -y`
- Confirm webform functionality is not impacted