### PR TITLE
#3204814: Backport schedule linking to Hatter theme.

### DIFF
--- a/web/modules/custom/midcamp_utility/midcamp_utility.module
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.module
@@ -99,7 +99,7 @@ function midcamp_utility_entity_view_mode_alter(&$view_mode, Drupal\Core\Entity\
       $event = reset($event);
       // Check if we are on a 2020 or 2021 Topic, and set the view mode
       // appropriately.
-      $virtual_event_tids = ['143', '231'];
+      $virtual_event_tids = ['143', '234'];
       if (in_array($event['target_id'], $virtual_event_tids)) {
         $view_mode = 'topic_page';
       }

--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -10,6 +10,13 @@
  */
 function hatter_theme_suggestions_taxonomy_term_alter(&$suggestions, $vars, $hook) {
   $suggestions[] = 'taxonomy_term__' . $vars['elements']['#view_mode'];
+  // Include bundles and view modes in template suggestions.
+  $element = $vars['elements'];
+  /** @var \Drupal\taxonomy\Entity\Term $term */
+  $term = $element['#taxonomy_term'];
+  $view_mode = $element['#view_mode'];
+  $bundle = $term->bundle();
+  $suggestions[] = 'taxonomy_term__' . $bundle . '__' . $view_mode;
 }
 
 /**
@@ -118,6 +125,19 @@ function hatter_preprocess_field(array &$variables, $hook) {
       if ($variables['entity_type'] == 'node' && $variables['element']['#bundle'] == 'topic') {
         foreach ($variables['items'] as $index => $item) {
           $variables['items'][$index]['content']['#title'] = 'View Transcript';
+        }
+      }
+      break;
+    case 'field_link':
+      // Add button class to `field_link` for `location` terms' `topic_page`
+      // display.
+      if (
+        $variables['entity_type'] == 'taxonomy_term'
+        && $variables['element']['#bundle'] == 'location'
+        && $variables['element']['#view_mode'] == 'topic_page'
+      ) {
+        foreach (\Drupal\Core\Render\Element::children($variables['element']) as $id) {
+          $variables['items'][$id]['content']['#options']['attributes']['class'][] = 'button--primary';
         }
       }
       break;

--- a/web/themes/custom/hatter/templates/term/taxonomy-term--location--topic-page.html.twig
+++ b/web/themes/custom/hatter/templates/term/taxonomy-term--location--topic-page.html.twig
@@ -1,0 +1,15 @@
+{%
+  set classes = [
+  'taxonomy-term',
+  'vocabulary-' ~ term.bundle|clean_class,
+]
+%}
+<div{{ attributes.setAttribute('id', 'taxonomy-term-' ~ term.id).addClass(classes) }}>
+  <div class="content">
+    {% if content.field_link|render %}
+      {{ content }}
+    {% else %}
+      {{ name }}
+    {% endif %}
+  </div>
+</div>

--- a/web/themes/custom/hatter/templates/term/taxonomy-term--location.html.twig
+++ b/web/themes/custom/hatter/templates/term/taxonomy-term--location.html.twig
@@ -1,0 +1,16 @@
+{%
+  set classes = [
+  'taxonomy-term',
+  'vocabulary-' ~ term.bundle|clean_class,
+]
+%}
+<div{{ attributes.setAttribute('id', 'taxonomy-term-' ~ term.id).addClass(classes) }}>
+  {{ title_prefix }}
+  {% if not page %}
+    {{ name }}
+  {% endif %}
+  {{ title_suffix }}
+  <div class="content">
+    {{ content }}
+  </div>
+</div>


### PR DESCRIPTION
# Motivation / Description

Satisfies https://www.drupal.org/project/midcamp/issues/3204814.

Back-ports the logic in #340 to the legacy Hatter theme, which is seeing life once more in 2021.

# Test instructions

- Rebuild caches with `lando drush cr`
- Assign a 2021 Topic Proposal node (like http://midcamp-org.lndo.site/2021/topic-proposal/drupal-core-testing-nightwatch-getting-and-running) a "Location" term.  Observe:
    - If the Location term has no link, the Topic node will display the room name
    - If the Location term has a link, the Topic node will display a button to visit that link

# Screenshots

## Location with no link

![image](https://user-images.githubusercontent.com/4048700/112074535-84623e00-8b44-11eb-84c4-dbd01675bf4c.png)

## Location with link

![image](https://user-images.githubusercontent.com/4048700/112074763-00f51c80-8b45-11eb-9fc3-5f3eb2e0b7dd.png)
