### PR TITLE
Quick fix for sponsor images being cut off

### DIFF
--- a/web/themes/custom/hatter/hatter.libraries.yml
+++ b/web/themes/custom/hatter/hatter.libraries.yml
@@ -4,6 +4,7 @@ global-css:
       css/print.css:
         media: print
       css/styles.css: {}
+      port-to-hatter-v2.css: {}
 global-js:
   js:
     js/site.js: {}

--- a/web/themes/custom/hatter/port-to-hatter-v2.css
+++ b/web/themes/custom/hatter/port-to-hatter-v2.css
@@ -1,0 +1,5 @@
+/* aka shame.css */
+
+.sponsor-item, .sponsor-item img {
+  display: inline-grid;
+}


### PR DESCRIPTION
This is a really hacky fix, but I haven't finished this PR https://github.com/MidCamp/hatter-v2/pull/19 that will allow us to use hatter V2 with the default color scheme. Rather than touch the original Hatter, I created a css file with this fix that makes it clear that it will need to be ported in the future. Perfectly reasonable fix for a week out from camp :)