### PR TITLE
Post camp

### DIFF
--- a/conf/drupal/config/block.block.views_block__live_sessions_block_1_2.yml
+++ b/conf/drupal/config/block.block.views_block__live_sessions_block_1_2.yml
@@ -1,6 +1,6 @@
 uuid: 78545a0e-2791-4e81-a66e-c6cfe8867c3d
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - views.view.live_sessions

--- a/conf/drupal/config/core.menu.static_menu_link_overrides.yml
+++ b/conf/drupal/config/core.menu.static_menu_link_overrides.yml
@@ -12,10 +12,10 @@ definitions:
     enabled: true
     expanded: false
   user__logout:
-    weight: -49
+    enabled: false
     menu_name: account
     parent: ''
     expanded: false
-    enabled: true
+    weight: -49
 _core:
   default_config_hash: jdY7AU0tU-QsjmiOw3W8vwpYMb-By--_MSFgbqKUTYM

--- a/conf/drupal/config/user.settings.yml
+++ b/conf/drupal/config/user.settings.yml
@@ -9,7 +9,7 @@ notify:
   register_admin_created: true
   register_no_approval_required: true
   register_pending_approval: true
-register: visitors_admin_approval
+register: admin_only
 cancel_method: user_cancel_block_unpublish
 password_reset_timeout: 86400
 password_strength: true

--- a/conf/drupal/config/views.view.schedule_2021.yml
+++ b/conf/drupal/config/views.view.schedule_2021.yml
@@ -444,9 +444,9 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: target_id
-          type: entity_reference_label
+          type: entity_reference_entity_view
           settings:
-            link: false
+            view_mode: topic_page
           group_column: target_id
           group_columns: {  }
           group_rows: true

--- a/web/themes/custom/hatter/templates/block/block--system-branding-block.html.twig
+++ b/web/themes/custom/hatter/templates/block/block--system-branding-block.html.twig
@@ -28,7 +28,7 @@
           {% endif %}
           <h2 class="event__subtitle">{{ site_slogan }}</h2>
           {# <a href="/submit-session" class="event__button button--primary">Submit a Session</a> #}
-          <a href="https://mid.camp/tickets/" class="event__button button--primary">Register</a>
+          {# <a href="https://mid.camp/tickets/" class="event__button button--primary">Register</a> #}
         </div>
       </div>
     </div>


### PR DESCRIPTION
# Description 

- Exports post-camp production config
- Disables the homepage CTA (currently a "register" link)

# Test instructions

_Test instructions below are for local testing.  Alternatively, test in the remote environment at https://nginx.feature-post-camp.midcamp-org.us2.amazee.io/_

- Import config with `lando drush cim -y`
- Rebuild caches with `lando drush cr`
- Navigate to the home page.  Observe the "Register" link is no longer present.