### PR TITLE
#3202165 Organizer Page updates

### DIFF
--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_3.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_3.yml
@@ -26,6 +26,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: '/*/sponsors'
+    pages: "/2018/sponsors\r\n/2019/sponsors\r\n/2020/sponsors"
     negate: false
     context_mapping: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_9.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_9.yml
@@ -26,6 +26,6 @@ settings:
 visibility:
   request_path:
     id: request_path
-    pages: /2020/sponsors
+    pages: "/2020/sponsors\r\n/2021/sponsors"
     negate: false
     context_mapping: {  }

--- a/conf/drupal/config/core.entity_form_display.user.user.default.yml
+++ b/conf/drupal/config/core.entity_form_display.user.user.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.user.user.field_company_url
     - field.field.user.user.field_do_profile
     - field.field.user.user.field_eventbrite_email
+    - field.field.user.user.field_leadership_year
     - field.field.user.user.field_mailing_list
     - field.field.user.user.field_name
     - field.field.user.user.field_organization
@@ -148,6 +149,16 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: email_default
+    region: content
+  field_leadership_year:
+    weight: 21
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
     region: content
   field_mailing_list:
     weight: 5

--- a/conf/drupal/config/core.entity_view_display.user.user.compact.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.compact.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.user.user.field_company_url
     - field.field.user.user.field_do_profile
     - field.field.user.user.field_eventbrite_email
+    - field.field.user.user.field_leadership_year
     - field.field.user.user.field_mailing_list
     - field.field.user.user.field_name
     - field.field.user.user.field_organization
@@ -86,6 +87,7 @@ hidden:
   field_company_url: true
   field_do_profile: true
   field_eventbrite_email: true
+  field_leadership_year: true
   field_mailing_list: true
   field_organizer_year: true
   field_site: true

--- a/conf/drupal/config/core.entity_view_display.user.user.default.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.default.yml
@@ -8,6 +8,7 @@ dependencies:
     - field.field.user.user.field_company_url
     - field.field.user.user.field_do_profile
     - field.field.user.user.field_eventbrite_email
+    - field.field.user.user.field_leadership_year
     - field.field.user.user.field_mailing_list
     - field.field.user.user.field_name
     - field.field.user.user.field_organization
@@ -130,6 +131,7 @@ content:
 hidden:
   field_company_url: true
   field_eventbrite_email: true
+  field_leadership_year: true
   field_mailing_list: true
   field_organizer_year: true
   member_for: true

--- a/conf/drupal/config/core.entity_view_display.user.user.email.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.email.yml
@@ -5,12 +5,15 @@ dependencies:
   config:
     - core.entity_view_mode.user.email
     - field.field.user.user.field_bio
+    - field.field.user.user.field_company_logo
     - field.field.user.user.field_company_url
     - field.field.user.user.field_do_profile
     - field.field.user.user.field_eventbrite_email
+    - field.field.user.user.field_leadership_year
     - field.field.user.user.field_mailing_list
     - field.field.user.user.field_name
     - field.field.user.user.field_organization
+    - field.field.user.user.field_organizer_year
     - field.field.user.user.field_site
     - field.field.user.user.field_title
     - field.field.user.user.field_tracks
@@ -34,11 +37,14 @@ content:
     third_party_settings: {  }
 hidden:
   field_bio: true
+  field_company_logo: true
   field_company_url: true
   field_do_profile: true
+  field_leadership_year: true
   field_mailing_list: true
   field_name: true
   field_organization: true
+  field_organizer_year: true
   field_site: true
   field_title: true
   field_tracks: true

--- a/conf/drupal/config/core.entity_view_display.user.user.featured_speaker.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.featured_speaker.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.user.user.field_company_url
     - field.field.user.user.field_do_profile
     - field.field.user.user.field_eventbrite_email
+    - field.field.user.user.field_leadership_year
     - field.field.user.user.field_mailing_list
     - field.field.user.user.field_name
     - field.field.user.user.field_organization
@@ -88,6 +89,7 @@ hidden:
   field_company_logo: true
   field_do_profile: true
   field_eventbrite_email: true
+  field_leadership_year: true
   field_mailing_list: true
   field_organizer_year: true
   field_site: true

--- a/conf/drupal/config/core.entity_view_display.user.user.schedule.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.schedule.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.user.user.field_company_url
     - field.field.user.user.field_do_profile
     - field.field.user.user.field_eventbrite_email
+    - field.field.user.user.field_leadership_year
     - field.field.user.user.field_mailing_list
     - field.field.user.user.field_name
     - field.field.user.user.field_organization
@@ -76,6 +77,7 @@ hidden:
   field_company_url: true
   field_do_profile: true
   field_eventbrite_email: true
+  field_leadership_year: true
   field_mailing_list: true
   field_organizer_year: true
   field_site: true

--- a/conf/drupal/config/core.entity_view_display.user.user.socials.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.socials.yml
@@ -9,6 +9,7 @@ dependencies:
     - field.field.user.user.field_company_url
     - field.field.user.user.field_do_profile
     - field.field.user.user.field_eventbrite_email
+    - field.field.user.user.field_leadership_year
     - field.field.user.user.field_mailing_list
     - field.field.user.user.field_name
     - field.field.user.user.field_organization
@@ -57,6 +58,7 @@ hidden:
   field_company_url: true
   field_do_profile: true
   field_eventbrite_email: true
+  field_leadership_year: true
   field_mailing_list: true
   field_organization: true
   field_organizer_year: true

