### PR TITLE
Fix Views Paragraphs

### DIFF
--- a/conf/drupal/config/core.entity_form_display.paragraph.view.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.view.default.yml
@@ -1,0 +1,27 @@
+uuid: 2e813d8c-8f5c-4fd3-8587-1d07606592bc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.view.field_view
+    - paragraphs.paragraphs_type.view
+  module:
+    - viewsreference
+id: paragraph.view.default
+targetEntityType: paragraph
+bundle: view
+mode: default
+content:
+  field_view:
+    type: viewsreference_autocomplete
+    weight: 0
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  status: true

--- a/conf/drupal/config/field.field.paragraph.view.field_view.yml
+++ b/conf/drupal/config/field.field.paragraph.view.field_view.yml
@@ -19,8 +19,60 @@ default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:view'
-  handler_settings: {  }
+  handler_settings:
+    target_bundles: null
+    auto_create: 0
   plugin_types:
     block: block
-  preselect_views: {  }
+    page: page
+    default: 0
+    feed: 0
+    attachment: 0
+    entity_reference: 0
+    embed: 0
+  preselect_views:
+    attendees: 0
+    attendees_2020: 0
+    block_content: 0
+    comment: 0
+    comments_recent: 0
+    content: 0
+    content_recent: 0
+    drupal_planet: 0
+    event_news: 0
+    event_sponsors: 0
+    event_sub_events: 0
+    event_venue: 0
+    files: 0
+    jobs_board: 0
+    live_sessions: 0
+    media: 0
+    media_library: 0
+    news: 0
+    organizers: 0
+    random_session: 0
+    redirect: 0
+    schedule: 0
+    scheduler_scheduled_content: 0
+    schedule_2019: 0
+    schedule_2020: 0
+    schedule_2021: 0
+    sessions: 0
+    sessions_export: 0
+    session_feedback: 0
+    session_management: 0
+    session_selection: 0
+    speakers: 0
+    sponsor_company_field_filter: 0
+    summits: 0
+    survey_filters: 0
+    topics_: 0
+    training: 0
+    trainings: 0
+    user_admin_people: 0
+    user_entityreference: 0
+    watchdog: 0
+    webform_submissions: 0
+    who_s_new: 0
+    who_s_online: 0
 field_type: viewsreference

--- a/conf/drupal/config/field.storage.paragraph.field_view.yml
+++ b/conf/drupal/config/field.storage.paragraph.field_view.yml
@@ -3,9 +3,13 @@ langcode: en
 status: true
 dependencies:
   module:
+    - field_permissions
     - paragraphs
     - views
     - viewsreference
+third_party_settings:
+  field_permissions:
+    permission_type: public
 id: paragraph.field_view
 field_name: field_view
 entity_type: paragraph


### PR DESCRIPTION
# Motivation

Allows Views to be embedded in Paragraphs.

# Description 

- Updates Paragraph type `view` form display (at `/admin/structure/paragraphs_type/view/form-display`) to enable the "View" field (previously disabled entirely, leaving no fields present here at all).
- Updates Paragraph type `view` `field_view` settings to allow referencing both Block as well as Page View displays

# Test instructions

(Optionally test this here: https://nginx.feature-fix-views-paragraphs.midcamp-org.us2.amazee.io/2021/building-community-day, but note the schedule for 2021 does not have published content to support it)

- Import configuration with `lando drush cim -y`
- Navigate to a basic page node add/edit form
- Click "Add View" in the Paragraph field.  Observe you now have an autocomplete field to specify the View you are trying to embed.

![image](https://user-images.githubusercontent.com/4048700/111625047-6d28f680-87ba-11eb-9024-a196cb22f275.png)
