### PR TITLE
3252659: Correct config directory syntax.

### DIFF
--- a/web/sites/default/all.settings.php
+++ b/web/sites/default/all.settings.php
@@ -10,7 +10,7 @@
 
 // Defines where the sync folder of your configuration lives. In this case it's outside
 // the web folder for an advanced security measure: '../config/sync'.
-$config_directories['sync'] = '../conf/drupal/config';
+$settings['config_sync_directory'] = '../conf/drupal/config';
 $settings['install_profile'] = 'config_installer';
 $settings['file_private_path'] = 'sites/default/files/private';
 


### PR DESCRIPTION
## Issue

[#3252659 Correct deprecated use of $config_directories in settings.php](https://www.drupal.org/project/midcamp/issues/3252659)

## Description 

Per https://www.drupal.org/node/3018145, `$config_directories['sync']` has become deprecated, to be replaced by syntax like `$settings['config_sync_directory']`.

## Test instructions

- Rebuild caches with `lando drush cr`
- Visit the Upgrade Status report at http://midcamp-org.lndo.site/admin/reports/upgrade-status.  Observe the `Use of $config_directories in settings.php is deprecated.` requirement shows a green status.
- Attempt to export and import configuration.  Observe that this is successful.