### PR TITLE
3252658: Additional D9 module upgrades

### DIFF
--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -2,10 +2,11 @@ FROM amazeeio/node:10-builder as builder
 COPY package.json package-lock.json /app/
 COPY ./web/themes/custom/hatter_2019 /app/web/themes/custom/hatter_2019
 RUN npm ci
-FROM amazeeio/php:7.4-cli-drupal
+FROM uselagoon/php-7.4-cli-drupal
 
 RUN composer selfupdate --2
 COPY composer.json composer.lock /app/
+COPY patches /app/patches
 RUN composer install --prefer-dist --no-dev --no-suggest --optimize-autoloader --apcu-autoloader
 
 COPY . /app

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "drupal/name": "^1.0",
         "drupal/paragraphs": "^1.12",
         "drupal/pathauto": "^1.8",
-        "drupal/r4032login": "1.x-dev",
+        "drupal/r4032login": "^2.1",
         "drupal/recaptcha": "^3.0",
         "drupal/redirect": "^1.0",
         "drupal/scheduler": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -99,27 +99,42 @@
     },
     "extra": {
         "patches": {
-          "drupal/mailchimp": {
-            "MailchimpListsSubscribeForm wants an array, but gets an object (www.drupal.org/project/mailchimp/issues/2931408)": "https://www.drupal.org/files/issues/2931408-2-list-form-cant-array.patch"
-          },
-          "drupal/libraries": {
-              "Missing global variable $base_theme_info [#3057777]": "https://www.drupal.org/files/issues/2019-06-26/missing_base_theme_info_global_variable-3057777-4.patch"
-          },
-          "drupal/scheduler": {
-              "Add Drush 10 support [#3169731]": "https://www.drupal.org/files/issues/2020-09-08/3169731-2.drush10.patch"
-          },
-          "drupal/entity_reference_revisions": {
-              "composer.json is missing extra.drush.services section [#3225141]": "https://www.drupal.org/files/issues/2021-07-23/entity_reference_revisions_composer.patch"
-          }
+            "drupal/mailchimp": {
+                "MailchimpListsSubscribeForm wants an array, but gets an object (www.drupal.org/project/mailchimp/issues/2931408)": "https://www.drupal.org/files/issues/2931408-2-list-form-cant-array.patch",
+                "Ensure missing API keys in lower environments don't break the site": "patches/mailchimp-prevent-wsod-missing-keys.patch"
+            },
+            "drupal/libraries": {
+                "Missing global variable $base_theme_info [#3057777]": "https://www.drupal.org/files/issues/2019-06-26/missing_base_theme_info_global_variable-3057777-4.patch"
+            },
+            "drupal/scheduler": {
+                "Add Drush 10 support [#3169731]": "https://www.drupal.org/files/issues/2020-09-08/3169731-2.drush10.patch"
+            },
+            "drupal/entity_reference_revisions": {
+                "composer.json is missing extra.drush.services section [#3225141]": "https://www.drupal.org/files/issues/2021-07-23/entity_reference_revisions_composer.patch"
+            }
         },
-        "installer-types": ["butler-styleguide"],
+        "installer-types": [
+            "butler-styleguide"
+        ],
         "installer-paths": {
-            "web/core": ["type:drupal-core"],
-            "web/modules/contrib/{$name}": ["type:drupal-module"],
-            "web/profiles/contrib/{$name}": ["type:drupal-profile"],
-            "web/themes/contrib/{$name}": ["type:drupal-theme"],
-            "drush/Commands/contrib/{$name}": ["type:drupal-drush"],
-            "styleguide": ["type:butler-styleguide"]
+            "web/core": [
+                "type:drupal-core"
+            ],
+            "web/modules/contrib/{$name}": [
+                "type:drupal-module"
+            ],
+            "web/profiles/contrib/{$name}": [
+                "type:drupal-profile"
+            ],
+            "web/themes/contrib/{$name}": [
+                "type:drupal-theme"
+            ],
+            "drush/Commands/contrib/{$name}": [
+                "type:drupal-drush"
+            ],
+            "styleguide": [
+                "type:butler-styleguide"
+            ]
         },
         "drupal-scaffold": {
             "locations": {

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "drupal/scheduler": "^1.3",
         "drupal/simple_sitemap": "^3.8",
         "drupal/switch_page_theme": "1.x-dev",
-        "drupal/twig_extensions": "1.x-dev",
+        "drupal/twig_extensions": "2.x-dev",
         "drupal/upgrade_status": "^3.10",
         "drupal/video_embed_field": "^2.4",
         "drupal/viewsreference": "^1.7",
@@ -99,9 +99,6 @@
     },
     "extra": {
         "patches": {
-          "drupal/twig_extensions": {
-            "Error after upgrading to Drupal 8.1 (https://www.drupal.org/project/twig_extensions/issues/2726531)": "https://www.drupal.org/files/issues/error_after_upgrading-2726531-9.patch"
-          },
           "drupal/mailchimp": {
             "MailchimpListsSubscribeForm wants an array, but gets an object (www.drupal.org/project/mailchimp/issues/2931408)": "https://www.drupal.org/files/issues/2931408-2-list-form-cant-array.patch"
           },

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         }
     },
     "require": {
-        "brian-clement/eventbrite_events": "dev-master",
+        "brian-clement/eventbrite_events": "^1.0",
         "brian-clement/tito": "dev-master",
         "composer/installers": "^1.9",
         "cweagans/composer-patches": "^1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "74b10ab83ec531c4f745b67947ab6f45",
+    "content-hash": "622db8199596a66d9fa1d5c514fee23c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3866,31 +3866,28 @@
         },
         {
             "name": "drupal/twig_extensions",
-            "version": "dev-1.x",
+            "version": "dev-2.x",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/twig_extensions.git",
-                "reference": "2e73803b1dd4e05b8e268d991518416ae49e6455"
+                "reference": "35e09f8ff9d4fc2409326f4348321f4799b7d5aa"
             },
             "require": {
-                "drupal/core": "~8.0",
+                "drupal/core": "^8 || ^9",
                 "twig/extensions": "^1.3"
             },
             "type": "drupal-module",
             "extra": {
                 "branch-alias": {
-                    "dev-1.x": "1.x-dev"
+                    "dev-2.x": "2.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.x-dev",
-                    "datestamp": "1534896480",
+                    "version": "8.x-2.0+3-dev",
+                    "datestamp": "1591199111",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Dev releases are not covered by Drupal security advisories."
                     }
-                },
-                "patches_applied": {
-                    "Error after upgrading to Drupal 8.1 (https://www.drupal.org/project/twig_extensions/issues/2726531)": "https://www.drupal.org/files/issues/error_after_upgrading-2726531-9.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -3904,15 +3901,14 @@
                 }
             ],
             "description": "Twig Extensions",
-            "homepage": "http://drupal.org/project/twig_extensions",
+            "homepage": "https://www.drupal.org/project/twig_extensions",
             "keywords": [
                 "Drupal"
             ],
             "support": {
-                "source": "http://cgit.drupalcode.org/twig_extensions",
-                "issues": "http://drupal.org/project/issues/twig_extensions"
-            },
-            "time": "2018-08-22T00:02:56+00:00"
+                "source": "https://git.drupalcode.org/project/twig_extensions",
+                "issues": "https://www.drupal.org/project/issues/twig_extensions"
+            }
         },
         {
             "name": "drupal/upgrade_status",
@@ -14638,5 +14634,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "622db8199596a66d9fa1d5c514fee23c",
+    "content-hash": "217f03a0c382ad6e09ee679f63121e03",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3405,26 +3405,29 @@
         },
         {
             "name": "drupal/r4032login",
-            "version": "dev-1.x",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/r4032login.git",
-                "reference": "90904367bc60e14320ee1478d934ca6dce34233d"
+                "reference": "2.1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/r4032login-2.1.0.zip",
+                "reference": "2.1.0",
+                "shasum": "2004f3ea4a4d4e0f08cdcd75f6f89c3f58d903fa"
             },
             "require": {
-                "drupal/core": "~8.0"
+                "drupal/core": "^8.8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
-                "branch-alias": {
-                    "dev-1.x": "1.x-dev"
-                },
                 "drupal": {
-                    "version": "8.x-1.1+3-dev",
-                    "datestamp": "1578675183",
+                    "version": "2.1.0",
+                    "datestamp": "1615710471",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Dev releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -3436,6 +3439,10 @@
                 {
                     "name": "Bevan",
                     "homepage": "https://www.drupal.org/user/49989"
+                },
+                {
+                    "name": "Grayle",
+                    "homepage": "https://www.drupal.org/user/3145497"
                 },
                 {
                     "name": "Nixou",
@@ -3478,8 +3485,7 @@
             "homepage": "https://www.drupal.org/project/r4032login",
             "support": {
                 "source": "https://git.drupalcode.org/project/r4032login"
-            },
-            "time": "2020-01-10T16:52:01+00:00"
+            }
         },
         {
             "name": "drupal/recaptcha",
@@ -14624,7 +14630,6 @@
         "brian-clement/tito": 20,
         "drupal/captcha": 20,
         "drupal/libraries": 10,
-        "drupal/r4032login": 20,
         "drupal/switch_page_theme": 20,
         "drupal/twig_extensions": 20,
         "midcamp/hatter": 20,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd744fc338cca82e5886bd4abda439b7",
+    "content-hash": "156ac2978bc1bee7f3c52c6fa1e9dbd0",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -64,16 +64,16 @@
         },
         {
             "name": "brian-clement/eventbrite_events",
-            "version": "dev-master",
+            "version": "1.0-beta",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Brian-Clement/eventbrite_events.git",
-                "reference": "1ac7032b3fe9fda40f92e1899f090d88638f0c73"
+                "reference": "4a9a2c5734035396e970c9f3ae5553d14a8ae3f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Brian-Clement/eventbrite_events/zipball/1ac7032b3fe9fda40f92e1899f090d88638f0c73",
-                "reference": "1ac7032b3fe9fda40f92e1899f090d88638f0c73",
+                "url": "https://api.github.com/repos/Brian-Clement/eventbrite_events/zipball/4a9a2c5734035396e970c9f3ae5553d14a8ae3f2",
+                "reference": "4a9a2c5734035396e970c9f3ae5553d14a8ae3f2",
                 "shasum": ""
             },
             "type": "drupal-module",
@@ -85,10 +85,10 @@
                 "Drupal"
             ],
             "support": {
-                "source": "https://github.com/Brian-Clement/eventbrite_events/tree/master",
+                "source": "https://github.com/Brian-Clement/eventbrite_events/tree/1.0-beta",
                 "issues": "https://github.com/Brian-Clement/eventbrite_events/issues"
             },