--- a/conf/drupal/config/core.menu.static_menu_link_overrides.yml
+++ b/conf/drupal/config/core.menu.static_menu_link_overrides.yml
@@ -5,5 +5,17 @@ definitions:
     parent: ''
     expanded: false
     weight: 0
+  user__page:
+    weight: -50
+    menu_name: account
+    parent: ''
+    enabled: true
+    expanded: false
+  user__logout:
+    weight: -49
+    menu_name: account
+    parent: ''
+    expanded: false
+    enabled: true
 _core:
   default_config_hash: jdY7AU0tU-QsjmiOw3W8vwpYMb-By--_MSFgbqKUTYM

--- a/conf/drupal/config/field.field.user.user.field_leadership_year.yml
+++ b/conf/drupal/config/field.field.user.user.field_leadership_year.yml
@@ -1,0 +1,30 @@
+uuid: 92553c66-62eb-4434-bac6-1bfbc5731877
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.user.field_leadership_year
+    - taxonomy.vocabulary.event
+  module:
+    - user
+id: user.user.field_leadership_year
+field_name: field_leadership_year
+entity_type: user
+bundle: user
+label: 'Leadership Year'
+description: 'Select the events for which this user has been on the leadership team. '
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      event: event
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/drupal/config/field.storage.user.field_leadership_year.yml
+++ b/conf/drupal/config/field.storage.user.field_leadership_year.yml
@@ -1,0 +1,24 @@
+uuid: dc955887-8096-4d0f-90e9-8feacacdc61c
+langcode: en
+status: true
+dependencies:
+  module:
+    - field_permissions
+    - taxonomy
+    - user
+third_party_settings:
+  field_permissions:
+    permission_type: custom
+id: user.field_leadership_year
+field_name: field_leadership_year
+entity_type: user
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/drupal/config/views.view.organizers.yml
+++ b/conf/drupal/config/views.view.organizers.yml
@@ -223,6 +223,121 @@ display:
         - user
         - user.permissions
       tags: {  }
+  attachment_1:
+    display_plugin: attachment
+    id: attachment_1
+    display_title: '20201 Leadership Attachment'
+    position: 5
+    display_options:
+      display_extenders: {  }
+      displays:
+        page_4: page_4
+      filters:
+        status:
+          value: '1'
+          table: users_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: user
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+          group: 1
+        field_leadership_year_target_id:
+          id: field_leadership_year_target_id
+          table: user__field_leadership_year
+          field: field_leadership_year_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value:
+            - 234
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: textfield
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+      defaults:
+        filters: false
+        filter_groups: false
+        header: false
+        footer: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content:
+            value: "<h2>Leadership</h2>\r\n<p>MidCamp is organized by a group of volunteers from the Drupal community in Chicago, and beyond!</p>"
+            format: basic_html
+          plugin_id: text
+      footer:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content:
+            value: '<h2>Organizers</h2>'
+            format: basic_html
+          plugin_id: text
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - user.permissions
+      tags: {  }
   page_1:
     display_plugin: page
     id: page_1
@@ -492,9 +607,56 @@ display:
           hierarchy: false
           error_message: true
           plugin_id: taxonomy_index_tid
+        field_leadership_year_target_id:
+          id: field_leadership_year_target_id
+          table: user__field_leadership_year
+          field: field_leadership_year_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: not
+          value:
+            - 234
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: textfield
+          limit: true
+          vid: event
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
       defaults:
         filters: false
         filter_groups: false
+        header: false
       filter_groups:
         operator: AND
         groups:
@@ -509,6 +671,20 @@ display:
         context: '0'
         menu_name: midcamp-2021-navigation
       display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: false
+          tokenize: false
+          content:
+            value: ''
+            format: basic_html
+          plugin_id: text
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.organizers.yml
+++ b/conf/drupal/config/views.view.organizers.yml
@@ -313,7 +313,7 @@ display:
           empty: false
           tokenize: false
           content:
-            value: "<h2>Leadership</h2>\r\n<p>MidCamp is organized by a group of volunteers from the Drupal community in Chicago, and beyond!</p>"
+            value: '<h2>Leadership</h2>'
             format: basic_html
           plugin_id: text
       footer:
@@ -682,7 +682,7 @@ display:
           empty: false
           tokenize: false
           content:
-            value: ''
+            value: '<p>MidCamp is organized by a group of volunteers from the Drupal community in Chicago, and beyond!</p>'
             format: basic_html
           plugin_id: text
     cache_metadata:


### PR DESCRIPTION
# Satisfies

[Rearrange Organizer Page #3202165](https://www.drupal.org/project/midcamp/issues/3202165)

# Description

- Exports production config
- Adds `field_leadership_year` to the `User` entity.  This is an entity reference field, targeting `event` terms consistent with how `field_organizer_year` is currently configured.
- Adds a Views attachment to the `organizers` View to show Leaders for a given year.
- Updates the `organizers` View to omit users who are both Organizers and Leaders to prevent them from displaying twice

# Test instructions

- Import configuration changes with `lando drush cim -y`
- Navigate to http://midcamp-org.lndo.site/admin/people and assign some users the `MidCamp 2021` value in `field_leadership_year`
- Navigate to http://midcamp-org.lndo.site/2021/organizers.  Observe these users appear in the upper "Leadership" portion of the page.  Observe they do not appear below with the rest of the Organizing team

# Screenshots

<img width="1676" alt="image" src="https://user-images.githubusercontent.com/4048700/110957383-2d24c800-8311-11eb-886d-1612eecf7387.png">