-            "time": "2019-10-21T23:02:13+00:00"
+            "time": "2022-05-22T18:32:28+00:00"
         },
         {
             "name": "brian-clement/tito",
@@ -14626,7 +14626,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "brian-clement/eventbrite_events": 20,
         "brian-clement/tito": 20,
         "drupal/captcha": 20,
         "drupal/libraries": 10,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "217f03a0c382ad6e09ee679f63121e03",
+    "content-hash": "cd744fc338cca82e5886bd4abda439b7",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/patches/mailchimp-prevent-wsod-missing-keys.patch
+++ b/patches/mailchimp-prevent-wsod-missing-keys.patch
@@ -1,0 +1,14 @@
+--- web/modules/contrib/mailchimp/mailchimp.module
++++ web/modules/contrib/mailchimp/mailchimp.module
+@@ -1484,6 +1484,11 @@
+           /* @var \Mailchimp\MailchimpConnectedSites $mc_connected */
+           $mc_connected = mailchimp_get_api_object('MailchimpConnectedSites');
+
++          // Handle instances where API keys may be missing.
++          if (!isset($mc_connected)) {
++            return;
++          }
++
+           // Verify Connected Site exists on the Mailchimp side and insert JS.
+           $connected_site = $mc_connected->getConnectedSite($connected_site_id);
+           if (!empty($connected_site)) {

--- a/web/modules/custom/midcamp_event_label_block/midcamp_event_label_block.info.yml
+++ b/web/modules/custom/midcamp_event_label_block/midcamp_event_label_block.info.yml
@@ -1,5 +1,5 @@
 name: 'MidCamp Event Label Block'
 type: module
 description: 'Exposes field_event value in a Block'
-core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'MidCamp'

--- a/web/modules/custom/midcamp_migration/midcamp_migration.info.yml
+++ b/web/modules/custom/midcamp_migration/midcamp_migration.info.yml
@@ -1,7 +1,7 @@
 name: midcamp_migration
 type: module
 description: MidCamp Migrations module to import content.
-core: 8.x
+core_version_requirement: ^8 || ^9
 package: MidCamp
 dependencies:
   - migrate

--- a/web/modules/custom/midcamp_tito/midcamp_tito.info.yml
+++ b/web/modules/custom/midcamp_tito/midcamp_tito.info.yml
@@ -1,7 +1,7 @@
 name: 'MidCamp Tito'
 type: module
 description: 'Integrate with Tito API to sync event and attendee data'
-core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Custom'
 dependencies:
   - tito

--- a/web/modules/custom/midcamp_utility/midcamp_utility.info.yml
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.info.yml
@@ -1,5 +1,5 @@
 name: 'Midcamp Utility'
 type: module
 description: 'Misc modifications and helpers'
-core: 8.x
+core_version_requirement: ^8 || ^9
 package: 'Midcamp'

--- a/web/modules/custom/midcamp_vbo/midcamp_vbo.info.yml
+++ b/web/modules/custom/midcamp_vbo/midcamp_vbo.info.yml
@@ -1,4 +1,4 @@
 name: Midcamp VBO
 description: Provide custom bulk operations.
-core: 8.x
+core_version_requirement: ^8 || ^9
 type: module

--- a/web/themes/custom/hatter/hatter.info.yml
+++ b/web/themes/custom/hatter/hatter.info.yml
@@ -1,7 +1,7 @@
 name: Hatter
 description: Now with more madness!
 type: theme
-core: 8.x
+core_version_requirement: ^8 || ^9
 base theme: classy
 libraries:
   - hatter/global-css

--- a/web/themes/custom/hatter_2019/hatter_2019.info.yml
+++ b/web/themes/custom/hatter_2019/hatter_2019.info.yml
@@ -1,7 +1,7 @@
 name: Hatter 2019
 description: O'Midcamp!
 type: theme
-core: 8.x
+core_version_requirement: ^8 || ^9
 base theme: hatter_base
 libraries:
   - hatter_2019/global-css

--- a/web/themes/custom/hatter_base/hatter_base.info.yml
+++ b/web/themes/custom/hatter_base/hatter_base.info.yml
@@ -1,7 +1,7 @@
 name: Hatter Base
 description: Now with more madness!
 type: theme
-core: 8.x
+core_version_requirement: ^8 || ^9
 base theme: classy
 libraries:
   - hatter_base/global-css


### PR DESCRIPTION
# Description

- Updates the following modules for D9 compliance:
  - Twig Extensions
  - R4032login
  - Eventbrite Events
- Patches MailChimp module to spare ourselves WSOD pain in lower environments where API keys may be missing
- Update's Lagoon's CLI Dockerfile to ensure patch files local to our repo exist, and also uses their new namespacing for Docker images

# Motivation/Context

We need to get upgraded to Drupal 9.  This has taken an embarrassingly long time.

# Test instructions

1. Install updated dependencies via `lando composer install`
2. Perform database updates via `lando drush updb -y`
3. Test the site, make sure it isn't broken