### PR TITLE
Drupal 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
             "drupal/console-extend-plugin": true,
             "drupal/core-composer-scaffold": true,
             "cweagans/composer-patches": true,
-            "oomphinc/composer-installers-extender": true
+            "oomphinc/composer-installers-extender": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         }
     },
     "repositories": {
@@ -53,8 +54,8 @@
         "drupal/captcha": "1.x-dev",
         "drupal/config_ignore": "^2.3",
         "drupal/contact_formatter": "^2.0",
-        "drupal/core": "~8.9.0",
-        "drupal/core-composer-scaffold": "~8.9.0",
+        "drupal/core-composer-scaffold": "^9.3",
+        "drupal/core-recommended": "^9.3",
         "drupal/entity": "^1.2",
         "drupal/entityqueue": "^1.2",
         "drupal/field_group": "^3.2",
@@ -79,19 +80,15 @@
         "drupal/video_embed_field": "^2.4",
         "drupal/viewsreference": "^1.7",
         "drupal/webform": "^6.1",
-        "midcamp/hatter": "dev-master",
         "oomphinc/composer-installers-extender": "^2.0",
         "twig/extensions": "^1.5"
     },
     "require-dev": {
         "amazeeio/drupal_integrations": "^0.3.3",
-        "behat/behat": "^3.1",
         "behat/mink-extension": "^2.2",
-        "drupal/console": "^1.9",
-        "drupal/core-dev": "~8.9",
-        "drupal/drupal-extension": "^3.1",
-        "drush/drush": "^10.0",
-        "palantirnet/palantir-behat-extension": "dev-drupal8-file-revisited",
+        "drupal/core-dev": "^9.3",
+        "drupal/drupal-extension": "^4",
+        "drush/drush": "^10.6",
         "phpmd/phpmd": "^2.4"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "drupal/pathauto": "^1.8",
         "drupal/r4032login": "^2.1",
         "drupal/recaptcha": "^3.0",
-        "drupal/redirect": "^1.0",
+        "drupal/redirect": "^1.7",
         "drupal/scheduler": "^1.3",
         "drupal/simple_sitemap": "^3.8",
         "drupal/switch_page_theme": "1.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,9 @@
             "url": "https://packages.drupal.org/8"
         }
     },
+    "replace": {
+      "spress/spress": "*"
+    },
     "require": {
         "brian-clement/eventbrite_events": "^1.0",
         "brian-clement/tito": "dev-master",
@@ -80,6 +83,7 @@
         "drupal/video_embed_field": "^2.4",
         "drupal/viewsreference": "^1.7",
         "drupal/webform": "^6.1",
+        "midcamp/hatter": "dev-master",
         "oomphinc/composer-installers-extender": "^2.0",
         "twig/extensions": "^1.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
         "drupal/field_group": "^3.2",
         "drupal/field_permissions": "^1.1",
         "drupal/google_analytics": "^3.1",
-        "drupal/honeypot": "^1.31",
+        "drupal/honeypot": "^2.1",
         "drupal/libraries": "^3.0@beta",
         "drupal/linkicon": "^1.4",
         "drupal/mailchimp": "^1.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2feccce89a89fa0124d65d47069103ae",
+    "content-hash": "9dc5331adfd0b4ec8d1edf872ca12f29",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4537,6 +4537,39 @@
                 }
             ],
             "time": "2021-08-27T13:48:19+00:00"
+        },
+        {
+            "name": "midcamp/hatter",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MidCamp/Hatter.git",
+                "reference": "0f5e194858da5b9b26a4e131669fcf5a6cb2c103"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MidCamp/Hatter/zipball/0f5e194858da5b9b26a4e131669fcf5a6cb2c103",
+                "reference": "0f5e194858da5b9b26a4e131669fcf5a6cb2c103",
+                "shasum": ""
+            },
+            "require": {
+                "spress/spress": "^2.1"
+            },
+            "default-branch": true,
+            "type": "butler-styleguide",
+            "autoload": {
+                "psr-0": {
+                    "MidCamp\\": "src/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "support": {
+                "source": "https://github.com/MidCamp/Hatter/tree/master",
+                "issues": "https://github.com/MidCamp/Hatter/issues"
+            },
+            "time": "2019-11-02T13:57:41+00:00"
         },
         {
             "name": "nette/finder",
@@ -14281,7 +14314,8 @@
         "drupal/captcha": 20,
         "drupal/libraries": 10,
         "drupal/switch_page_theme": 20,
-        "drupal/twig_extensions": 20
+        "drupal/twig_extensions": 20,
+        "midcamp/hatter": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9dc5331adfd0b4ec8d1edf872ca12f29",
+    "content-hash": "25807508daa26235487cbe683e12b67b",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2117,26 +2117,29 @@
         },
         {
             "name": "drupal/honeypot",
-            "version": "1.31.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/honeypot.git",
-                "reference": "8.x-1.31"
+                "reference": "2.1.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/honeypot-8.x-1.31.zip",
-                "reference": "8.x-1.31",
-                "shasum": "a0e7fd5cabdf8bbd4ceedc39d0a25f9d54ea3c41"
+                "url": "https://ftp.drupal.org/files/projects/honeypot-2.1.0.zip",
+                "reference": "2.1.0",
+                "shasum": "7ddb2d0bfeaa65d55823d82bdf01c9c330a1e12f"
             },
             "require": {
-                "drupal/core": "^8.8.2 || ^9"
+                "drupal/core": "^9.2 || ^10"
+            },
+            "require-dev": {
+                "drupal/rules": "^3.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.31",
-                    "datestamp": "1637735546",
+                    "version": "2.1.0",
+                    "datestamp": "1651894953",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "156ac2978bc1bee7f3c52c6fa1e9dbd0",
+    "content-hash": "15c7b5d9204a7ff96c69cfb32c7a88a7",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -179,171 +179,6 @@
             "time": "2021-10-30T12:33:41+00:00"
         },
         {
-            "name": "composer/ca-bundle",
-            "version": "1.2.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "9fdb22c2e97a614657716178093cd1da90a64aa8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/9fdb22c2e97a614657716178093cd1da90a64aa8",
-                "reference": "9fdb22c2e97a614657716178093cd1da90a64aa8",
-                "shasum": ""
-            },
-            "require": {
-                "ext-openssl": "*",
-                "ext-pcre": "*",
-                "php": "^5.3.2 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^0.12.55",
-                "psr/log": "^1.0",
-                "symfony/phpunit-bridge": "^4.2 || ^5",
-                "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\CaBundle\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
-            "keywords": [
-                "cabundle",
-                "cacert",
-                "certificate",
-                "ssl",
-                "tls"
-            ],
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-06-07T13:58:28+00:00"
-        },
-        {
-            "name": "composer/composer",
-            "version": "1.10.22",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/composer.git",
-                "reference": "28c9dfbe2351635961f670773e8d7b17bc5eda25"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/28c9dfbe2351635961f670773e8d7b17bc5eda25",
-                "reference": "28c9dfbe2351635961f670773e8d7b17bc5eda25",
-                "shasum": ""
-            },
-            "require": {
-                "composer/ca-bundle": "^1.0",
-                "composer/semver": "^1.0",
-                "composer/spdx-licenses": "^1.2",
-                "composer/xdebug-handler": "^1.1",
-                "justinrainbow/json-schema": "^5.2.10",
-                "php": "^5.3.2 || ^7.0 || ^8.0",
-                "psr/log": "^1.0",
-                "seld/jsonlint": "^1.4",
-                "seld/phar-utils": "^1.0",
-                "symfony/console": "^2.7 || ^3.0 || ^4.0 || ^5.0",
-                "symfony/filesystem": "^2.7 || ^3.0 || ^4.0 || ^5.0",
-                "symfony/finder": "^2.7 || ^3.0 || ^4.0 || ^5.0",
-                "symfony/process": "^2.7 || ^3.0 || ^4.0 || ^5.0"
-            },
-            "conflict": {
-                "symfony/console": "2.8.38"
-            },
-            "require-dev": {
-                "phpspec/prophecy": "^1.10",
-                "symfony/phpunit-bridge": "^4.2"
-            },
-            "suggest": {
-                "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",
-                "ext-zip": "Enabling the zip extension allows you to unzip archives",
-                "ext-zlib": "Allow gzip compression of HTTP requests"
-            },
-            "bin": [
-                "bin/composer"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\": "src/Composer"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "Composer helps you declare, manage and install dependencies of PHP projects. It ensures you have the right stack everywhere.",
-            "homepage": "https://getcomposer.org/",
-            "keywords": [
-                "autoload",
-                "dependency",
-                "package"
-            ],
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-04-27T11:10:45+00:00"
-        },
-        {
             "name": "composer/installers",
             "version": "v1.12.0",
             "source": {
@@ -492,28 +327,29 @@
         },
         {
             "name": "composer/semver",
-            "version": "1.7.2",
+            "version": "3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "647490bbcaf7fc4891c58f47b825eb99d19c377a"
+                "reference": "83e511e247de329283478496f7a1e114c9517506"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/647490bbcaf7fc4891c58f47b825eb99d19c377a",
-                "reference": "647490bbcaf7fc4891c58f47b825eb99d19c377a",
+                "url": "https://api.github.com/repos/composer/semver/zipball/83e511e247de329283478496f7a1e114c9517506",
+                "reference": "83e511e247de329283478496f7a1e114c9517506",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.5 || ^5.0.5"
+                "phpstan/phpstan": "^0.12.54",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -552,7 +388,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/1.7.2"
+                "source": "https://github.com/composer/semver/tree/3.2.6"
             },
             "funding": [
                 {
@@ -568,140 +404,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-03T15:47:16+00:00"
-        },
-        {
-            "name": "composer/spdx-licenses",
-            "version": "1.5.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "de30328a7af8680efdc03e396aad24befd513200"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/de30328a7af8680efdc03e396aad24befd513200",
-                "reference": "de30328a7af8680efdc03e396aad24befd513200",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Spdx\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "SPDX licenses list and validation library.",
-            "keywords": [
-                "license",
-                "spdx",
-                "validator"
-            ],
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-12-03T16:04:16+00:00"
-        },
-        {
-            "name": "composer/xdebug-handler",
-            "version": "1.4.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "f27e06cd9675801df441b3656569b328e04aa37c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/f27e06cd9675801df441b3656569b328e04aa37c",
-                "reference": "f27e06cd9675801df441b3656569b328e04aa37c",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0",
-                "psr/log": "^1.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^0.12.55",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Composer\\XdebugHandler\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "John Stevenson",
-                    "email": "john-stevenson@blueyonder.co.uk"
-                }
-            ],
-            "description": "Restarts a process without Xdebug.",
-            "keywords": [
-                "Xdebug",
-                "performance"
-            ],
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-03-25T17:01:18+00:00"
+            "time": "2021-10-25T11:34:17+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -732,6 +435,10 @@
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
+            "support": {
+                "issues": "https://github.com/container-interop/container-interop/issues",
+                "source": "https://github.com/container-interop/container-interop/tree/master"
+            },
             "abandoned": "psr/container",
             "time": "2017-02-14T19:40:03+00:00"
         },
@@ -778,61 +485,6 @@
             ],
             "description": "Provides a way to patch Composer packages.",
             "time": "2021-06-08T15:12:46+00:00"
-        },
-        {
-            "name": "dflydev/apache-mime-types",
-            "version": "v1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/dflydev/dflydev-apache-mime-types.git",
-                "reference": "f30a57e59b7476e4c5270b6a0727d79c9c0eb861"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-apache-mime-types/zipball/f30a57e59b7476e4c5270b6a0727d79c9c0eb861",
-                "reference": "f30a57e59b7476e4c5270b6a0727d79c9c0eb861",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3"
-            },
-            "require-dev": {
-                "twig/twig": "1.*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Dflydev\\ApacheMimeTypes": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Dragonfly Development Inc.",
-                    "email": "info@dflydev.com",
-                    "homepage": "http://dflydev.com"
-                },
-                {
-                    "name": "Beau Simensen",
-                    "email": "beau@dflydev.com",
-                    "homepage": "http://beausimensen.com"
-                }
-            ],
-            "description": "Apache MIME Types",
-            "keywords": [
-                "apache",
-                "mime",
-                "mimetypes"
-            ],
-            "time": "2013-05-14T02:02:01+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -907,105 +559,6 @@
             "time": "2021-08-05T19:00:23+00:00"
         },
         {
-            "name": "doctrine/cache",
-            "version": "1.12.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/cache.git",
-                "reference": "4cf401d14df219fa6f38b671f5493449151c9ad8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/4cf401d14df219fa6f38b671f5493449151c9ad8",
-                "reference": "4cf401d14df219fa6f38b671f5493449151c9ad8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "~7.1 || ^8.0"
-            },
-            "conflict": {
-                "doctrine/common": ">2.2,<2.4"
-            },
-            "require-dev": {
-                "alcaeus/mongo-php-adapter": "^1.1",
-                "cache/integration-tests": "dev-master",
-                "doctrine/coding-standard": "^8.0",
-                "mongodb/mongodb": "^1.1",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
-                "predis/predis": "~1.0",
-                "psr/cache": "^1.0 || ^2.0 || ^3.0",
-                "symfony/cache": "^4.4 || ^5.2 || ^6.0@dev",
-                "symfony/var-exporter": "^4.4 || ^5.2 || ^6.0@dev"
-            },
-            "suggest": {
-                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.",
-            "homepage": "https://www.doctrine-project.org/projects/cache.html",
-            "keywords": [
-                "abstraction",
-                "apcu",
-                "cache",
-                "caching",
-                "couchdb",
-                "memcached",
-                "php",
-                "redis",
-                "xcache"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/cache/issues",
-                "source": "https://github.com/doctrine/cache/tree/1.12.1"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcache",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-07-17T14:39:21+00:00"
-        },
-        {
             "name": "doctrine/collections",
             "version": "1.6.8",
             "source": {
@@ -1075,320 +628,33 @@
             "time": "2021-08-10T18:51:53+00:00"
         },
         {
-            "name": "doctrine/common",
-            "version": "2.13.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/common.git",
-                "reference": "f3812c026e557892c34ef37f6ab808a6b567da7f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/common/zipball/f3812c026e557892c34ef37f6ab808a6b567da7f",
-                "reference": "f3812c026e557892c34ef37f6ab808a6b567da7f",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/annotations": "^1.0",
-                "doctrine/cache": "^1.0",
-                "doctrine/collections": "^1.0",
-                "doctrine/event-manager": "^1.0",
-                "doctrine/inflector": "^1.0",
-                "doctrine/lexer": "^1.0",
-                "doctrine/persistence": "^1.3.3",
-                "doctrine/reflection": "^1.0",
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^1.0",
-                "phpstan/phpstan": "^0.11",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpunit/phpunit": "^7.0",
-                "squizlabs/php_codesniffer": "^3.0",
-                "symfony/phpunit-bridge": "^4.0.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.11.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\": "lib/Doctrine/Common"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                },
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                }
-            ],
-            "description": "PHP Doctrine Common project is a library that provides additional functionality that other Doctrine projects depend on such as better reflection support, persistence interfaces, proxies, event system and much more.",
-            "homepage": "https://www.doctrine-project.org/projects/common.html",
-            "keywords": [
-                "common",
-                "doctrine",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/common/issues",
-                "source": "https://github.com/doctrine/common/tree/2.13.x"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcommon",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-06-05T16:46:05+00:00"
-        },
-        {
-            "name": "doctrine/event-manager",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/event-manager.git",
-                "reference": "41370af6a30faa9dc0368c4a6814d596e81aba7f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/41370af6a30faa9dc0368c4a6814d596e81aba7f",
-                "reference": "41370af6a30faa9dc0368c4a6814d596e81aba7f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "conflict": {
-                "doctrine/common": "<2.9@dev"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^6.0",
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\": "lib/Doctrine/Common"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                },
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                }
-            ],
-            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
-            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
-            "keywords": [
-                "event",
-                "event dispatcher",
-                "event manager",
-                "event system",
-                "events"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/event-manager/issues",
-                "source": "https://github.com/doctrine/event-manager/tree/1.1.x"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-05-29T18:28:51+00:00"
-        },
-        {
-            "name": "doctrine/inflector",
-            "version": "1.4.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/inflector.git",
-                "reference": "4bd5c1cdfcd00e9e2d8c484f79150f67e5d355d9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/inflector/zipball/4bd5c1cdfcd00e9e2d8c484f79150f67e5d355d9",
-                "reference": "4bd5c1cdfcd00e9e2d8c484f79150f67e5d355d9",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^8.0",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpstan/phpstan-strict-rules": "^0.12",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector",
-                    "Doctrine\\Inflector\\": "lib/Doctrine/Inflector"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "PHP Doctrine Inflector is a small library that can perform string manipulations with regard to upper/lowercase and singular/plural forms of words.",
-            "homepage": "https://www.doctrine-project.org/projects/inflector.html",
-            "keywords": [
-                "inflection",
-                "inflector",
-                "lowercase",
-                "manipulation",
-                "php",
-                "plural",
-                "singular",
-                "strings",
-                "uppercase",
-                "words"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/inflector/issues",
-                "source": "https://github.com/doctrine/inflector/tree/1.4.4"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finflector",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-04-16T17:34:40+00:00"
-        },
-        {
             "name": "doctrine/lexer",
-            "version": "1.2.2",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "9c50f840f257bbb941e6f4a0e94ccf5db5c3f76c"
+                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/9c50f840f257bbb941e6f4a0e94ccf5db5c3f76c",
-                "reference": "9c50f840f257bbb941e6f4a0e94ccf5db5c3f76c",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/e864bbf5904cb8f5bb334f99209b48018522f042",
+                "reference": "e864bbf5904cb8f5bb334f99209b48018522f042",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9.0",
-                "phpstan/phpstan": "1.3",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.11"
+                "doctrine/coding-standard": "^6.0",
+                "phpstan/phpstan": "^0.11.8",
+                "phpunit/phpunit": "^8.2"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
@@ -1423,7 +689,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/1.2.2"
+                "source": "https://github.com/doctrine/lexer/tree/1.2.1"
             },
             "funding": [
                 {
@@ -1439,109 +705,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-12T08:27:12+00:00"
-        },
-        {
-            "name": "doctrine/persistence",
-            "version": "1.3.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/persistence.git",
-                "reference": "7a6eac9fb6f61bba91328f15aa7547f4806ca288"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/persistence/zipball/7a6eac9fb6f61bba91328f15aa7547f4806ca288",
-                "reference": "7a6eac9fb6f61bba91328f15aa7547f4806ca288",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/annotations": "^1.0",
-                "doctrine/cache": "^1.0",
-                "doctrine/collections": "^1.0",
-                "doctrine/event-manager": "^1.0",
-                "doctrine/reflection": "^1.2",
-                "php": "^7.1 || ^8.0"
-            },
-            "conflict": {
-                "doctrine/common": "<2.10@dev"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^6.0",
-                "phpstan/phpstan": "^0.11",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
-                "vimeo/psalm": "^3.11"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\": "lib/Doctrine/Common",
-                    "Doctrine\\Persistence\\": "lib/Doctrine/Persistence"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                },
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                }
-            ],
-            "description": "The Doctrine Persistence project is a set of shared interfaces and functionality that the different Doctrine object mappers share.",
-            "homepage": "https://doctrine-project.org/projects/persistence.html",
-            "keywords": [
-                "mapper",
-                "object",
-                "odm",
-                "orm",
-                "persistence"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/persistence/issues",
-                "source": "https://github.com/doctrine/persistence/tree/1.3.x"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fpersistence",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-06-20T12:56:16+00:00"
+            "time": "2020-05-25T17:44:05+00:00"
         },
         {
             "name": "doctrine/reflection",
@@ -2085,25 +1249,24 @@
         },
         {
             "name": "drupal/core",
-            "version": "8.9.20",
+            "version": "9.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core.git",
-                "reference": "39e2e1c32498338921923af66a90cb4a23a5b389"
+                "reference": "02ba7a3a42612a04124ac5131df0726e1e5097c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core/zipball/39e2e1c32498338921923af66a90cb4a23a5b389",
-                "reference": "39e2e1c32498338921923af66a90cb4a23a5b389",
+                "url": "https://api.github.com/repos/drupal/core/zipball/02ba7a3a42612a04124ac5131df0726e1e5097c6",
+                "reference": "02ba7a3a42612a04124ac5131df0726e1e5097c6",
                 "shasum": ""
             },
             "require": {
                 "asm89/stack-cors": "^1.1",
-                "composer/semver": "^1.0",
-                "doctrine/annotations": "^1.4",
-                "doctrine/common": "^2.7",
-                "easyrdf/easyrdf": "^0.9",
-                "egulias/email-validator": "^2.0",
+                "composer/semver": "^3.0",
+                "doctrine/annotations": "^1.12",
+                "doctrine/reflection": "^1.1",
+                "egulias/email-validator": "^2.1.22|^3.0",
                 "ext-date": "*",
                 "ext-dom": "*",
                 "ext-filter": "*",
@@ -2117,34 +1280,34 @@
                 "ext-spl": "*",
                 "ext-tokenizer": "*",
                 "ext-xml": "*",
-                "guzzlehttp/guzzle": "^6.3",
-                "laminas/laminas-diactoros": "^1.8",
+                "guzzlehttp/guzzle": "^6.5.2",
+                "laminas/laminas-diactoros": "^2.1",
                 "laminas/laminas-feed": "^2.12",
                 "masterminds/html5": "^2.1",
                 "pear/archive_tar": "^1.4.14",
-                "php": "^7.0.8",
+                "php": ">=7.3.0",
                 "psr/log": "^1.0",
                 "stack/builder": "^1.0",
-                "symfony-cmf/routing": "^1.4",
-                "symfony/class-loader": "~3.4.0",
-                "symfony/console": "~3.4.0",
-                "symfony/dependency-injection": "~3.4.26",
-                "symfony/event-dispatcher": "~3.4.0",
-                "symfony/http-foundation": "~3.4.35",
-                "symfony/http-kernel": "~3.4.14",
+                "symfony-cmf/routing": "^2.1",
+                "symfony/console": "^4.4",
+                "symfony/dependency-injection": "^4.4",
+                "symfony/event-dispatcher": "^4.4",
+                "symfony/http-foundation": "^4.4.7",
+                "symfony/http-kernel": "^4.4",
+                "symfony/mime": "^5.4",
                 "symfony/polyfill-iconv": "^1.0",
-                "symfony/process": "~3.4.0",
-                "symfony/psr-http-message-bridge": "^1.1.2",
-                "symfony/routing": "~3.4.0",
-                "symfony/serializer": "~3.4.0",
-                "symfony/translation": "~3.4.0",
-                "symfony/validator": "~3.4.0",
-                "symfony/yaml": "~3.4.5",
-                "twig/twig": "^1.38.2",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/process": "^4.4",
+                "symfony/psr-http-message-bridge": "^2.0",
+                "symfony/routing": "^4.4",
+                "symfony/serializer": "^4.4",
+                "symfony/translation": "^4.4",
+                "symfony/validator": "^4.4",
+                "symfony/yaml": "^4.4.19",
+                "twig/twig": "^2.12.0",
                 "typo3/phar-stream-wrapper": "^3.1.3"
             },
             "conflict": {
-                "drupal/pathauto": "<1.6",
                 "drush/drush": "<8.1.10"
             },
             "replace": {
@@ -2157,10 +1320,10 @@
                 "drupal/big_pipe": "self.version",
                 "drupal/block": "self.version",
                 "drupal/block_content": "self.version",
-                "drupal/block_place": "self.version",
                 "drupal/book": "self.version",
                 "drupal/breakpoint": "self.version",
                 "drupal/ckeditor": "self.version",
+                "drupal/ckeditor5": "self.version",
                 "drupal/claro": "self.version",
                 "drupal/classy": "self.version",
                 "drupal/color": "self.version",
@@ -2183,6 +1346,7 @@
                 "drupal/core-file-cache": "self.version",
                 "drupal/core-file-security": "self.version",
                 "drupal/core-filesystem": "self.version",
+                "drupal/core-front-matter": "self.version",
                 "drupal/core-gettext": "self.version",
                 "drupal/core-graph": "self.version",
                 "drupal/core-http-foundation": "self.version",
@@ -2229,6 +1393,7 @@
                 "drupal/migrate_drupal_ui": "self.version",
                 "drupal/minimal": "self.version",
                 "drupal/node": "self.version",
+                "drupal/olivero": "self.version",
                 "drupal/options": "self.version",
                 "drupal/page_cache": "self.version",
                 "drupal/path": "self.version",
@@ -2242,7 +1407,6 @@
                 "drupal/settings_tray": "self.version",
                 "drupal/seven": "self.version",
                 "drupal/shortcut": "self.version",
-                "drupal/simpletest": "self.version",
                 "drupal/standard": "self.version",
                 "drupal/stark": "self.version",
                 "drupal/statistics": "self.version",
@@ -2275,7 +1439,7 @@
                         "[web-root]/example.gitignore": "assets/scaffold/files/example.gitignore",
                         "[web-root]/index.php": "assets/scaffold/files/index.php",
                         "[web-root]/INSTALL.txt": "assets/scaffold/files/drupal.INSTALL.txt",
-                        "[web-root]/README.txt": "assets/scaffold/files/drupal.README.txt",
+                        "[web-root]/README.md": "assets/scaffold/files/drupal.README.md",
                         "[web-root]/robots.txt": "assets/scaffold/files/robots.txt",
                         "[web-root]/update.php": "assets/scaffold/files/update.php",
                         "[web-root]/web.config": "assets/scaffold/files/web.config",
@@ -2292,18 +1456,41 @@
                 }
             },
             "autoload": {
+                "files": [
+                    "includes/bootstrap.inc",
+                    "includes/guzzle_php81_shim.php"
+                ],
                 "psr-4": {
                     "Drupal\\Core\\": "lib/Drupal/Core",
-                    "Drupal\\Component\\": "lib/Drupal/Component",
-                    "Drupal\\Driver\\": "../drivers/lib/Drupal/Driver"
+                    "Drupal\\Driver\\": "../drivers/lib/Drupal/Driver",
+                    "Drupal\\Component\\": "lib/Drupal/Component"
                 },
                 "classmap": [
                     "lib/Drupal.php",
+                    "lib/Drupal/Component/DependencyInjection/Container.php",
+                    "lib/Drupal/Component/DependencyInjection/PhpArrayContainer.php",
+                    "lib/Drupal/Component/FileCache/FileCacheFactory.php",
                     "lib/Drupal/Component/Utility/Timer.php",
                     "lib/Drupal/Component/Utility/Unicode.php",
+                    "lib/Drupal/Core/Cache/Cache.php",
+                    "lib/Drupal/Core/Cache/CacheBackendInterface.php",
+                    "lib/Drupal/Core/Cache/CacheTagsChecksumInterface.php",
+                    "lib/Drupal/Core/Cache/CacheTagsChecksumTrait.php",
+                    "lib/Drupal/Core/Cache/CacheTagsInvalidatorInterface.php",
+                    "lib/Drupal/Core/Cache/DatabaseBackend.php",
+                    "lib/Drupal/Core/Cache/DatabaseCacheTagsChecksum.php",
+                    "lib/Drupal/Core/Database/Connection.php",
                     "lib/Drupal/Core/Database/Database.php",
+                    "lib/Drupal/Core/Database/Driver/mysql/Connection.php",
+                    "lib/Drupal/Core/Database/Driver/pgsql/Connection.php",
+                    "lib/Drupal/Core/Database/Driver/sqlite/Connection.php",
+                    "lib/Drupal/Core/Database/Statement.php",
+                    "lib/Drupal/Core/Database/StatementInterface.php",
+                    "lib/Drupal/Core/DependencyInjection/Container.php",
                     "lib/Drupal/Core/DrupalKernel.php",
                     "lib/Drupal/Core/DrupalKernelInterface.php",
+                    "lib/Drupal/Core/Http/InputBag.php",
+                    "lib/Drupal/Core/Installer/InstallerRedirectTrait.php",
                     "lib/Drupal/Core/Site/Settings.php"
                 ]
             },
@@ -2313,27 +1500,27 @@
             ],
             "description": "Drupal is an open source content management platform powering millions of websites and applications.",
             "support": {
-                "source": "https://github.com/drupal/core/tree/8.9.20"
+                "source": "https://github.com/drupal/core/tree/9.3.13"
             },
-            "time": "2021-11-17T21:24:28+00:00"
+            "time": "2022-05-11T09:20:58+00:00"
         },
         {
             "name": "drupal/core-composer-scaffold",
-            "version": "8.9.11",
+            "version": "9.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-composer-scaffold.git",
-                "reference": "c902d07cb49ef73777e2b33a39e54c2861a8c81d"
+                "reference": "a9dd9def8891e1c388719474720b57d3fe929a2f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-composer-scaffold/zipball/c902d07cb49ef73777e2b33a39e54c2861a8c81d",
-                "reference": "c902d07cb49ef73777e2b33a39e54c2861a8c81d",
+                "url": "https://api.github.com/repos/drupal/core-composer-scaffold/zipball/a9dd9def8891e1c388719474720b57d3fe929a2f",
+                "reference": "a9dd9def8891e1c388719474720b57d3fe929a2f",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1 || ^2",
-                "php": ">=7.0.8"
+                "php": ">=7.3.0"
             },
             "conflict": {
                 "drupal-composer/drupal-scaffold": "*"
@@ -2362,7 +1549,96 @@
             "keywords": [
                 "drupal"
             ],
-            "time": "2020-08-07T22:30:30+00:00"
+            "support": {
+                "source": "https://github.com/drupal/core-composer-scaffold/tree/9.3.13"
+            },
+            "time": "2022-02-24T17:40:56+00:00"
+        },
+        {
+            "name": "drupal/core-recommended",
+            "version": "9.3.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/drupal/core-recommended.git",
+                "reference": "0fe76c7af47fafcff37d8cb6053014e52e0f4a69"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/drupal/core-recommended/zipball/0fe76c7af47fafcff37d8cb6053014e52e0f4a69",
+                "reference": "0fe76c7af47fafcff37d8cb6053014e52e0f4a69",
+                "shasum": ""
+            },
+            "require": {
+                "asm89/stack-cors": "1.3.0",
+                "composer/semver": "3.2.6",
+                "doctrine/annotations": "1.13.2",
+                "doctrine/lexer": "1.2.1",
+                "doctrine/reflection": "1.2.2",
+                "drupal/core": "9.3.13",
+                "egulias/email-validator": "3.1.2",
+                "guzzlehttp/guzzle": "6.5.5",
+                "guzzlehttp/promises": "1.5.1",
+                "guzzlehttp/psr7": "1.8.5",
+                "laminas/laminas-diactoros": "2.8.0",
+                "laminas/laminas-escaper": "2.9.0",
+                "laminas/laminas-feed": "2.15.0",
+                "laminas/laminas-stdlib": "3.6.1",
+                "masterminds/html5": "2.7.5",
+                "pear/archive_tar": "1.4.14",
+                "pear/console_getopt": "v1.4.3",
+                "pear/pear-core-minimal": "v1.10.11",
+                "pear/pear_exception": "v1.0.2",
+                "psr/cache": "1.0.1",
+                "psr/container": "1.1.1",
+                "psr/http-factory": "1.0.1",
+                "psr/http-message": "1.0.1",
+                "psr/log": "1.1.4",
+                "ralouphie/getallheaders": "3.0.3",
+                "stack/builder": "v1.0.6",
+                "symfony-cmf/routing": "2.3.4",
+                "symfony/console": "v4.4.34",
+                "symfony/debug": "v4.4.31",
+                "symfony/dependency-injection": "v4.4.34",
+                "symfony/deprecation-contracts": "v2.5.0",
+                "symfony/error-handler": "v4.4.34",
+                "symfony/event-dispatcher": "v4.4.34",
+                "symfony/event-dispatcher-contracts": "v1.1.11",
+                "symfony/http-client-contracts": "v2.5.0",
+                "symfony/http-foundation": "v4.4.34",
+                "symfony/http-kernel": "v4.4.35",
+                "symfony/mime": "v5.4.0",
+                "symfony/polyfill-ctype": "v1.23.0",
+                "symfony/polyfill-iconv": "v1.23.0",
+                "symfony/polyfill-intl-idn": "v1.23.0",
+                "symfony/polyfill-intl-normalizer": "v1.23.0",
+                "symfony/polyfill-mbstring": "v1.23.1",
+                "symfony/polyfill-php80": "v1.23.1",
+                "symfony/process": "v4.4.35",
+                "symfony/psr-http-message-bridge": "v2.1.2",
+                "symfony/routing": "v4.4.34",
+                "symfony/serializer": "v4.4.35",
+                "symfony/service-contracts": "v2.5.0",
+                "symfony/translation": "v4.4.34",
+                "symfony/translation-contracts": "v2.5.0",
+                "symfony/validator": "v4.4.35",
+                "symfony/var-dumper": "v5.4.0",
+                "symfony/yaml": "v4.4.34",
+                "twig/twig": "v2.14.11",
+                "typo3/phar-stream-wrapper": "v3.1.7"
+            },
+            "conflict": {
+                "webflo/drupal-core-strict": "*"
+            },
+            "type": "metapackage",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Locked core dependencies; require this project INSTEAD OF drupal/core.",
+            "support": {
+                "source": "https://github.com/drupal/core-recommended/tree/9.3.13"
+            },
+            "time": "2022-05-11T09:20:58+00:00"
         },
         {
             "name": "drupal/ctools",
@@ -4240,96 +3516,28 @@
             }
         },
         {
-            "name": "easyrdf/easyrdf",
-            "version": "0.9.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/easyrdf/easyrdf.git",
-                "reference": "acd09dfe0555fbcfa254291e433c45fdd4652566"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/easyrdf/easyrdf/zipball/acd09dfe0555fbcfa254291e433c45fdd4652566",
-                "reference": "acd09dfe0555fbcfa254291e433c45fdd4652566",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "ext-pcre": "*",
-                "php": ">=5.2.8"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~3.5",
-                "sami/sami": "~1.4",
-                "squizlabs/php_codesniffer": "~1.4.3"
-            },
-            "suggest": {
-                "ml/json-ld": "~1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "EasyRdf_": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nicholas Humfrey",
-                    "email": "njh@aelius.com",
-                    "homepage": "http://www.aelius.com/njh/",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Alexey Zakhlestin",
-                    "email": "indeyets@gmail.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "EasyRdf is a PHP library designed to make it easy to consume and produce RDF.",
-            "homepage": "http://www.easyrdf.org/",
-            "keywords": [
-                "Linked Data",
-                "RDF",
-                "Semantic Web",
-                "Turtle",
-                "rdfa",
-                "sparql"
-            ],
-            "support": {
-                "forum": "http://groups.google.com/group/easyrdf/",
-                "irc": "irc://chat.freenode.net/easyrdf",
-                "issues": "http://github.com/njh/easyrdf/issues",
-                "source": "https://github.com/easyrdf/easyrdf/tree/0.9.1"
-            },
-            "time": "2015-02-27T09:45:49+00:00"
-        },
-        {
             "name": "egulias/email-validator",
-            "version": "2.1.25",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "0dbf5d78455d4d6a41d186da50adc1122ec066f4"
+                "reference": "ee0db30118f661fb166bcffbf5d82032df484697"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/0dbf5d78455d4d6a41d186da50adc1122ec066f4",
-                "reference": "0dbf5d78455d4d6a41d186da50adc1122ec066f4",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/ee0db30118f661fb166bcffbf5d82032df484697",
+                "reference": "ee0db30118f661fb166bcffbf5d82032df484697",
                 "shasum": ""
             },
             "require": {
-                "doctrine/lexer": "^1.0.1",
-                "php": ">=5.5",
-                "symfony/polyfill-intl-idn": "^1.10"
+                "doctrine/lexer": "^1.2",
+                "php": ">=7.2",
+                "symfony/polyfill-intl-idn": "^1.15"
             },
             "require-dev": {
-                "dominicsayers/isemail": "^3.0.7",
-                "phpunit/phpunit": "^4.8.36|^7.5.15",
-                "satooshi/php-coveralls": "^1.0.1"
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^8.5.8|^9.3.3",
+                "vimeo/psalm": "^4"
             },
             "suggest": {
                 "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
@@ -4337,7 +3545,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -4365,7 +3573,7 @@
             ],
             "support": {
                 "issues": "https://github.com/egulias/EmailValidator/issues",
-                "source": "https://github.com/egulias/EmailValidator/tree/2.1.25"
+                "source": "https://github.com/egulias/EmailValidator/tree/3.1.2"
             },
             "funding": [
                 {
@@ -4373,145 +3581,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-12-29T14:50:06+00:00"
-        },
-        {
-            "name": "erusev/parsedown",
-            "version": "1.7.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/erusev/parsedown.git",
-                "reference": "92e9c27ba0e74b8b028b111d1b6f956a15c01fc1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/erusev/parsedown/zipball/92e9c27ba0e74b8b028b111d1b6f956a15c01fc1",
-                "reference": "92e9c27ba0e74b8b028b111d1b6f956a15c01fc1",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Parsedown": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Emanuil Rusev",
-                    "email": "hello@erusev.com",
-                    "homepage": "http://erusev.com"
-                }
-            ],
-            "description": "Parser for Markdown.",
-            "homepage": "http://parsedown.org",
-            "keywords": [
-                "markdown",
-                "parser"
-            ],
-            "time": "2018-03-08T01:11:30+00:00"
-        },
-        {
-            "name": "erusev/parsedown-extra",
-            "version": "0.7.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/erusev/parsedown-extra.git",
-                "reference": "0db5cce7354e4b76f155d092ab5eb3981c21258c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/erusev/parsedown-extra/zipball/0db5cce7354e4b76f155d092ab5eb3981c21258c",
-                "reference": "0db5cce7354e4b76f155d092ab5eb3981c21258c",
-                "shasum": ""
-            },
-            "require": {
-                "erusev/parsedown": "~1.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "ParsedownExtra": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Emanuil Rusev",
-                    "email": "hello@erusev.com",
-                    "homepage": "http://erusev.com"
-                }
-            ],
-            "description": "An extension of Parsedown that adds support for Markdown Extra.",
-            "homepage": "https://github.com/erusev/parsedown-extra",
-            "keywords": [
-                "markdown",
-                "markdown extra",
-                "parsedown",
-                "parser"
-            ],
-            "time": "2015-11-01T10:19:22+00:00"
-        },
-        {
-            "name": "evenement/evenement",
-            "version": "v2.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/igorw/evenement.git",
-                "reference": "6ba9a777870ab49f417e703229d53931ed40fd7a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/igorw/evenement/zipball/6ba9a777870ab49f417e703229d53931ed40fd7a",
-                "reference": "6ba9a777870ab49f417e703229d53931ed40fd7a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0||^5.7||^4.8.35"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Evenement": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Igor Wiedler",
-                    "email": "igor@wiedler.ch"
-                }
-            ],
-            "description": "Événement is a very simple event dispatching library for PHP",
-            "keywords": [
-                "event-dispatcher",
-                "event-emitter"
-            ],
-            "time": "2017-07-17T17:39:19+00:00"
+            "time": "2021-10-11T09:18:27+00:00"
         },
         {
             "name": "google/recaptcha",
@@ -4601,12 +3671,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4663,12 +3733,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Promise\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4722,16 +3792,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.8.3",
+            "version": "1.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85"
+                "reference": "337e3ad8e5716c15f9657bd214d16cc5e69df268"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
-                "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/337e3ad8e5716c15f9657bd214d16cc5e69df268",
+                "reference": "337e3ad8e5716c15f9657bd214d16cc5e69df268",
                 "shasum": ""
             },
             "require": {
@@ -4756,12 +3826,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Psr7\\": "src/"
-                },
                 "files": [
                     "src/functions_include.php"
-                ]
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4812,7 +3882,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/1.8.3"
+                "source": "https://github.com/guzzle/psr7/tree/1.8.5"
             },
             "funding": [
                 {
@@ -4828,110 +3898,53 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-05T13:56:00+00:00"
-        },
-        {
-            "name": "justinrainbow/json-schema",
-            "version": "5.2.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "2ab6744b7296ded80f8cc4f9509abbff393399aa"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/2ab6744b7296ded80f8cc4f9509abbff393399aa",
-                "reference": "2ab6744b7296ded80f8cc4f9509abbff393399aa",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
-                "json-schema/json-schema-test-suite": "1.2.0",
-                "phpunit/phpunit": "^4.8.35"
-            },
-            "bin": [
-                "bin/validate-json"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "JsonSchema\\": "src/JsonSchema/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bruno Prieto Reis",
-                    "email": "bruno.p.reis@gmail.com"
-                },
-                {
-                    "name": "Justin Rainbow",
-                    "email": "justin.rainbow@gmail.com"
-                },
-                {
-                    "name": "Igor Wiedler",
-                    "email": "igor@wiedler.ch"
-                },
-                {
-                    "name": "Robert Schönthal",
-                    "email": "seroscho@googlemail.com"
-                }
-            ],
-            "description": "A library to validate a json schema.",
-            "homepage": "https://github.com/justinrainbow/json-schema",
-            "keywords": [
-                "json",
-                "schema"
-            ],
-            "time": "2021-07-22T09:24:00+00:00"
+            "time": "2022-03-20T21:51:18+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",
-            "version": "1.8.7p2",
+            "version": "2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-diactoros.git",
-                "reference": "6991c1af7c8d2c8efee81b22ba97024781824aaa"
+                "reference": "0c26ef1d95b6d7e6e3943a243ba3dc0797227199"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/6991c1af7c8d2c8efee81b22ba97024781824aaa",
-                "reference": "6991c1af7c8d2c8efee81b22ba97024781824aaa",
+                "url": "https://api.github.com/repos/laminas/laminas-diactoros/zipball/0c26ef1d95b6d7e6e3943a243ba3dc0797227199",
+                "reference": "0c26ef1d95b6d7e6e3943a243ba3dc0797227199",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^5.6 || ^7.0",
+                "php": "^7.3 || ~8.0.0 || ~8.1.0",
+                "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.0"
             },
+            "conflict": {
+                "phpspec/prophecy": "<1.9.0",
+                "zendframework/zend-diactoros": "*"
+            },
             "provide": {
+                "psr/http-factory-implementation": "1.0",
                 "psr/http-message-implementation": "1.0"
             },
-            "replace": {
-                "zendframework/zend-diactoros": "~1.8.7.0"
-            },
             "require-dev": {
+                "ext-curl": "*",
                 "ext-dom": "*",
+                "ext-gd": "*",
                 "ext-libxml": "*",
-                "laminas/laminas-coding-standard": "~1.0",
-                "php-http/psr7-integration-tests": "dev-master",
-                "phpunit/phpunit": "^5.7.16 || ^6.0.8 || ^7.2.7"
+                "http-interop/http-factory-tests": "^0.8.0",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "php-http/psr7-integration-tests": "^1.1",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.1",
+                "psalm/plugin-phpunit": "^0.14.0",
+                "vimeo/psalm": "^4.3"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-release-1.8": "1.8.x-dev"
+                "laminas": {
+                    "config-provider": "Laminas\\Diactoros\\ConfigProvider",
+                    "module": "Laminas\\Diactoros"
                 }
             },
             "autoload": {
@@ -4967,6 +3980,7 @@
                 "http",
                 "laminas",
                 "psr",
+                "psr-17",
                 "psr-7"
             ],
             "support": {
@@ -4977,7 +3991,13 @@
                 "rss": "https://github.com/laminas/laminas-diactoros/releases.atom",
                 "source": "https://github.com/laminas/laminas-diactoros"
             },
-            "time": "2020-03-23T15:28:28+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-22T03:54:36+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
@@ -5043,16 +4063,16 @@
         },
         {
             "name": "laminas/laminas-feed",
-            "version": "2.16.0",
+            "version": "2.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-feed.git",
-                "reference": "cbd0e10c867a1efa6594164d229d8caf4a4ae4c7"
+                "reference": "3ef837a12833c74b438d2c3780023c4244e0abae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-feed/zipball/cbd0e10c867a1efa6594164d229d8caf4a4ae4c7",
-                "reference": "cbd0e10c867a1efa6594164d229d8caf4a4ae4c7",
+                "url": "https://api.github.com/repos/laminas/laminas-feed/zipball/3ef837a12833c74b438d2c3780023c4244e0abae",
+                "reference": "3ef837a12833c74b438d2c3780023c4244e0abae",
                 "shasum": ""
             },
             "require": {
@@ -5116,7 +4136,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-12-17T09:12:35+00:00"
+            "time": "2021-09-20T18:11:11+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
@@ -5198,16 +4218,16 @@
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.7.1",
+            "version": "3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "bcd869e2fe88d567800057c1434f2380354fe325"
+                "reference": "db581851a092246ad99e12d4fddf105184924c71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/bcd869e2fe88d567800057c1434f2380354fe325",
-                "reference": "bcd869e2fe88d567800057c1434f2380354fe325",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/db581851a092246ad99e12d4fddf105184924c71",
+                "reference": "db581851a092246ad99e12d4fddf105184924c71",
                 "shasum": ""
             },
             "require": {
@@ -5218,8 +4238,8 @@
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~2.3.0",
-                "phpbench/phpbench": "^1.0",
-                "phpunit/phpunit": "^9.3.7",
+                "phpbench/phpbench": "^0.17.1",
+                "phpunit/phpunit": "~9.3.7",
                 "psalm/plugin-phpunit": "^0.16.0",
                 "vimeo/psalm": "^4.7"
             },
@@ -5253,7 +4273,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-01-21T15:50:46+00:00"
+            "time": "2021-11-10T11:33:52+00:00"
         },
         {
             "name": "laminas/laminas-text",
@@ -5304,68 +4324,6 @@
                 }
             ],
             "time": "2021-09-02T16:50:53+00:00"
-        },
-        {
-            "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "88bf037259869891afce6504cacc4f8a07b24d0f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/88bf037259869891afce6504cacc4f8a07b24d0f",
-                "reference": "88bf037259869891afce6504cacc4f8a07b24d0f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "psalm/plugin-phpunit": "^0.15.1",
-                "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "module": "Laminas\\ZendFrameworkBridge"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
-                "psr-4": {
-                    "Laminas\\ZendFrameworkBridge\\": "src//"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
-            "keywords": [
-                "ZendFramework",
-                "autoloading",
-                "laminas",
-                "zf"
-            ],
-            "support": {
-                "forum": "https://discourse.laminas.dev/",
-                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
-                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
-                "source": "https://github.com/laminas/laminas-zendframework-bridge"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-12-21T14:34:37+00:00"
         },
         {
             "name": "masterminds/html5",
@@ -5581,89 +4539,6 @@
             "time": "2021-08-27T13:48:19+00:00"
         },
         {
-            "name": "michelf/php-markdown",
-            "version": "1.5.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/michelf/php-markdown.git",
-                "reference": "155287e4222d2dd69b6a21221617b50668d5892e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/michelf/php-markdown/zipball/155287e4222d2dd69b6a21221617b50668d5892e",
-                "reference": "155287e4222d2dd69b6a21221617b50668d5892e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-lib": "1.4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Michelf": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Michel Fortin",
-                    "email": "michel.fortin@michelf.ca",
-                    "homepage": "https://michelf.ca/",
-                    "role": "Developer"
-                },
-                {
-                    "name": "John Gruber",
-                    "homepage": "https://daringfireball.net/"
-                }
-            ],
-            "description": "PHP Markdown",
-            "homepage": "https://michelf.ca/projects/php-markdown/",
-            "keywords": [
-                "markdown"
-            ],
-            "time": "2015-12-22T18:18:12+00:00"
-        },
-        {
-            "name": "midcamp/hatter",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/MidCamp/Hatter.git",
-                "reference": "0f5e194858da5b9b26a4e131669fcf5a6cb2c103"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/MidCamp/Hatter/zipball/0f5e194858da5b9b26a4e131669fcf5a6cb2c103",
-                "reference": "0f5e194858da5b9b26a4e131669fcf5a6cb2c103",
-                "shasum": ""
-            },
-            "require": {
-                "spress/spress": "^2.1"
-            },
-            "type": "butler-styleguide",
-            "autoload": {
-                "psr-0": {
-                    "MidCamp\\": "src/"
-                }
-            },
-            "license": [
-                "MIT"
-            ],
-            "support": {
-                "source": "https://github.com/MidCamp/Hatter/tree/master",
-                "issues": "https://github.com/MidCamp/Hatter/issues"
-            },
-            "time": "2019-11-02T13:57:41+00:00"
-        },
-        {
             "name": "nette/finder",
             "version": "v2.5.2",
             "source": {
@@ -5809,16 +4684,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.13.0",
+            "version": "v4.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "50953a2691a922aa1769461637869a0a2faa3f53"
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/50953a2691a922aa1769461637869a0a2faa3f53",
-                "reference": "50953a2691a922aa1769461637869a0a2faa3f53",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
                 "shasum": ""
             },
             "require": {
@@ -5857,7 +4732,11 @@
                 "parser",
                 "php"
             ],
-            "time": "2021-09-20T12:20:58+00:00"
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
+            },
+            "time": "2021-11-30T19:35:32+00:00"
         },
         {
             "name": "oomphinc/composer-installers-extender",
@@ -6258,56 +5137,6 @@
             "time": "2020-12-13T10:20:54+00:00"
         },
         {
-            "name": "pimple/pimple",
-            "version": "v3.2.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/silexphp/Pimple.git",
-                "reference": "9e403941ef9d65d20cba7d54e29fe906db42cf32"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/silexphp/Pimple/zipball/9e403941ef9d65d20cba7d54e29fe906db42cf32",
-                "reference": "9e403941ef9d65d20cba7d54e29fe906db42cf32",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0",
-                "psr/container": "^1.0"
-            },
-            "require-dev": {
-                "symfony/phpunit-bridge": "^3.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Pimple": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "Pimple, a simple Dependency Injection Container",
-            "homepage": "http://pimple.sensiolabs.org",
-            "keywords": [
-                "container",
-                "dependency injection"
-            ],
-            "time": "2018-01-21T07:42:36+00:00"
-        },
-        {
             "name": "psr/cache",
             "version": "1.0.1",
             "source": {
@@ -6358,20 +5187,20 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.2",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.4.0"
+                "php": ">=7.2.0"
             },
             "type": "library",
             "autoload": {
@@ -6400,9 +5229,64 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
             },
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-03-05T17:36:06+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory/tree/master"
+            },
+            "time": "2019-04-30T12:38:16+00:00"
         },
         {
             "name": "psr/http-message",
@@ -6552,467 +5436,17 @@
             "time": "2019-03-08T08:55:37+00:00"
         },
         {
-            "name": "react/event-loop",
-            "version": "v0.4.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/event-loop.git",
-                "reference": "8bde03488ee897dc6bb3d91e4e17c353f9c5252f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/8bde03488ee897dc6bb3d91e4e17c353f9c5252f",
-                "reference": "8bde03488ee897dc6bb3d91e4e17c353f9c5252f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.8"
-            },
-            "suggest": {
-                "ext-event": "~1.0",
-                "ext-libev": "*",
-                "ext-libevent": ">=0.1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "React\\EventLoop\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Event loop abstraction layer that libraries can use for evented I/O.",
-            "keywords": [
-                "asynchronous",
-                "event-loop"
-            ],
-            "time": "2017-04-27T10:56:23+00:00"
-        },
-        {
-            "name": "react/http",
-            "version": "v0.4.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/http.git",
-                "reference": "aac319bd789cbc7b478d42cde2d03596e97e3222"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/http/zipball/aac319bd789cbc7b478d42cde2d03596e97e3222",
-                "reference": "aac319bd789cbc7b478d42cde2d03596e97e3222",
-                "shasum": ""
-            },
-            "require": {
-                "evenement/evenement": "^2.0 || ^1.0",
-                "php": ">=5.3.0",
-                "react/socket": "^0.4",
-                "react/stream": "^0.4.4",
-                "ringcentral/psr7": "^1.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.10||^5.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "React\\Http\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Library for building an evented http server.",
-            "keywords": [
-                "http"
-            ],
-            "time": "2017-02-13T14:12:50+00:00"
-        },
-        {
-            "name": "react/promise",
-            "version": "v2.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/promise.git",
-                "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/f3cff96a19736714524ca0dd1d4130de73dbbbc4",
-                "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0 || ^6.5 || ^5.7 || ^4.8.36"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "React\\Promise\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jan Sorgalla",
-                    "email": "jsorgalla@gmail.com"
-                }
-            ],
-            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
-            "keywords": [
-                "promise",
-                "promises"
-            ],
-            "support": {
-                "issues": "https://github.com/reactphp/promise/issues",
-                "source": "https://github.com/reactphp/promise/tree/v2.8.0"
-            },
-            "time": "2020-05-12T15:16:56+00:00"
-        },
-        {
-            "name": "react/socket",
-            "version": "v0.4.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/socket.git",
-                "reference": "cf074e53c974df52388ebd09710a9018894745d2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/socket/zipball/cf074e53c974df52388ebd09710a9018894745d2",
-                "reference": "cf074e53c974df52388ebd09710a9018894745d2",
-                "shasum": ""
-            },
-            "require": {
-                "evenement/evenement": "~2.0|~1.0",
-                "php": ">=5.3.0",
-                "react/event-loop": "0.4.*|0.3.*",
-                "react/promise": "^2.0 || ^1.1",
-                "react/stream": "^0.4.5"
-            },
-            "require-dev": {
-                "clue/block-react": "^1.1",
-                "phpunit/phpunit": "~4.8",
-                "react/socket-client": "^0.5.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "React\\Socket\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Async, streaming plaintext TCP/IP and secure TLS socket server for React PHP",
-            "keywords": [
-                "Socket"
-            ],
-            "time": "2017-01-26T09:23:38+00:00"
-        },
-        {
-            "name": "react/stream",
-            "version": "v0.4.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/stream.git",
-                "reference": "44dc7f51ea48624110136b535b9ba44fd7d0c1ee"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/stream/zipball/44dc7f51ea48624110136b535b9ba44fd7d0c1ee",
-                "reference": "44dc7f51ea48624110136b535b9ba44fd7d0c1ee",
-                "shasum": ""
-            },
-            "require": {
-                "evenement/evenement": "^2.0|^1.0",
-                "php": ">=5.3.8"
-            },
-            "require-dev": {
-                "clue/stream-filter": "~1.2",
-                "react/event-loop": "^0.4|^0.3",
-                "react/promise": "^2.0|^1.0"
-            },
-            "suggest": {
-                "react/event-loop": "^0.4",
-                "react/promise": "^2.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "React\\Stream\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Basic readable and writable stream interfaces that support piping.",
-            "keywords": [
-                "pipe",
-                "stream"
-            ],
-            "time": "2017-01-25T14:44:14+00:00"
-        },
-        {
-            "name": "ringcentral/psr7",
-            "version": "1.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ringcentral/psr7.git",
-                "reference": "dcd84bbb49b96c616d1dcc8bfb9bef3f2cd53d1c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ringcentral/psr7/zipball/dcd84bbb49b96c616d1dcc8bfb9bef3f2cd53d1c",
-                "reference": "dcd84bbb49b96c616d1dcc8bfb9bef3f2cd53d1c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3",
-                "psr/http-message": "~1.0"
-            },
-            "provide": {
-                "psr/http-message-implementation": "1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "RingCentral\\Psr7\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "PSR-7 message implementation",
-            "keywords": [
-                "http",
-                "message",
-                "stream",
-                "uri"
-            ],
-            "time": "2018-01-15T21:00:49+00:00"
-        },
-        {
-            "name": "seld/jsonlint",
-            "version": "1.8.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "9ad6ce79c342fbd44df10ea95511a1b24dee5b57"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/9ad6ce79c342fbd44df10ea95511a1b24dee5b57",
-                "reference": "9ad6ce79c342fbd44df10ea95511a1b24dee5b57",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
-            },
-            "bin": [
-                "bin/jsonlint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                }
-            ],
-            "description": "JSON Linter",
-            "keywords": [
-                "json",
-                "linter",
-                "parser",
-                "validator"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/Seldaek",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/seld/jsonlint",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-11-11T09:19:24+00:00"
-        },
-        {
-            "name": "seld/phar-utils",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Seldaek/phar-utils.git",
-                "reference": "8674b1d84ffb47cc59a101f5d5a3b61e87d23796"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/phar-utils/zipball/8674b1d84ffb47cc59a101f5d5a3b61e87d23796",
-                "reference": "8674b1d84ffb47cc59a101f5d5a3b61e87d23796",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Seld\\PharUtils\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be"
-                }
-            ],
-            "description": "PHAR file format utilities, for when PHP phars you up",
-            "keywords": [
-                "phar"
-            ],
-            "time": "2020-07-07T18:42:57+00:00"
-        },
-        {
-            "name": "spress/spress",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/spress/spress.git",
-                "reference": "7925396b0aed20ed181cf3f8fa710d731ba98764"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/spress/spress/zipball/7925396b0aed20ed181cf3f8fa710d731ba98764",
-                "reference": "7925396b0aed20ed181cf3f8fa710d731ba98764",
-                "shasum": ""
-            },
-            "require": {
-                "dflydev/apache-mime-types": "1.0.*",
-                "erusev/parsedown-extra": "0.7.*",
-                "michelf/php-markdown": "1.5.*",
-                "php": ">=5.6",
-                "pimple/pimple": "~3.0",
-                "symfony/console": "3.4.*",
-                "symfony/event-dispatcher": "3.4.*",
-                "symfony/filesystem": "3.4.*",
-                "symfony/finder": "3.4.*",
-                "symfony/lts": "3.0",
-                "symfony/yaml": "3.4.*",
-                "twig/twig": ">=1.8,<2.0",
-                "yosymfony/config-loader": "1.3.*",
-                "yosymfony/embedded-composer": "1.0.*",
-                "yosymfony/httpserver": "1.3.*",
-                "yosymfony/resource-watcher": "1.2.*"
-            },
-            "replace": {
-                "spress/spress-core": "self.version"
-            },
-            "bin": [
-                "bin/spress"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Yosymfony\\Spress\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Victor Puertas",
-                    "email": "vpgugr@gmail.com"
-                }
-            ],
-            "description": "Static site generator with blogs support",
-            "homepage": "http://spress.yosymfony.com",
-            "keywords": [
-                "blog",
-                "cms",
-                "html",
-                "markdown",
-                "twig",
-                "web"
-            ],
-            "time": "2018-04-05T22:01:03+00:00"
-        },
-        {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.1",
+            "version": "3.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e"
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f268ca40d54617c6e06757f83f699775c9b3ff2e",
-                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
                 "shasum": ""
             },
             "require": {
@@ -7055,7 +5489,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-10-11T04:00:11+00:00"
+            "time": "2021-12-12T21:44:58+00:00"
         },
         {
             "name": "stack/builder",
@@ -7113,43 +5547,43 @@
         },
         {
             "name": "symfony-cmf/routing",
-            "version": "1.4.1",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony-cmf/routing.git",
-                "reference": "fb1e7f85ff8c6866238b7e73a490a0a0243ae8ac"
+                "url": "https://github.com/symfony-cmf/Routing.git",
+                "reference": "bbcdf2f6301d740454ba9ebb8adaefd436c36a6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony-cmf/routing/zipball/fb1e7f85ff8c6866238b7e73a490a0a0243ae8ac",
-                "reference": "fb1e7f85ff8c6866238b7e73a490a0a0243ae8ac",
+                "url": "https://api.github.com/repos/symfony-cmf/Routing/zipball/bbcdf2f6301d740454ba9ebb8adaefd436c36a6b",
+                "reference": "bbcdf2f6301d740454ba9ebb8adaefd436c36a6b",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.9|^7.0",
-                "psr/log": "1.*",
-                "symfony/http-kernel": "^2.2|3.*",
-                "symfony/routing": "^2.2|3.*"
+                "php": "^7.2 || ^8.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/http-kernel": "^4.4 || ^5.0",
+                "symfony/routing": "^4.4 || ^5.0"
             },
             "require-dev": {
-                "friendsofsymfony/jsrouting-bundle": "^1.1",
-                "symfony-cmf/testing": "^1.3",
-                "symfony/config": "^2.2|3.*",
-                "symfony/dependency-injection": "^2.0.5|3.*",
-                "symfony/event-dispatcher": "^2.1|3.*"
+                "symfony-cmf/testing": "^3@dev",
+                "symfony/config": "^4.4 || ^5.0",
+                "symfony/dependency-injection": "^4.4 || ^5.0",
+                "symfony/event-dispatcher": "^4.4 || ^5.0",
+                "symfony/phpunit-bridge": "^5.0"
             },
             "suggest": {
-                "symfony/event-dispatcher": "DynamicRouter can optionally trigger an event at the start of matching. Minimal version (~2.1)"
+                "symfony/event-dispatcher": "DynamicRouter can optionally trigger an event at the start of matching. Minimal version (^4.4 || ^5.0)"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Cmf\\Component\\Routing\\": ""
+                    "Symfony\\Cmf\\Component\\Routing\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -7162,192 +5596,57 @@
                     "homepage": "https://github.com/symfony-cmf/Routing/contributors"
                 }
             ],
-            "description": "Extends the Symfony2 routing component for dynamic routes and chaining several routers",
+            "description": "Extends the Symfony routing component for dynamic routes and chaining several routers",
             "homepage": "http://cmf.symfony.com",
             "keywords": [
                 "database",
                 "routing"
             ],
             "support": {
-                "issues": "https://github.com/symfony-cmf/routing/issues",
-                "source": "https://github.com/symfony-cmf/routing/tree/1.4"
+                "issues": "https://github.com/symfony-cmf/Routing/issues",
+                "source": "https://github.com/symfony-cmf/Routing/tree/2.3.4"
             },
-            "time": "2017-05-09T08:10:41+00:00"
-        },
-        {
-            "name": "symfony/class-loader",
-            "version": "v3.4.47",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/class-loader.git",
-                "reference": "a22265a9f3511c0212bf79f54910ca5a77c0e92c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/class-loader/zipball/a22265a9f3511c0212bf79f54910ca5a77c0e92c",
-                "reference": "a22265a9f3511c0212bf79f54910ca5a77c0e92c",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8"
-            },
-            "require-dev": {
-                "symfony/finder": "~2.8|~3.0|~4.0",
-                "symfony/polyfill-apcu": "~1.1"
-            },
-            "suggest": {
-                "symfony/polyfill-apcu": "For using ApcClassLoader on HHVM"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\ClassLoader\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony ClassLoader Component",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/class-loader/tree/v3.4.47"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-10-24T10:57:07+00:00"
-        },
-        {
-            "name": "symfony/config",
-            "version": "v3.4.47",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/config.git",
-                "reference": "bc6b3fd3930d4b53a60b42fe2ed6fc466b75f03f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/bc6b3fd3930d4b53a60b42fe2ed6fc466b75f03f",
-                "reference": "bc6b3fd3930d4b53a60b42fe2ed6fc466b75f03f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/filesystem": "~2.8|~3.0|~4.0",
-                "symfony/polyfill-ctype": "~1.8"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<3.3",
-                "symfony/finder": "<3.3"
-            },
-            "require-dev": {
-                "symfony/dependency-injection": "~3.3|~4.0",
-                "symfony/event-dispatcher": "~3.3|~4.0",
-                "symfony/finder": "~3.3|~4.0",
-                "symfony/yaml": "~3.0|~4.0"
-            },
-            "suggest": {
-                "symfony/yaml": "To use the yaml reference dumper"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Config\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Config Component",
-            "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2021-11-08T16:33:10+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.47",
+            "version": "v4.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "a10b1da6fc93080c180bba7219b5ff5b7518fe81"
+                "reference": "329b3a75cc6b16d435ba1b1a41df54a53382a3f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/a10b1da6fc93080c180bba7219b5ff5b7518fe81",
-                "reference": "a10b1da6fc93080c180bba7219b5ff5b7518fe81",
+                "url": "https://api.github.com/repos/symfony/console/zipball/329b3a75cc6b16d435ba1b1a41df54a53382a3f0",
+                "reference": "329b3a75cc6b16d435ba1b1a41df54a53382a3f0",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/debug": "~2.8|~3.0|~4.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=7.1.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.8",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.1|^2"
             },
             "conflict": {
+                "psr/log": ">=3",
                 "symfony/dependency-injection": "<3.4",
+                "symfony/event-dispatcher": "<4.3|>=5",
+                "symfony/lock": "<4.4",
                 "symfony/process": "<3.3"
             },
             "provide": {
-                "psr/log-implementation": "1.0"
+                "psr/log-implementation": "1.0|2.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "~3.3|~4.0",
-                "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
-                "symfony/lock": "~3.4|~4.0",
-                "symfony/process": "~3.3|~4.0"
+                "psr/log": "^1|^2",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/event-dispatcher": "^4.3",
+                "symfony/lock": "^4.4|^5.0",
+                "symfony/process": "^3.4|^4.0|^5.0",
+                "symfony/var-dumper": "^4.3|^5.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -7378,10 +5677,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Console Component",
+            "description": "Eases the creation of beautiful and testable command line interfaces",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/console/tree/v3.4.47"
+                "source": "https://github.com/symfony/console/tree/v4.4.34"
             },
             "funding": [
                 {
@@ -7397,31 +5696,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2021-11-04T12:23:33+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.4.47",
+            "version": "v4.4.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "ab42889de57fdfcfcc0759ab102e2fd4ea72dcae"
+                "reference": "43ede438d4cb52cd589ae5dc070e9323866ba8e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/ab42889de57fdfcfcc0759ab102e2fd4ea72dcae",
-                "reference": "ab42889de57fdfcfcc0759ab102e2fd4ea72dcae",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/43ede438d4cb52cd589ae5dc070e9323866ba8e0",
+                "reference": "43ede438d4cb52cd589ae5dc070e9323866ba8e0",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "psr/log": "~1.0"
+                "php": ">=7.1.3",
+                "psr/log": "^1|^2|^3"
             },
             "conflict": {
-                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
+                "symfony/http-kernel": "<3.4"
             },
             "require-dev": {
-                "symfony/http-kernel": "~2.8|~3.0|~4.0"
+                "symfony/http-kernel": "^3.4|^4.0|^5.0"
             },
             "type": "library",
             "autoload": {
@@ -7446,10 +5745,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Debug Component",
+            "description": "Provides tools to ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/debug/tree/v3.4.47"
+                "source": "https://github.com/symfony/debug/tree/v4.4.31"
             },
             "funding": [
                 {
@@ -7465,39 +5764,42 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2021-09-24T13:30:14+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v3.4.47",
+            "version": "v4.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "51d2a2708c6ceadad84393f8581df1dcf9e5e84b"
+                "reference": "117d7f132ed7efbd535ec947709d49bec1b9d24b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/51d2a2708c6ceadad84393f8581df1dcf9e5e84b",
-                "reference": "51d2a2708c6ceadad84393f8581df1dcf9e5e84b",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/117d7f132ed7efbd535ec947709d49bec1b9d24b",
+                "reference": "117d7f132ed7efbd535ec947709d49bec1b9d24b",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "psr/container": "^1.0"
+                "php": ">=7.1.3",
+                "psr/container": "^1.0",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.1.6|^2"
             },
             "conflict": {
-                "symfony/config": "<3.3.7",
-                "symfony/finder": "<3.3",
+                "symfony/config": "<4.3|>=5.0",
+                "symfony/finder": "<3.4",
                 "symfony/proxy-manager-bridge": "<3.4",
                 "symfony/yaml": "<3.4"
             },
             "provide": {
-                "psr/container-implementation": "1.0"
+                "psr/container-implementation": "1.0",
+                "symfony/service-implementation": "1.0|2.0"
             },
             "require-dev": {
-                "symfony/config": "~3.3|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/yaml": "~3.4|~4.0"
+                "symfony/config": "^4.3",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/yaml": "^4.4|^5.0"
             },
             "suggest": {
                 "symfony/config": "",
@@ -7529,10 +5831,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony DependencyInjection Component",
+            "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v3.4.47"
+                "source": "https://github.com/symfony/dependency-injection/tree/v4.4.34"
             },
             "funding": [
                 {
@@ -7548,35 +5850,178 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2021-11-15T14:42:25+00:00"
         },
         {
-            "name": "symfony/event-dispatcher",
-            "version": "v3.4.47",
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "31fde73757b6bad247c54597beef974919ec6860"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/31fde73757b6bad247c54597beef974919ec6860",
-                "reference": "31fde73757b6bad247c54597beef974919ec6860",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/6f981ee24cf69ee7ce9736146d1c57c2780598a8",
+                "reference": "6f981ee24cf69ee7ce9736146d1c57c2780598a8",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=7.1"
             },
-            "conflict": {
-                "symfony/dependency-injection": "<3.3"
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-12T14:48:14+00:00"
+        },
+        {
+            "name": "symfony/error-handler",
+            "version": "v4.4.34",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/error-handler.git",
+                "reference": "17785c374645def1e884d8ec49976c156c61db4d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/17785c374645def1e884d8ec49976c156c61db4d",
+                "reference": "17785c374645def1e884d8ec49976c156c61db4d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "psr/log": "^1|^2|^3",
+                "symfony/debug": "^4.4.5",
+                "symfony/var-dumper": "^4.4|^5.0"
             },
             "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
-                "symfony/debug": "~3.4|~4.4",
-                "symfony/dependency-injection": "~3.3|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/stopwatch": "~2.8|~3.0|~4.0"
+                "symfony/http-kernel": "^4.4|^5.0",
+                "symfony/serializer": "^4.4|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ErrorHandler\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to manage errors and ease debugging PHP code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/error-handler/tree/v4.4.34"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-12T14:57:39+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v4.4.34",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "1a024b45369c9d55d76b6b8a241bd20c9ea1cbd8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/1a024b45369c9d55d76b6b8a241bd20c9ea1cbd8",
+                "reference": "1a024b45369c9d55d76b6b8a241bd20c9ea1cbd8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/event-dispatcher-contracts": "^1.1",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<3.4"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "1.1"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/error-handler": "~3.4|~4.4",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/http-foundation": "^3.4|^4.0|^5.0",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/stopwatch": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -7605,10 +6050,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony EventDispatcher Component",
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v3.4.47"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v4.4.34"
             },
             "funding": [
                 {
@@ -7624,34 +6069,43 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2021-11-15T14:42:25+00:00"
         },
         {
-            "name": "symfony/filesystem",
-            "version": "v3.4.47",
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v1.1.11",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "e58d7841cddfed6e846829040dca2cca0ebbbbb3"
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "01e9a4efac0ee33a05dfdf93b346f62e7d0e998c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e58d7841cddfed6e846829040dca2cca0ebbbbb3",
-                "reference": "e58d7841cddfed6e846829040dca2cca0ebbbbb3",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/01e9a4efac0ee33a05dfdf93b346f62e7d0e998c",
+                "reference": "01e9a4efac0ee33a05dfdf93b346f62e7d0e998c",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-ctype": "~1.8"
+                "php": ">=7.1.3"
+            },
+            "suggest": {
+                "psr/event-dispatcher": "",
+                "symfony/event-dispatcher-implementation": ""
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -7659,16 +6113,27 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
                 },
                 {
                     "name": "Symfony Community",
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Filesystem Component",
+            "description": "Generic abstractions related to dispatching event",
             "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v1.1.11"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -7683,33 +6148,42 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2021-03-23T15:25:38+00:00"
         },
         {
-            "name": "symfony/finder",
-            "version": "v3.4.47",
+            "name": "symfony/http-client-contracts",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/finder.git",
-                "reference": "b6b6ad3db3edb1b4b1c1896b1975fb684994de6e"
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "ec82e57b5b714dbb69300d348bd840b345e24166"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/b6b6ad3db3edb1b4b1c1896b1975fb684994de6e",
-                "reference": "b6b6ad3db3edb1b4b1c1896b1975fb684994de6e",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/ec82e57b5b714dbb69300d348bd840b345e24166",
+                "reference": "ec82e57b5b714dbb69300d348bd840b345e24166",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=7.2.5"
+            },
+            "suggest": {
+                "symfony/http-client-implementation": ""
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Component\\Finder\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -7717,16 +6191,27 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
                 },
                 {
                     "name": "Symfony Community",
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Finder Component",
+            "description": "Generic abstractions related to HTTP clients",
             "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v2.5.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -7741,29 +6226,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-16T17:02:08+00:00"
+            "time": "2021-11-03T09:24:47+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.4.47",
+            "version": "v4.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "b9885fcce6fe494201da4f70a9309770e9d13dc8"
+                "reference": "f4cbbb6fc428588ce8373802461e7fe84e6809ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/b9885fcce6fe494201da4f70a9309770e9d13dc8",
-                "reference": "b9885fcce6fe494201da4f70a9309770e9d13dc8",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/f4cbbb6fc428588ce8373802461e7fe84e6809ab",
+                "reference": "f4cbbb6fc428588ce8373802461e7fe84e6809ab",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": ">=7.1.3",
+                "symfony/mime": "^4.3|^5.0",
                 "symfony/polyfill-mbstring": "~1.1",
-                "symfony/polyfill-php70": "~1.6"
+                "symfony/polyfill-php80": "^1.16"
             },
             "require-dev": {
-                "symfony/expression-language": "~2.8|~3.0|~4.0"
+                "predis/predis": "~1.0",
+                "symfony/expression-language": "^3.4|^4.0|^5.0"
             },
             "type": "library",
             "autoload": {
@@ -7788,10 +6275,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony HttpFoundation Component",
+            "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v3.4.47"
+                "source": "https://github.com/symfony/http-foundation/tree/v4.4.34"
             },
             "funding": [
                 {
@@ -7807,65 +6294,67 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2021-11-04T12:23:33+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.4.49",
+            "version": "v4.4.35",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "5aa72405f5bd5583c36ed6e756acb17d3f98ac40"
+                "reference": "fb793f1381c34b79a43596a532a6a49bd729c9db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/5aa72405f5bd5583c36ed6e756acb17d3f98ac40",
-                "reference": "5aa72405f5bd5583c36ed6e756acb17d3f98ac40",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/fb793f1381c34b79a43596a532a6a49bd729c9db",
+                "reference": "fb793f1381c34b79a43596a532a6a49bd729c9db",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "psr/log": "~1.0",
-                "symfony/debug": "^3.3.3|~4.0",
-                "symfony/event-dispatcher": "~2.8|~3.0|~4.0",
-                "symfony/http-foundation": "~3.4.12|~4.0.12|^4.1.1",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-php56": "~1.8"
+                "php": ">=7.1.3",
+                "psr/log": "^1|^2",
+                "symfony/error-handler": "^4.4",
+                "symfony/event-dispatcher": "^4.4",
+                "symfony/http-client-contracts": "^1.1|^2",
+                "symfony/http-foundation": "^4.4.30|^5.3.7",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-php73": "^1.9",
+                "symfony/polyfill-php80": "^1.16"
             },
             "conflict": {
-                "symfony/config": "<2.8",
-                "symfony/dependency-injection": "<3.4.10|<4.0.10,>=4",
-                "symfony/var-dumper": "<3.3",
-                "twig/twig": "<1.34|<2.4,>=2"
+                "symfony/browser-kit": "<4.3",
+                "symfony/config": "<3.4",
+                "symfony/console": ">=5",
+                "symfony/dependency-injection": "<4.3",
+                "symfony/translation": "<4.2",
+                "twig/twig": "<1.43|<2.13,>=2"
             },
             "provide": {
-                "psr/log-implementation": "1.0"
+                "psr/log-implementation": "1.0|2.0"
             },
             "require-dev": {
-                "psr/cache": "~1.0",
-                "symfony/browser-kit": "~2.8|~3.0|~4.0",
-                "symfony/class-loader": "~2.8|~3.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
-                "symfony/console": "~2.8|~3.0|~4.0",
-                "symfony/css-selector": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "^3.4.10|^4.0.10",
-                "symfony/dom-crawler": "~2.8|~3.0|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/finder": "~2.8|~3.0|~4.0",
-                "symfony/process": "~2.8|~3.0|~4.0",
-                "symfony/routing": "~3.4|~4.0",
-                "symfony/stopwatch": "~2.8|~3.0|~4.0",
-                "symfony/templating": "~2.8|~3.0|~4.0",
-                "symfony/translation": "~2.8|~3.0|~4.0",
-                "symfony/var-dumper": "~3.3|~4.0"
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "symfony/browser-kit": "^4.3|^5.0",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/console": "^3.4|^4.0",
+                "symfony/css-selector": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^4.3|^5.0",
+                "symfony/dom-crawler": "^3.4|^4.0|^5.0",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/finder": "^3.4|^4.0|^5.0",
+                "symfony/process": "^3.4|^4.0|^5.0",
+                "symfony/routing": "^3.4|^4.0|^5.0",
+                "symfony/stopwatch": "^3.4|^4.0|^5.0",
+                "symfony/templating": "^3.4|^4.0|^5.0",
+                "symfony/translation": "^4.2|^5.0",
+                "symfony/translation-contracts": "^1.1|^2",
+                "twig/twig": "^1.43|^2.13|^3.0.4"
             },
             "suggest": {
                 "symfony/browser-kit": "",
                 "symfony/config": "",
                 "symfony/console": "",
-                "symfony/dependency-injection": "",
-                "symfony/finder": "",
-                "symfony/var-dumper": ""
+                "symfony/dependency-injection": ""
             },
             "type": "library",
             "autoload": {
@@ -7890,10 +6379,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony HttpKernel Component",
+            "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v3.4.49"
+                "source": "https://github.com/symfony/http-kernel/tree/v4.4.35"
             },
             "funding": [
                 {
@@ -7909,81 +6398,51 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-19T12:06:59+00:00"
+            "time": "2021-11-24T08:40:10+00:00"
         },
         {
-            "name": "symfony/lts",
-            "version": "v3",
+            "name": "symfony/mime",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/lts.git",
-                "reference": "3a4e88df038e3197e6b66d091d2495fd7d255c0b"
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "d4365000217b67c01acff407573906ff91bcfb34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/lts/zipball/3a4e88df038e3197e6b66d091d2495fd7d255c0b",
-                "reference": "3a4e88df038e3197e6b66d091d2495fd7d255c0b",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/d4365000217b67c01acff407573906ff91bcfb34",
+                "reference": "d4365000217b67c01acff407573906ff91bcfb34",
                 "shasum": ""
             },
-            "conflict": {
-                "symfony/asset": ">=4",
-                "symfony/browser-kit": ">=4",
-                "symfony/cache": ">=4",
-                "symfony/class-loader": ">=4",
-                "symfony/config": ">=4",
-                "symfony/console": ">=4",
-                "symfony/css-selector": ">=4",
-                "symfony/debug": ">=4",
-                "symfony/debug-bundle": ">=4",
-                "symfony/dependency-injection": ">=4",
-                "symfony/doctrine-bridge": ">=4",
-                "symfony/dom-crawler": ">=4",
-                "symfony/dotenv": ">=4",
-                "symfony/event-dispatcher": ">=4",
-                "symfony/expression-language": ">=4",
-                "symfony/filesystem": ">=4",
-                "symfony/finder": ">=4",
-                "symfony/form": ">=4",
-                "symfony/framework-bundle": ">=4",
-                "symfony/http-foundation": ">=4",
-                "symfony/http-kernel": ">=4",
-                "symfony/inflector": ">=4",
-                "symfony/intl": ">=4",
-                "symfony/ldap": ">=4",
-                "symfony/lock": ">=4",
-                "symfony/monolog-bridge": ">=4",
-                "symfony/options-resolver": ">=4",
-                "symfony/process": ">=4",
-                "symfony/property-access": ">=4",
-                "symfony/property-info": ">=4",
-                "symfony/proxy-manager-bridge": ">=4",
-                "symfony/routing": ">=4",
-                "symfony/security": ">=4",
-                "symfony/security-bundle": ">=4",
-                "symfony/security-core": ">=4",
-                "symfony/security-csrf": ">=4",
-                "symfony/security-guard": ">=4",
-                "symfony/security-http": ">=4",
-                "symfony/serializer": ">=4",
-                "symfony/stopwatch": ">=4",
-                "symfony/symfony": ">=4",
-                "symfony/templating": ">=4",
-                "symfony/translation": ">=4",
-                "symfony/twig-bridge": ">=4",
-                "symfony/twig-bundle": ">=4",
-                "symfony/validator": ">=4",
-                "symfony/var-dumper": ">=4",
-                "symfony/web-link": ">=4",
-                "symfony/web-profiler-bundle": ">=4",
-                "symfony/web-server-bundle": ">=4",
-                "symfony/workflow": ">=4",
-                "symfony/yaml": ">=4"
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/polyfill-php80": "^1.16"
             },
-            "type": "metapackage",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3-dev"
-                }
+            "conflict": {
+                "egulias/email-validator": "~3.0.0",
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/mailer": "<4.4"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3.1",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/property-access": "^4.4|^5.1|^6.0",
+                "symfony/property-info": "^4.4|^5.1|^6.0",
+                "symfony/serializer": "^5.2|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -7999,30 +6458,47 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Enforces Long Term Supported versions of Symfony components",
+            "description": "Allows manipulating MIME messages",
             "homepage": "https://symfony.com",
-            "abandoned": "symfony/flex",
-            "time": "2017-10-19T02:02:36+00:00"
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/mime/tree/v5.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-23T10:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.24.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
-                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
-            },
-            "provide": {
-                "ext-ctype": "*"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -8038,12 +6514,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -8068,7 +6544,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -8084,27 +6560,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-20T20:35:02+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-iconv",
-            "version": "v1.24.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "f1aed619e28cb077fc83fac8c4c0383578356e40"
+                "reference": "63b5bb7db83e5673936d6e3b8b3e022ff6474933"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/f1aed619e28cb077fc83fac8c4c0383578356e40",
-                "reference": "f1aed619e28cb077fc83fac8c4c0383578356e40",
+                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/63b5bb7db83e5673936d6e3b8b3e022ff6474933",
+                "reference": "63b5bb7db83e5673936d6e3b8b3e022ff6474933",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
-            },
-            "provide": {
-                "ext-iconv": "*"
             },
             "suggest": {
                 "ext-iconv": "For best performance"
@@ -8120,12 +6593,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Iconv\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Iconv\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -8151,7 +6624,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -8167,20 +6640,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-04T09:04:05+00:00"
+            "time": "2021-05-27T09:27:20+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.24.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "749045c69efb97c70d25d7463abba812e91f3a44"
+                "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/749045c69efb97c70d25d7463abba812e91f3a44",
-                "reference": "749045c69efb97c70d25d7463abba812e91f3a44",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/65bd267525e82759e7d8c4e8ceea44f398838e65",
+                "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65",
                 "shasum": ""
             },
             "require": {
@@ -8202,12 +6675,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -8238,7 +6711,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -8254,11 +6727,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-14T14:02:44+00:00"
+            "time": "2021-05-27T09:27:20+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.24.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -8287,12 +6760,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -8322,7 +6795,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -8342,23 +6815,20 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.24.0",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825"
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/0abb51d2f102e00a4eefcf46ba7fec406d245825",
-                "reference": "0abb51d2f102e00a4eefcf46ba7fec406d245825",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
-            },
-            "provide": {
-                "ext-mbstring": "*"
             },
             "suggest": {
                 "ext-mbstring": "For best performance"
@@ -8374,12 +6844,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Mbstring\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -8405,7 +6875,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.1"
             },
             "funding": [
                 {
@@ -8421,147 +6891,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-30T18:21:41+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php56",
-            "version": "v1.20.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php56.git",
-                "reference": "54b8cd7e6c1643d78d011f3be89f3ef1f9f4c675"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/54b8cd7e6c1643d78d011f3be89f3ef1f9f4c675",
-                "reference": "54b8cd7e6c1643d78d011f3be89f3ef1f9f4c675",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "metapackage",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.20-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 5.6+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php56/tree/v1.20.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-10-23T14:02:19+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php70",
-            "version": "v1.20.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "5f03a781d984aae42cebd18e7912fa80f02ee644"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/5f03a781d984aae42cebd18e7912fa80f02ee644",
-                "reference": "5f03a781d984aae42cebd18e7912fa80f02ee644",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "metapackage",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.20-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 7.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php70/tree/v1.20.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-05-27T12:26:48+00:00"
         },
         {
             "name": "symfony/polyfill-php72",
-            "version": "v1.24.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php72.git",
@@ -8587,12 +6921,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php72\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -8617,7 +6951,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php72/tree/v1.24.0"
+                "source": "https://github.com/symfony/polyfill-php72/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -8636,21 +6970,184 @@
             "time": "2021-05-27T09:17:38+00:00"
         },
         {
-            "name": "symfony/process",
-            "version": "v3.4.47",
+            "name": "symfony/polyfill-php73",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "b8648cf1d5af12a44a51d07ef9bf980921f15fca"
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "cc5db0e22b3cb4111010e48785a97f670b350ca5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/b8648cf1d5af12a44a51d07ef9bf980921f15fca",
-                "reference": "b8648cf1d5af12a44a51d07ef9bf980921f15fca",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/cc5db0e22b3cb4111010e48785a97f670b350ca5",
+                "reference": "cc5db0e22b3cb4111010e48785a97f670b350ca5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.25.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-06-05T21:20:04+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.23.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-28T13:41:28+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v4.4.35",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "c2098705326addae6e6742151dfade47ac71da1b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c2098705326addae6e6742151dfade47ac71da1b",
+                "reference": "c2098705326addae6e6742151dfade47ac71da1b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/polyfill-php80": "^1.16"
             },
             "type": "library",
             "autoload": {
@@ -8675,10 +7172,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Process Component",
+            "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v3.4.47"
+                "source": "https://github.com/symfony/process/tree/v4.4.35"
             },
             "funding": [
                 {
@@ -8694,31 +7191,36 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2021-11-22T22:36:24+00:00"
         },
         {
             "name": "symfony/psr-http-message-bridge",
-            "version": "v1.2.0",
+            "version": "v2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/psr-http-message-bridge.git",
-                "reference": "9ab9d71f97d5c7d35a121a7fb69f74fee95cd0ad"
+                "reference": "22b37c8a3f6b5d94e9cdbd88e1270d96e2f97b34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/9ab9d71f97d5c7d35a121a7fb69f74fee95cd0ad",
-                "reference": "9ab9d71f97d5c7d35a121a7fb69f74fee95cd0ad",
+                "url": "https://api.github.com/repos/symfony/psr-http-message-bridge/zipball/22b37c8a3f6b5d94e9cdbd88e1270d96e2f97b34",
+                "reference": "22b37c8a3f6b5d94e9cdbd88e1270d96e2f97b34",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1",
+                "php": ">=7.1",
                 "psr/http-message": "^1.0",
-                "symfony/http-foundation": "^3.4 || ^4.0"
+                "symfony/http-foundation": "^4.4 || ^5.0 || ^6.0"
             },
             "require-dev": {
                 "nyholm/psr7": "^1.1",
-                "symfony/phpunit-bridge": "^3.4.20 || ^4.0",
-                "zendframework/zend-diactoros": "^1.4.1 || ^2.0"
+                "psr/log": "^1.1 || ^2 || ^3",
+                "symfony/browser-kit": "^4.4 || ^5.0 || ^6.0",
+                "symfony/config": "^4.4 || ^5.0 || ^6.0",
+                "symfony/event-dispatcher": "^4.4 || ^5.0 || ^6.0",
+                "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
+                "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0",
+                "symfony/phpunit-bridge": "^5.4@dev || ^6.0"
             },
             "suggest": {
                 "nyholm/psr7": "For a super lightweight PSR-7/17 implementation"
@@ -8726,7 +7228,7 @@
             "type": "symfony-bridge",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-main": "2.1-dev"
                 }
             },
             "autoload": {
@@ -8743,12 +7245,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
                 }
             ],
             "description": "PSR HTTP message bridge",
@@ -8761,40 +7263,55 @@
             ],
             "support": {
                 "issues": "https://github.com/symfony/psr-http-message-bridge/issues",
-                "source": "https://github.com/symfony/psr-http-message-bridge/tree/master"
+                "source": "https://github.com/symfony/psr-http-message-bridge/tree/v2.1.2"
             },
-            "time": "2019-03-11T18:22:33+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-05T13:13:39+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v3.4.47",
+            "version": "v4.4.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "3e522ac69cadffd8131cc2b22157fa7662331a6c"
+                "reference": "fc9dda0c8496f8ef0a89805c2eabfc43b8cef366"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/3e522ac69cadffd8131cc2b22157fa7662331a6c",
-                "reference": "3e522ac69cadffd8131cc2b22157fa7662331a6c",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/fc9dda0c8496f8ef0a89805c2eabfc43b8cef366",
+                "reference": "fc9dda0c8496f8ef0a89805c2eabfc43b8cef366",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=7.1.3",
+                "symfony/polyfill-php80": "^1.16"
             },
             "conflict": {
-                "symfony/config": "<3.3.1",
-                "symfony/dependency-injection": "<3.3",
+                "symfony/config": "<4.2",
+                "symfony/dependency-injection": "<3.4",
                 "symfony/yaml": "<3.4"
             },
             "require-dev": {
-                "doctrine/annotations": "~1.0",
-                "psr/log": "~1.0",
-                "symfony/config": "^3.3.1|~4.0",
-                "symfony/dependency-injection": "~3.3|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/http-foundation": "~2.8|~3.0|~4.0",
-                "symfony/yaml": "~3.4|~4.0"
+                "doctrine/annotations": "^1.10.4",
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^4.2|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/http-foundation": "^3.4|^4.0|^5.0",
+                "symfony/yaml": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "doctrine/annotations": "For using the annotation loader",
@@ -8826,7 +7343,7 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Routing Component",
+            "description": "Maps an HTTP request to a set of configuration variables",
             "homepage": "https://symfony.com",
             "keywords": [
                 "router",
@@ -8835,7 +7352,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v3.4.47"
+                "source": "https://github.com/symfony/routing/tree/v4.4.34"
             },
             "funding": [
                 {
@@ -8851,48 +7368,51 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2021-11-04T12:23:33+00:00"
         },
         {
             "name": "symfony/serializer",
-            "version": "v3.4.47",
+            "version": "v4.4.35",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "6d69ccc1dcfb64c1e9c9444588643e98718d1849"
+                "reference": "1b2ae02cb1b923987947e013688c51954a80b751"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/6d69ccc1dcfb64c1e9c9444588643e98718d1849",
-                "reference": "6d69ccc1dcfb64c1e9c9444588643e98718d1849",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/1b2ae02cb1b923987947e013688c51954a80b751",
+                "reference": "1b2ae02cb1b923987947e013688c51954a80b751",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-ctype": "~1.8"
+                "php": ">=7.1.3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php80": "^1.16"
             },
             "conflict": {
-                "phpdocumentor/type-resolver": "<0.2.1",
-                "symfony/dependency-injection": "<3.2",
-                "symfony/property-access": ">=3.0,<3.0.4|>=2.8,<2.8.4",
-                "symfony/property-info": "<3.1",
+                "phpdocumentor/reflection-docblock": "<3.0|>=3.2.0,<3.2.2",
+                "phpdocumentor/type-resolver": "<0.3.0|1.3.*",
+                "symfony/dependency-injection": "<3.4",
+                "symfony/property-access": "<3.4",
+                "symfony/property-info": "<3.4",
                 "symfony/yaml": "<3.4"
             },
             "require-dev": {
-                "doctrine/annotations": "~1.0",
-                "doctrine/cache": "~1.0",
-                "phpdocumentor/reflection-docblock": "^3.0|^4.0",
-                "symfony/cache": "~3.1|~4.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "~3.2|~4.0",
-                "symfony/http-foundation": "~2.8|~3.0|~4.0",
-                "symfony/property-access": "~2.8|~3.0|~4.0",
-                "symfony/property-info": "^3.4.13|~4.0",
-                "symfony/yaml": "~3.4|~4.0"
+                "doctrine/annotations": "^1.10.4",
+                "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
+                "symfony/cache": "^3.4|^4.0|^5.0",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/error-handler": "^4.4|^5.0",
+                "symfony/http-foundation": "^3.4|^4.0|^5.0",
+                "symfony/mime": "^4.4|^5.0",
+                "symfony/property-access": "^3.4.41|^4.4.9|^5.0.9",
+                "symfony/property-info": "^3.4.13|~4.0|^5.0",
+                "symfony/validator": "^3.4|^4.0|^5.0",
+                "symfony/yaml": "^3.4|^4.0|^5.0"
             },
             "suggest": {
-                "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
-                "doctrine/cache": "For using the default cached annotation reader and metadata cache.",
+                "doctrine/annotations": "For using the annotation mapping.",
                 "psr/cache-implementation": "For using the metadata cache.",
                 "symfony/config": "For using the XML mapping loader.",
                 "symfony/http-foundation": "For using a MIME type guesser within the DataUriNormalizer.",
@@ -8923,10 +7443,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Serializer Component",
+            "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v3.4.47"
+                "source": "https://github.com/symfony/serializer/tree/v4.4.35"
             },
             "funding": [
                 {
@@ -8942,40 +7462,130 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2021-11-24T08:12:42+00:00"
         },
         {
-            "name": "symfony/translation",
-            "version": "v3.4.47",
+            "name": "symfony/service-contracts",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/translation.git",
-                "reference": "be83ee6c065cb32becdb306ba61160d598b1ce88"
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/be83ee6c065cb32becdb306ba61160d598b1ce88",
-                "reference": "be83ee6c065cb32becdb306ba61160d598b1ce88",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
+                "reference": "1ab11b933cd6bc5464b08e81e2c5b07dec58b0fc",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=7.2.5",
+                "psr/container": "^1.1",
+                "symfony/deprecation-contracts": "^2.1"
             },
             "conflict": {
-                "symfony/config": "<2.8",
+                "ext-psr": "<1.1|>=2"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-04T16:48:04+00:00"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v4.4.34",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "26d330720627b234803595ecfc0191eeabc65190"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/26d330720627b234803595ecfc0191eeabc65190",
+                "reference": "26d330720627b234803595ecfc0191eeabc65190",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/translation-contracts": "^1.1.6|^2"
+            },
+            "conflict": {
+                "symfony/config": "<3.4",
                 "symfony/dependency-injection": "<3.4",
+                "symfony/http-kernel": "<4.4",
                 "symfony/yaml": "<3.4"
             },
+            "provide": {
+                "symfony/translation-implementation": "1.0|2.0"
+            },
             "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "~3.4|~4.0",
-                "symfony/finder": "~2.8|~3.0|~4.0",
-                "symfony/http-kernel": "~3.4|~4.0",
-                "symfony/intl": "^2.8.18|^3.2.5|~4.0",
-                "symfony/var-dumper": "~3.4|~4.0",
-                "symfony/yaml": "~3.4|~4.0"
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/console": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/finder": "~2.8|~3.0|~4.0|^5.0",
+                "symfony/http-kernel": "^4.4",
+                "symfony/intl": "^3.4|^4.0|^5.0",
+                "symfony/service-contracts": "^1.1.2|^2",
+                "symfony/yaml": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "psr/log-implementation": "To use logging capability in translator",
@@ -9005,10 +7615,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Translation Component",
+            "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v3.4.47"
+                "source": "https://github.com/symfony/translation/tree/v4.4.34"
             },
             "funding": [
                 {
@@ -9024,60 +7634,146 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2021-11-04T12:23:33+00:00"
         },
         {
-            "name": "symfony/validator",
-            "version": "v3.4.47",
+            "name": "symfony/translation-contracts",
+            "version": "v2.5.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/validator.git",
-                "reference": "d25ceea5c99022aecf37adf157c76c31fc5dcbed"
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "d28150f0f44ce854e942b671fc2620a98aae1b1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/d25ceea5c99022aecf37adf157c76c31fc5dcbed",
-                "reference": "d25ceea5c99022aecf37adf157c76c31fc5dcbed",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/d28150f0f44ce854e942b671fc2620a98aae1b1e",
+                "reference": "d28150f0f44ce854e942b671fc2620a98aae1b1e",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": ">=7.2.5"
+            },
+            "suggest": {
+                "symfony/translation-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/translation-contracts/tree/v2.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-08-17T14:20:01+00:00"
+        },
+        {
+            "name": "symfony/validator",
+            "version": "v4.4.35",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/validator.git",
+                "reference": "629f420d8350634fd8ed686d4472c1f10044b265"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/629f420d8350634fd8ed686d4472c1f10044b265",
+                "reference": "629f420d8350634fd8ed686d4472c1f10044b265",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/translation": "~2.8|~3.0|~4.0"
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/translation-contracts": "^1.1|^2"
             },
             "conflict": {
                 "doctrine/lexer": "<1.0.2",
                 "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0",
-                "symfony/dependency-injection": "<3.3",
-                "symfony/http-kernel": "<3.3.5",
+                "symfony/dependency-injection": "<3.4",
+                "symfony/http-kernel": "<4.4",
+                "symfony/intl": "<4.3",
+                "symfony/translation": ">=5.0",
                 "symfony/yaml": "<3.4"
             },
             "require-dev": {
-                "doctrine/annotations": "~1.7",
-                "doctrine/cache": "~1.0",
-                "egulias/email-validator": "^2.1.10",
-                "symfony/cache": "~3.1|~4.0",
-                "symfony/config": "~2.8|~3.0|~4.0",
-                "symfony/dependency-injection": "~3.3|~4.0",
-                "symfony/expression-language": "~2.8|~3.0|~4.0",
-                "symfony/http-foundation": "~2.8|~3.0|~4.0",
-                "symfony/http-kernel": "^3.3.5|~4.0",
-                "symfony/intl": "^2.8.18|^3.2.5|~4.0",
-                "symfony/property-access": "~2.8|~3.0|~4.0",
-                "symfony/var-dumper": "~3.3|~4.0",
-                "symfony/yaml": "~3.4|~4.0"
+                "doctrine/annotations": "^1.10.4",
+                "doctrine/cache": "^1.0|^2.0",
+                "egulias/email-validator": "^2.1.10|^3",
+                "symfony/cache": "^3.4|^4.0|^5.0",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/expression-language": "^3.4|^4.0|^5.0",
+                "symfony/http-client": "^4.3|^5.0",
+                "symfony/http-foundation": "^4.1|^5.0",
+                "symfony/http-kernel": "^4.4",
+                "symfony/intl": "^4.3|^5.0",
+                "symfony/mime": "^4.4|^5.0",
+                "symfony/property-access": "^3.4|^4.0|^5.0",
+                "symfony/property-info": "^3.4|^4.0|^5.0",
+                "symfony/translation": "^4.2",
+                "symfony/yaml": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "doctrine/annotations": "For using the annotation mapping. You will also need doctrine/cache.",
-                "doctrine/cache": "For using the default cached annotation reader and metadata cache.",
+                "doctrine/cache": "For using the default cached annotation reader.",
                 "egulias/email-validator": "Strict (RFC compliant) email validation",
-                "psr/cache-implementation": "For using the metadata cache.",
+                "psr/cache-implementation": "For using the mapping cache.",
                 "symfony/config": "",
                 "symfony/expression-language": "For using the Expression validator",
                 "symfony/http-foundation": "",
                 "symfony/intl": "",
                 "symfony/property-access": "For accessing properties within comparison constraints",
+                "symfony/property-info": "To automatically add NotNull and Type constraints",
+                "symfony/translation": "For translating validation errors.",
                 "symfony/yaml": ""
             },
             "type": "library",
@@ -9103,10 +7799,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Validator Component",
+            "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/validator/tree/v3.4.47"
+                "source": "https://github.com/symfony/validator/tree/v4.4.35"
             },
             "funding": [
                 {
@@ -9122,31 +7818,120 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-28T05:23:51+00:00"
+            "time": "2021-11-22T21:43:32+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.4.47",
+            "name": "symfony/var-dumper",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "88289caa3c166321883f67fe5130188ebbb47094"
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "89ab66eaef230c9cd1992de2e9a1b26652b127b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/88289caa3c166321883f67fe5130188ebbb47094",
-                "reference": "88289caa3c166321883f67fe5130188ebbb47094",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/89ab66eaef230c9cd1992de2e9a1b26652b127b9",
+                "reference": "89ab66eaef230c9cd1992de2e9a1b26652b127b9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": ">=7.2.5",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.3",
+                "symfony/console": "<4.4"
+            },
+            "require-dev": {
+                "ext-iconv": "*",
+                "symfony/console": "^4.4|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/uid": "^5.1|^6.0",
+                "twig/twig": "^2.13|^3.0.4"
+            },
+            "suggest": {
+                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
+                "ext-intl": "To show region name in time zone dump",
+                "symfony/console": "To use the ServerDumpCommand and/or the bin/var-dump-server script"
+            },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides mechanisms for walking through any arbitrary PHP variable",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-dumper/tree/v5.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-29T15:30:56+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v4.4.34",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "2c309e258adeb9970229042be39b360d34986fad"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/2c309e258adeb9970229042be39b360d34986fad",
+                "reference": "2c309e258adeb9970229042be39b360d34986fad",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "symfony/console": "<3.4"
             },
             "require-dev": {
-                "symfony/console": "~3.4|~4.0"
+                "symfony/console": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
@@ -9174,10 +7959,10 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Yaml Component",
+            "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v3.4.47"
+                "source": "https://github.com/symfony/yaml/tree/v4.4.34"
             },
             "funding": [
                 {
@@ -9193,7 +7978,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2021-11-18T18:49:23+00:00"
         },
         {
             "name": "thinkshout/mailchimp-api-php",
@@ -9295,30 +8080,32 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.44.6",
+            "version": "v2.14.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "ae39480f010ef88adc7938503c9b02d3baf2f3b3"
+                "reference": "66baa66f29ee30e487e05f1679903e36eb01d727"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/ae39480f010ef88adc7938503c9b02d3baf2f3b3",
-                "reference": "ae39480f010ef88adc7938503c9b02d3baf2f3b3",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/66baa66f29ee30e487e05f1679903e36eb01d727",
+                "reference": "66baa66f29ee30e487e05f1679903e36eb01d727",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-ctype": "^1.8"
+                "php": ">=7.1.3",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "^1.3",
+                "symfony/polyfill-php72": "^1.8"
             },
             "require-dev": {
                 "psr/container": "^1.0",
-                "symfony/phpunit-bridge": "^4.4.9|^5.0.9"
+                "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.44-dev"
+                    "dev-master": "2.14-dev"
                 }
             },
             "autoload": {
@@ -9357,7 +8144,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v1.44.6"
+                "source": "https://github.com/twigphp/Twig/tree/v2.14.11"
             },
             "funding": [
                 {
@@ -9369,7 +8156,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-25T13:31:46+00:00"
+            "time": "2022-02-04T06:57:25+00:00"
         },
         {
             "name": "typo3/phar-stream-wrapper",
@@ -9465,292 +8252,9 @@
             ],
             "description": "Helper class to locate a Drupal installation from a given path.",
             "time": "2020-10-27T09:42:17+00:00"
-        },
-        {
-            "name": "yosymfony/config-loader",
-            "version": "v1.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/yosymfony/Config-loader.git",
-                "reference": "32c52be7d15fca7ab7d93d32b2e024746fa17fe7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/yosymfony/Config-loader/zipball/32c52be7d15fca7ab7d93d32b2e024746fa17fe7",
-                "reference": "32c52be7d15fca7ab7d93d32b2e024746fa17fe7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3",
-                "symfony/config": "^2.7|^3.0"
-            },
-            "require-dev": {
-                "symfony/yaml": "^2.7|^3.0",
-                "yosymfony/toml": "0.3.*@dev"
-            },
-            "suggest": {
-                "symfony/yaml": "^2.7|^3.0",
-                "yosymfony/toml": "0.3.*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Yosymfony\\ConfigLoader\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Victor Puertas",
-                    "email": "vpgugr@gmail.com",
-                    "homepage": "http://yosymfony.com"
-                }
-            ],
-            "description": "Configuration loader for YAML, TOML and JSON files",
-            "keywords": [
-                "config",
-                "configuration",
-                "json",
-                "toml",
-                "yaml"
-            ],
-            "time": "2016-10-26T19:18:11+00:00"
-        },
-        {
-            "name": "yosymfony/embedded-composer",
-            "version": "v1.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/yosymfony/Embedded-composer.git",
-                "reference": "bcdf7fb05392c08be22c86248e271bc9a176a78b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/yosymfony/Embedded-composer/zipball/bcdf7fb05392c08be22c86248e271bc9a176a78b",
-                "reference": "bcdf7fb05392c08be22c86248e271bc9a176a78b",
-                "shasum": ""
-            },
-            "require": {
-                "composer/composer": "^1.3",
-                "php": ">=5.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Yosymfony\\EmbeddedComposer\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Dragonfly Development Inc.",
-                    "email": "info@dflydev.com",
-                    "homepage": "http://dflydev.com"
-                },
-                {
-                    "name": "Beau Simensen",
-                    "email": "beau@dflydev.com",
-                    "homepage": "http://beausimensen.com"
-                },
-                {
-                    "name": "Victor Puertas",
-                    "email": "vpgugr@gmail.com",
-                    "homepage": "http://yosymfony.com"
-                }
-            ],
-            "description": "Embed Composer into another application",
-            "keywords": [
-                "composer",
-                "embedded",
-                "extensibility"
-            ],
-            "time": "2017-01-14T18:38:39+00:00"
-        },
-        {
-            "name": "yosymfony/httpserver",
-            "version": "v1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/yosymfony/HttpServer.git",
-                "reference": "7c145578044cffe2b1f0f3d3ec3c6829d73f7719"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/yosymfony/HttpServer/zipball/7c145578044cffe2b1f0f3d3ec3c6829d73f7719",
-                "reference": "7c145578044cffe2b1f0f3d3ec3c6829d73f7719",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.5",
-                "react/http": "0.4.*",
-                "symfony/http-foundation": "^2.7|^3.0",
-                "symfony/http-kernel": "^2.7|^3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Yosymfony\\HttpServer\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Victor Puertas",
-                    "email": "vpgugr@gmail.com"
-                }
-            ],
-            "description": "A simple HTTP server",
-            "homepage": "http://yosymfony.com",
-            "keywords": [
-                "http",
-                "react",
-                "request",
-                "server"
-            ],
-            "time": "2017-01-14T18:23:41+00:00"
-        },
-        {
-            "name": "yosymfony/resource-watcher",
-            "version": "v1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/yosymfony/Resource-watcher.git",
-                "reference": "c20a2cf2b90579d9804ec63dc3991ebe140f0d18"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/yosymfony/Resource-watcher/zipball/c20a2cf2b90579d9804ec63dc3991ebe140f0d18",
-                "reference": "c20a2cf2b90579d9804ec63dc3991ebe140f0d18",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5.5",
-                "symfony/finder": "^2.7|^3.0"
-            },
-            "require-dev": {
-                "symfony/filesystem": "^2.7|^3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Yosymfony\\ResourceWatcher\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Victor Puertas",
-                    "email": "vpgugr@gmail.com"
-                }
-            ],
-            "description": "A simple resource watcher using Symfony Finder",
-            "homepage": "http://yosymfony.com",
-            "keywords": [
-                "finder",
-                "resources",
-                "symfony",
-                "watcher"
-            ],
-            "time": "2017-01-14T17:56:57+00:00"
         }
     ],
     "packages-dev": [
-        {
-            "name": "alchemy/zippy",
-            "version": "0.4.9",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/alchemy-fr/Zippy.git",
-                "reference": "59fbeefb9a249122867ef25e53addfcce31850d7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/alchemy-fr/Zippy/zipball/59fbeefb9a249122867ef25e53addfcce31850d7",
-                "reference": "59fbeefb9a249122867ef25e53addfcce31850d7",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/collections": "~1.0",
-                "php": ">=5.5",
-                "symfony/filesystem": "^2.0.5 || ^3.0 || ^4.0",
-                "symfony/polyfill-mbstring": "^1.3",
-                "symfony/process": "^2.1 || ^3.0 || ^4.0"
-            },
-            "require-dev": {
-                "ext-zip": "*",
-                "guzzle/guzzle": "~3.0",
-                "guzzlehttp/guzzle": "^6.0",
-                "phpunit/phpunit": "^4.0 || ^5.0",
-                "symfony/finder": "^2.0.5 || ^3.0 || ^4.0"
-            },
-            "suggest": {
-                "ext-zip": "To use the ZipExtensionAdapter",
-                "guzzle/guzzle": "To use the GuzzleTeleporter with Guzzle 3",
-                "guzzlehttp/guzzle": "To use the GuzzleTeleporter with Guzzle 6"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Alchemy\\Zippy\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Alchemy",
-                    "email": "dev.team@alchemy.fr",
-                    "homepage": "http://www.alchemy.fr/"
-                }
-            ],
-            "description": "Zippy, the archive manager companion",
-            "keywords": [
-                "bzip",
-                "compression",
-                "tar",
-                "zip"
-            ],
-            "time": "2018-02-22T13:58:36+00:00"
-        },
         {
             "name": "amazeeio/drupal_integrations",
             "version": "0.3.3",
@@ -9803,42 +8307,39 @@
         },
         {
             "name": "behat/behat",
-            "version": "v3.4.3",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Behat/Behat.git",
-                "reference": "d60b161bff1b95ec4bb80bb8cb210ccf890314c2"
+                "reference": "08052f739619a9e9f62f457a67302f0715e6dd13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/Behat/zipball/d60b161bff1b95ec4bb80bb8cb210ccf890314c2",
-                "reference": "d60b161bff1b95ec4bb80bb8cb210ccf890314c2",
+                "url": "https://api.github.com/repos/Behat/Behat/zipball/08052f739619a9e9f62f457a67302f0715e6dd13",
+                "reference": "08052f739619a9e9f62f457a67302f0715e6dd13",
                 "shasum": ""
             },
             "require": {
-                "behat/gherkin": "^4.5.1",
+                "behat/gherkin": "^4.6.0",
                 "behat/transliterator": "^1.2",
-                "container-interop/container-interop": "^1.2",
                 "ext-mbstring": "*",
                 "php": ">=5.3.3",
                 "psr/container": "^1.0",
-                "symfony/class-loader": "~2.1||~3.0||~4.0",
-                "symfony/config": "~2.3||~3.0||~4.0",
-                "symfony/console": "~2.5||~3.0||~4.0",
-                "symfony/dependency-injection": "~2.1||~3.0||~4.0",
-                "symfony/event-dispatcher": "~2.1||~3.0||~4.0",
-                "symfony/translation": "~2.3||~3.0||~4.0",
-                "symfony/yaml": "~2.1||~3.0||~4.0"
+                "symfony/config": "^2.7.51 || ^3.0 || ^4.0 || ^5.0",
+                "symfony/console": "^2.7.51 || ^2.8.33 || ^3.3.15 || ^3.4.3 || ^4.0.3 || ^5.0",
+                "symfony/dependency-injection": "^2.7.51 || ^3.0 || ^4.0 || ^5.0",
+                "symfony/event-dispatcher": "^2.7.51 || ^3.0 || ^4.0 || ^5.0",
+                "symfony/translation": "^2.7.51 || ^3.0 || ^4.0 || ^5.0",
+                "symfony/yaml": "^2.7.51 || ^3.0 || ^4.0 || ^5.0"
             },
             "require-dev": {
+                "container-interop/container-interop": "^1.2",
                 "herrera-io/box": "~1.6.1",
-                "phpunit/phpunit": "^4.8.36|^6.3",
-                "symfony/process": "~2.5|~3.0|~4.0"
+                "phpunit/phpunit": "^4.8.36 || ^6.5.14 || ^7.5.20",
+                "symfony/process": "~2.5 || ^3.0 || ^4.0 || ^5.0"
             },
             "suggest": {
-                "behat/mink-extension": "for integration with Mink testing framework",
-                "behat/symfony2-extension": "for integration with Symfony2 web framework",
-                "behat/yii-extension": "for integration with Yii web framework"
+                "ext-dom": "Needed to output test results in JUnit format."
             },
             "bin": [
                 "bin/behat"
@@ -9846,13 +8347,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2.x-dev"
+                    "dev-master": "3.6.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Behat\\Behat": "src/",
-                    "Behat\\Testwork": "src/"
+                "psr-4": {
+                    "Behat\\Behat\\": "src/Behat/Behat/",
+                    "Behat\\Testwork\\": "src/Behat/Testwork/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -9882,29 +8383,33 @@
                 "symfony",
                 "testing"
             ],
-            "time": "2017-11-27T10:37:56+00:00"
+            "support": {
+                "issues": "https://github.com/Behat/Behat/issues",
+                "source": "https://github.com/Behat/Behat/tree/v3.7.0"
+            },
+            "time": "2020-06-03T13:08:44+00:00"
         },
         {
             "name": "behat/gherkin",
-            "version": "v4.5.1",
+            "version": "v4.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Behat/Gherkin.git",
-                "reference": "74ac03d52c5e23ad8abd5c5cce4ab0e8dc1b530a"
+                "reference": "0bc8d1e30e96183e4f36db9dc79caead300beff4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/74ac03d52c5e23ad8abd5c5cce4ab0e8dc1b530a",
-                "reference": "74ac03d52c5e23ad8abd5c5cce4ab0e8dc1b530a",
+                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/0bc8d1e30e96183e4f36db9dc79caead300beff4",
+                "reference": "0bc8d1e30e96183e4f36db9dc79caead300beff4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.1"
+                "php": "~7.2|~8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.5|~5",
-                "symfony/phpunit-bridge": "~2.7|~3",
-                "symfony/yaml": "~2.3|~3"
+                "cucumber/cucumber": "dev-gherkin-22.0.0",
+                "phpunit/phpunit": "~8|~9",
+                "symfony/yaml": "~3|~4|~5"
             },
             "suggest": {
                 "symfony/yaml": "If you want to parse features, represented in YAML files"
@@ -9912,7 +8417,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "4.x-dev"
                 }
             },
             "autoload": {
@@ -9931,7 +8436,7 @@
                     "homepage": "http://everzet.com"
                 }
             ],
-            "description": "Gherkin DSL parser for PHP 5.3",
+            "description": "Gherkin DSL parser for PHP",
             "homepage": "http://behat.org/",
             "keywords": [
                 "BDD",
@@ -9941,34 +8446,37 @@
                 "gherkin",
                 "parser"
             ],
-            "time": "2017-08-30T11:04:43+00:00"
+            "support": {
+                "issues": "https://github.com/Behat/Gherkin/issues",
+                "source": "https://github.com/Behat/Gherkin/tree/v4.9.0"
+            },
+            "time": "2021-10-12T13:05:09+00:00"
         },
         {
             "name": "behat/mink",
-            "version": "v1.8.1",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/minkphp/Mink.git",
-                "reference": "07c6a9fe3fa98c2de074b25d9ed26c22904e3887"
+                "reference": "19e58905632e7cfdc5b2bafb9b950a3521af32c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/minkphp/Mink/zipball/07c6a9fe3fa98c2de074b25d9ed26c22904e3887",
-                "reference": "07c6a9fe3fa98c2de074b25d9ed26c22904e3887",
+                "url": "https://api.github.com/repos/minkphp/Mink/zipball/19e58905632e7cfdc5b2bafb9b950a3521af32c5",
+                "reference": "19e58905632e7cfdc5b2bafb9b950a3521af32c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.1",
-                "symfony/css-selector": "^2.7|^3.0|^4.0|^5.0"
+                "php": ">=7.2",
+                "symfony/css-selector": "^4.4 || ^5.0 || ^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20",
-                "symfony/debug": "^2.7|^3.0|^4.0",
-                "symfony/phpunit-bridge": "^3.4.38 || ^5.0.5"
+                "phpunit/phpunit": "^8.5.22 || ^9.5.11",
+                "symfony/error-handler": "^4.4 || ^5.0 || ^6.0",
+                "symfony/phpunit-bridge": "^5.4 || ^6.0"
             },
             "suggest": {
-                "behat/mink-browserkit-driver": "extremely fast headless driver for Symfony\\Kernel-based apps (Sf2, Silex)",
-                "behat/mink-goutte-driver": "fast headless driver for any app without JS emulation",
+                "behat/mink-browserkit-driver": "fast headless driver for any app without JS emulation",
                 "behat/mink-selenium2-driver": "slow, but JS-enabled driver for any app (requires Selenium2)",
                 "behat/mink-zombie-driver": "fast and JS-enabled headless driver for any app (requires node.js)",
                 "dmore/chrome-mink-driver": "fast and JS-enabled driver for any app (requires chromium or google chrome)"
@@ -9976,7 +8484,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -9996,70 +8504,17 @@
                 }
             ],
             "description": "Browser controller/emulator abstraction for PHP",
-            "homepage": "http://mink.behat.org/",
+            "homepage": "https://mink.behat.org/",
             "keywords": [
                 "browser",
                 "testing",
                 "web"
             ],
-            "time": "2020-03-11T15:45:53+00:00"
-        },
-        {
-            "name": "behat/mink-browserkit-driver",
-            "version": "v1.3.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/minkphp/MinkBrowserKitDriver.git",
-                "reference": "e3b90840022ebcd544c7b394a3c9597ae242cbee"
+            "support": {
+                "issues": "https://github.com/minkphp/Mink/issues",
+                "source": "https://github.com/minkphp/Mink/tree/v1.10.0"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/minkphp/MinkBrowserKitDriver/zipball/e3b90840022ebcd544c7b394a3c9597ae242cbee",
-                "reference": "e3b90840022ebcd544c7b394a3c9597ae242cbee",
-                "shasum": ""
-            },
-            "require": {
-                "behat/mink": "^1.7.1@dev",
-                "php": ">=5.3.6",
-                "symfony/browser-kit": "~2.3|~3.0|~4.0",
-                "symfony/dom-crawler": "~2.3|~3.0|~4.0"
-            },
-            "require-dev": {
-                "mink/driver-testsuite": "dev-master",
-                "symfony/debug": "^2.7|^3.0|^4.0",
-                "symfony/http-kernel": "~2.3|~3.0|~4.0"
-            },
-            "type": "mink-driver",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Behat\\Mink\\Driver\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
-                }
-            ],
-            "description": "Symfony2 BrowserKit driver for Mink framework",
-            "homepage": "http://mink.behat.org/",
-            "keywords": [
-                "Mink",
-                "Symfony2",
-                "browser",
-                "testing"
-            ],
-            "time": "2020-03-11T09:49:45+00:00"
+            "time": "2022-03-28T14:22:43+00:00"
         },
         {
             "name": "behat/mink-extension",
@@ -10122,31 +8577,30 @@
         },
         {
             "name": "behat/mink-goutte-driver",
-            "version": "v1.2.1",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/minkphp/MinkGoutteDriver.git",
-                "reference": "8b9ad6d2d95bc70b840d15323365f52fcdaea6ca"
+                "reference": "8139f520f417c81bf9d2f9a171fff400f6adc9ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/minkphp/MinkGoutteDriver/zipball/8b9ad6d2d95bc70b840d15323365f52fcdaea6ca",
-                "reference": "8b9ad6d2d95bc70b840d15323365f52fcdaea6ca",
+                "url": "https://api.github.com/repos/minkphp/MinkGoutteDriver/zipball/8139f520f417c81bf9d2f9a171fff400f6adc9ea",
+                "reference": "8139f520f417c81bf9d2f9a171fff400f6adc9ea",
                 "shasum": ""
             },
             "require": {
-                "behat/mink": "~1.6@dev",
                 "behat/mink-browserkit-driver": "~1.2@dev",
                 "fabpot/goutte": "~1.0.4|~2.0|~3.1",
-                "php": ">=5.3.1"
+                "php": ">=5.4"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "~2.7|~3.0"
+                "mink/driver-testsuite": "dev-master"
             },
             "type": "mink-driver",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -10166,41 +8620,48 @@
                 }
             ],
             "description": "Goutte driver for Mink framework",
-            "homepage": "http://mink.behat.org/",
+            "homepage": "https://mink.behat.org/",
             "keywords": [
                 "browser",
                 "goutte",
                 "headless",
                 "testing"
             ],
-            "time": "2016-03-05T09:04:22+00:00"
+            "support": {
+                "issues": "https://github.com/minkphp/MinkGoutteDriver/issues",
+                "source": "https://github.com/minkphp/MinkGoutteDriver/tree/v1.3.0"
+            },
+            "time": "2021-10-12T11:35:46+00:00"
         },
         {
             "name": "behat/mink-selenium2-driver",
-            "version": "v1.4.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/minkphp/MinkSelenium2Driver.git",
-                "reference": "312a967dd527f28980cce40850339cd5316da092"
+                "reference": "e5f8421654930da725499fb92983e6948c6f973e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/minkphp/MinkSelenium2Driver/zipball/312a967dd527f28980cce40850339cd5316da092",
-                "reference": "312a967dd527f28980cce40850339cd5316da092",
+                "url": "https://api.github.com/repos/minkphp/MinkSelenium2Driver/zipball/e5f8421654930da725499fb92983e6948c6f973e",
+                "reference": "e5f8421654930da725499fb92983e6948c6f973e",
                 "shasum": ""
             },
             "require": {
-                "behat/mink": "~1.7@dev",
-                "instaclick/php-webdriver": "~1.1",
-                "php": ">=5.4"
+                "behat/mink": "^1.9@dev",
+                "ext-json": "*",
+                "instaclick/php-webdriver": "^1.4",
+                "php": ">=7.2"
             },
             "require-dev": {
-                "mink/driver-testsuite": "dev-master"
+                "mink/driver-testsuite": "dev-master",
+                "phpunit/phpunit": "^8.5.22 || ^9.5.11",
+                "symfony/error-handler": "^4.4 || ^5.0"
             },
             "type": "mink-driver",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -10225,7 +8686,7 @@
                 }
             ],
             "description": "Selenium2 (WebDriver) driver for Mink framework",
-            "homepage": "http://mink.behat.org/",
+            "homepage": "https://mink.behat.org/",
             "keywords": [
                 "ajax",
                 "browser",
@@ -10234,38 +8695,43 @@
                 "testing",
                 "webdriver"
             ],
-            "time": "2020-03-11T14:43:21+00:00"
+            "support": {
+                "issues": "https://github.com/minkphp/MinkSelenium2Driver/issues",
+                "source": "https://github.com/minkphp/MinkSelenium2Driver/tree/v1.6.0"
+            },
+            "time": "2022-03-28T14:55:17+00:00"
         },
         {
             "name": "behat/transliterator",
-            "version": "v1.2.0",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Behat/Transliterator.git",
-                "reference": "826ce7e9c2a6664c0d1f381cbb38b1fb80a7ee2c"
+                "reference": "baac5873bac3749887d28ab68e2f74db3a4408af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/Transliterator/zipball/826ce7e9c2a6664c0d1f381cbb38b1fb80a7ee2c",
-                "reference": "826ce7e9c2a6664c0d1f381cbb38b1fb80a7ee2c",
+                "url": "https://api.github.com/repos/Behat/Transliterator/zipball/baac5873bac3749887d28ab68e2f74db3a4408af",
+                "reference": "baac5873bac3749887d28ab68e2f74db3a4408af",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.2"
             },
             "require-dev": {
                 "chuyskywalker/rolling-curl": "^3.1",
-                "php-yaoi/php-yaoi": "^1.0"
+                "php-yaoi/php-yaoi": "^1.0",
+                "phpunit/phpunit": "^8.5.25 || ^9.5.19"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Behat\\Transliterator": "src/"
+                "psr-4": {
+                    "Behat\\Transliterator\\": "src/Behat/Transliterator"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -10278,20 +8744,24 @@
                 "slug",
                 "transliterator"
             ],
-            "time": "2017-04-04T11:38:05+00:00"
+            "support": {
+                "issues": "https://github.com/Behat/Transliterator/issues",
+                "source": "https://github.com/Behat/Transliterator/tree/v1.5.0"
+            },
+            "time": "2022-03-30T09:27:43+00:00"
         },
         {
             "name": "chi-teck/drupal-code-generator",
-            "version": "1.32.1",
+            "version": "1.33.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Chi-teck/drupal-code-generator.git",
-                "reference": "8abba7131ed4c89c1e8fc6dca0d05a4b6d0b2749"
+                "reference": "5f814e980b6f9cf1ca8c74cc9385c3d81090d388"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Chi-teck/drupal-code-generator/zipball/8abba7131ed4c89c1e8fc6dca0d05a4b6d0b2749",
-                "reference": "8abba7131ed4c89c1e8fc6dca0d05a4b6d0b2749",
+                "url": "https://api.github.com/repos/Chi-teck/drupal-code-generator/zipball/5f814e980b6f9cf1ca8c74cc9385c3d81090d388",
+                "reference": "5f814e980b6f9cf1ca8c74cc9385c3d81090d388",
                 "shasum": ""
             },
             "require": {
@@ -10300,6 +8770,9 @@
                 "symfony/console": "^3.4 || ^4.0",
                 "symfony/filesystem": "^2.7 || ^3.4 || ^4.0",
                 "twig/twig": "^1.41 || ^2.12"
+            },
+            "conflict": {
+                "drush/drush": "< 10.3.2"
             },
             "bin": [
                 "bin/dcg"
@@ -10323,94 +8796,505 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Drupal code generator",
-            "time": "2020-07-15T06:08:04+00:00"
+            "support": {
+                "issues": "https://github.com/Chi-teck/drupal-code-generator/issues",
+                "source": "https://github.com/Chi-teck/drupal-code-generator/tree/1.33.1"
+            },
+            "time": "2020-12-05T05:59:11+00:00"
         },
         {
-            "name": "consolidation/annotated-command",
-            "version": "2.12.1",
+            "name": "composer/ca-bundle",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "0ee361762df2274f360c085e3239784a53f850b5"
+                "url": "https://github.com/composer/ca-bundle.git",
+                "reference": "4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/0ee361762df2274f360c085e3239784a53f850b5",
-                "reference": "0ee361762df2274f360c085e3239784a53f850b5",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b",
+                "reference": "4c679186f2aca4ab6a0f1b0b9cf9252decb44d0b",
                 "shasum": ""
             },
             "require": {
-                "consolidation/output-formatters": "^3.5.1",
-                "php": ">=5.4.5",
-                "psr/log": "^1",
-                "symfony/console": "^2.8|^3|^4",
-                "symfony/event-dispatcher": "^2.5|^3|^4",
-                "symfony/finder": "^2.5|^3|^4|^5"
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "g1a/composer-test-scenarios": "^3",
-                "php-coveralls/php-coveralls": "^1",
-                "phpunit/phpunit": "^6",
-                "squizlabs/php_codesniffer": "^2.7"
+                "phpstan/phpstan": "^0.12.55",
+                "psr/log": "^1.0",
+                "symfony/phpunit-bridge": "^4.2 || ^5",
+                "symfony/process": "^2.5 || ^3.0 || ^4.0 || ^5.0 || ^6.0"
             },
             "type": "library",
             "extra": {
-                "scenarios": {
-                    "finder5": {
-                        "require": {
-                            "symfony/finder": "^5"
-                        },
-                        "config": {
-                            "platform": {
-                                "php": "7.2.5"
-                            }
-                        }
-                    },
-                    "symfony4": {
-                        "require": {
-                            "symfony/console": "^4.0"
-                        },
-                        "config": {
-                            "platform": {
-                                "php": "7.1.3"
-                            }
-                        }
-                    },
-                    "symfony2": {
-                        "require": {
-                            "symfony/console": "^2.8"
-                        },
-                        "require-dev": {
-                            "phpunit/phpunit": "^4.8.36"
-                        },
-                        "remove": [
-                            "php-coveralls/php-coveralls"
-                        ],
-                        "config": {
-                            "platform": {
-                                "php": "5.4.8"
-                            }
-                        },
-                        "scenario-options": {
-                            "create-lockfile": "false"
-                        }
-                    },
-                    "phpunit4": {
-                        "require-dev": {
-                            "phpunit/phpunit": "^4.8.36"
-                        },
-                        "remove": [
-                            "php-coveralls/php-coveralls"
-                        ],
-                        "config": {
-                            "platform": {
-                                "php": "5.4.8"
-                            }
-                        }
-                    }
-                },
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\CaBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+            "keywords": [
+                "cabundle",
+                "cacert",
+                "certificate",
+                "ssl",
+                "tls"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/ca-bundle/issues",
+                "source": "https://github.com/composer/ca-bundle/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-10-28T20:44:15+00:00"
+        },
+        {
+            "name": "composer/composer",
+            "version": "2.2.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/composer.git",
+                "reference": "ba61e768b410736efe61df01b61f1ec44f51474f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/composer/zipball/ba61e768b410736efe61df01b61f1ec44f51474f",
+                "reference": "ba61e768b410736efe61df01b61f1ec44f51474f",
+                "shasum": ""
+            },
+            "require": {
+                "composer/ca-bundle": "^1.0",
+                "composer/metadata-minifier": "^1.0",
+                "composer/pcre": "^1.0",
+                "composer/semver": "^3.0",
+                "composer/spdx-licenses": "^1.2",
+                "composer/xdebug-handler": "^2.0 || ^3.0",
+                "justinrainbow/json-schema": "^5.2.11",
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0 || ^2.0",
+                "react/promise": "^1.2 || ^2.7",
+                "seld/jsonlint": "^1.4",
+                "seld/phar-utils": "^1.0",
+                "symfony/console": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0",
+                "symfony/filesystem": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/finder": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0",
+                "symfony/process": "^2.8.52 || ^3.4.35 || ^4.4 || ^5.0 || ^6.0"
+            },
+            "require-dev": {
+                "phpspec/prophecy": "^1.10",
+                "symfony/phpunit-bridge": "^4.2 || ^5.0 || ^6.0"
+            },
+            "suggest": {
+                "ext-openssl": "Enabling the openssl extension allows you to access https URLs for repositories and packages",
+                "ext-zip": "Enabling the zip extension allows you to unzip archives",
+                "ext-zlib": "Allow gzip compression of HTTP requests"
+            },
+            "bin": [
+                "bin/composer"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\": "src/Composer"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "https://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Composer helps you declare, manage and install dependencies of PHP projects. It ensures you have the right stack everywhere.",
+            "homepage": "https://getcomposer.org/",
+            "keywords": [
+                "autoload",
+                "dependency",
+                "package"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/composer/issues",
+                "source": "https://github.com/composer/composer/tree/2.2.12"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-04-13T14:42:25+00:00"
+        },
+        {
+            "name": "composer/metadata-minifier",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/metadata-minifier.git",
+                "reference": "c549d23829536f0d0e984aaabbf02af91f443207"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/metadata-minifier/zipball/c549d23829536f0d0e984aaabbf02af91f443207",
+                "reference": "c549d23829536f0d0e984aaabbf02af91f443207",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2",
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\MetadataMinifier\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Small utility library that handles metadata minification and expansion.",
+            "keywords": [
+                "composer",
+                "compression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/metadata-minifier/issues",
+                "source": "https://github.com/composer/metadata-minifier/tree/1.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-07T13:37:33+00:00"
+        },
+        {
+            "name": "composer/pcre",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/67a32d7d6f9f560b726ab25a061b38ff3a80c560",
+                "reference": "67a32d7d6f9f560b726ab25a061b38ff3a80c560",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.3",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-21T20:24:37+00:00"
+        },
+        {
+            "name": "composer/spdx-licenses",
+            "version": "1.5.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/spdx-licenses.git",
+                "reference": "a30d487169d799745ca7280bc90fdfa693536901"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/a30d487169d799745ca7280bc90fdfa693536901",
+                "reference": "a30d487169d799745ca7280bc90fdfa693536901",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^0.12.55",
+                "symfony/phpunit-bridge": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Spdx\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "SPDX licenses list and validation library.",
+            "keywords": [
+                "license",
+                "spdx",
+                "validator"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/spdx-licenses/issues",
+                "source": "https://github.com/composer/spdx-licenses/tree/1.5.6"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-11-18T10:14:14+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/ced299686f41dce890debac69273b47ffe98a40c",
+                "reference": "ced299686f41dce890debac69273b47ffe98a40c",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "symfony/phpunit-bridge": "^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-25T21:32:43+00:00"
+        },
+        {
+            "name": "consolidation/annotated-command",
+            "version": "4.5.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/consolidation/annotated-command.git",
+                "reference": "67cea8e8e7656b74da651ea6f49321853996c0fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/67cea8e8e7656b74da651ea6f49321853996c0fd",
+                "reference": "67cea8e8e7656b74da651ea6f49321853996c0fd",
+                "shasum": ""
+            },
+            "require": {
+                "consolidation/output-formatters": "^4.1.1",
+                "php": ">=7.1.3",
+                "psr/log": "^1|^2|^3",
+                "symfony/console": "^4.4.8|^5|^6",
+                "symfony/event-dispatcher": "^4.4.8|^5|^6",
+                "symfony/finder": "^4.4.8|^5|^6"
+            },
+            "require-dev": {
+                "composer-runtime-api": "^2.0",
+                "phpunit/phpunit": "^7.5.20 || ^8 || ^9",
+                "squizlabs/php_codesniffer": "^3",
+                "yoast/phpunit-polyfills": "^0.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
                 }
             },
             "autoload": {
@@ -10429,7 +9313,11 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2020-10-11T04:30:03+00:00"
+            "support": {
+                "issues": "https://github.com/consolidation/annotated-command/issues",
+                "source": "https://github.com/consolidation/annotated-command/tree/4.5.5"
+            },
+            "time": "2022-04-26T16:18:25+00:00"
         },
         {
             "name": "consolidation/config",
@@ -10510,6 +9398,10 @@
                 }
             ],
             "description": "Provide configuration services for a commandline tool.",
+            "support": {
+                "issues": "https://github.com/consolidation/config/issues",
+                "source": "https://github.com/consolidation/config/tree/master"
+            },
             "time": "2019-03-03T19:37:04+00:00"
         },
         {
@@ -10577,78 +9469,39 @@
                 }
             ],
             "description": "This project uses dflydev/dot-access-data to provide simple output filtering for applications built with annotated-command / Robo.",
+            "support": {
+                "source": "https://github.com/consolidation/filter-via-dot-access-data/tree/1.0.0"
+            },
             "time": "2019-01-18T06:05:07+00:00"
         },
         {
             "name": "consolidation/log",
-            "version": "1.1.1",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/log.git",
-                "reference": "b2e887325ee90abc96b0a8b7b474cd9e7c896e3a"
+                "reference": "3ad08dc57e8aff9400111bad36beb0ed387fe6a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/log/zipball/b2e887325ee90abc96b0a8b7b474cd9e7c896e3a",
-                "reference": "b2e887325ee90abc96b0a8b7b474cd9e7c896e3a",
+                "url": "https://api.github.com/repos/consolidation/log/zipball/3ad08dc57e8aff9400111bad36beb0ed387fe6a9",
+                "reference": "3ad08dc57e8aff9400111bad36beb0ed387fe6a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.5",
-                "psr/log": "^1.0",
-                "symfony/console": "^2.8|^3|^4"
+                "php": ">=7.1.3",
+                "psr/log": "^1 || ^2",
+                "symfony/console": "^4 || ^5 || ^6"
             },
             "require-dev": {
-                "g1a/composer-test-scenarios": "^3",
-                "php-coveralls/php-coveralls": "^1",
-                "phpunit/phpunit": "^6",
-                "squizlabs/php_codesniffer": "^2"
+                "phpunit/phpunit": ">=7.5.20",
+                "squizlabs/php_codesniffer": "^3",
+                "yoast/phpunit-polyfills": "^0.2.0"
             },
             "type": "library",
             "extra": {
-                "scenarios": {
-                    "symfony4": {
-                        "require": {
-                            "symfony/console": "^4.0"
-                        },
-                        "config": {
-                            "platform": {
-                                "php": "7.1.3"
-                            }
-                        }
-                    },
-                    "symfony2": {
-                        "require": {
-                            "symfony/console": "^2.8"
-                        },
-                        "require-dev": {
-                            "phpunit/phpunit": "^4.8.36"
-                        },
-                        "remove": [
-                            "php-coveralls/php-coveralls"
-                        ],
-                        "config": {
-                            "platform": {
-                                "php": "5.4.8"
-                            }
-                        }
-                    },
-                    "phpunit4": {
-                        "require-dev": {
-                            "phpunit/phpunit": "^4.8.36"
-                        },
-                        "remove": [
-                            "php-coveralls/php-coveralls"
-                        ],
-                        "config": {
-                            "platform": {
-                                "php": "5.4.8"
-                            }
-                        }
-                    }
-                },
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-main": "2.x-dev"
                 }
             },
             "autoload": {
@@ -10667,99 +9520,47 @@
                 }
             ],
             "description": "Improved Psr-3 / Psr\\Log logger based on Symfony Console components.",
-            "time": "2019-01-01T17:30:51+00:00"
+            "support": {
+                "issues": "https://github.com/consolidation/log/issues",
+                "source": "https://github.com/consolidation/log/tree/2.1.1"
+            },
+            "time": "2022-02-24T04:27:32+00:00"
         },
         {
             "name": "consolidation/output-formatters",
-            "version": "3.5.1",
+            "version": "4.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/output-formatters.git",
-                "reference": "0d38f13051ef05c223a2bb8e962d668e24785196"
+                "reference": "d57992bf81ead908ee21cd94b46ed65afa2e785b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/0d38f13051ef05c223a2bb8e962d668e24785196",
-                "reference": "0d38f13051ef05c223a2bb8e962d668e24785196",
+                "url": "https://api.github.com/repos/consolidation/output-formatters/zipball/d57992bf81ead908ee21cd94b46ed65afa2e785b",
+                "reference": "d57992bf81ead908ee21cd94b46ed65afa2e785b",
                 "shasum": ""
             },
             "require": {
-                "dflydev/dot-access-data": "^1.1.0",
-                "php": ">=5.4.0",
-                "symfony/console": "^2.8|^3|^4",
-                "symfony/finder": "^2.5|^3|^4|^5"
+                "dflydev/dot-access-data": "^1.1.0 || ^2 || ^3",
+                "php": ">=7.1.3",
+                "symfony/console": "^4|^5|^6",
+                "symfony/finder": "^4|^5|^6"
             },
             "require-dev": {
-                "g1a/composer-test-scenarios": "^3",
-                "php-coveralls/php-coveralls": "^1",
-                "phpunit/phpunit": "^5.7.27",
-                "squizlabs/php_codesniffer": "^2.7",
-                "symfony/var-dumper": "^2.8|^3|^4",
-                "victorjonsson/markdowndocs": "^1.3"
+                "php-coveralls/php-coveralls": "^2.4.2",
+                "phpunit/phpunit": ">=7",
+                "squizlabs/php_codesniffer": "^3",
+                "symfony/var-dumper": "^4|^5|^6",
+                "symfony/yaml": "^4|^5|^6",
+                "yoast/phpunit-polyfills": "^0.2.0"
             },
             "suggest": {
                 "symfony/var-dumper": "For using the var_dump formatter"
             },
             "type": "library",
             "extra": {
-                "scenarios": {
-                    "finder5": {
-                        "require": {
-                            "symfony/finder": "^5"
-                        },
-                        "config": {
-                            "platform": {
-                                "php": "7.2.5"
-                            }
-                        }
-                    },
-                    "symfony4": {
-                        "require": {
-                            "symfony/console": "^4.0"
-                        },
-                        "require-dev": {
-                            "phpunit/phpunit": "^6"
-                        },
-                        "config": {
-                            "platform": {
-                                "php": "7.1.3"
-                            }
-                        }
-                    },
-                    "symfony3": {
-                        "require": {
-                            "symfony/console": "^3.4",
-                            "symfony/finder": "^3.4",
-                            "symfony/var-dumper": "^3.4"
-                        },
-                        "config": {
-                            "platform": {
-                                "php": "5.6.32"
-                            }
-                        }
-                    },
-                    "symfony2": {
-                        "require": {
-                            "symfony/console": "^2.8"
-                        },
-                        "require-dev": {
-                            "phpunit/phpunit": "^4.8.36"
-                        },
-                        "remove": [
-                            "php-coveralls/php-coveralls"
-                        ],
-                        "config": {
-                            "platform": {
-                                "php": "5.4.8"
-                            }
-                        },
-                        "scenario-options": {
-                            "create-lockfile": "false"
-                        }
-                    }
-                },
                 "branch-alias": {
-                    "dev-master": "3.x-dev"
+                    "dev-main": "4.x-dev"
                 }
             },
             "autoload": {
@@ -10778,54 +9579,57 @@
                 }
             ],
             "description": "Format text by applying transformations provided by plug-in formatters.",
-            "time": "2020-10-11T04:15:32+00:00"
+            "support": {
+                "issues": "https://github.com/consolidation/output-formatters/issues",
+                "source": "https://github.com/consolidation/output-formatters/tree/4.2.2"
+            },
+            "time": "2022-02-13T15:28:30+00:00"
         },
         {
             "name": "consolidation/robo",
-            "version": "1.4.13",
+            "version": "3.0.10",
             "source": {
                 "type": "git",
-                "url": "https://github.com/consolidation/Robo.git",
-                "reference": "fd28dcca1b935950ece26e63541fbdeeb09f7343"
+                "url": "https://github.com/consolidation/robo.git",
+                "reference": "206bbe23b34081a36bfefc4de2abbc1abcd29ef4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/Robo/zipball/fd28dcca1b935950ece26e63541fbdeeb09f7343",
-                "reference": "fd28dcca1b935950ece26e63541fbdeeb09f7343",
+                "url": "https://api.github.com/repos/consolidation/robo/zipball/206bbe23b34081a36bfefc4de2abbc1abcd29ef4",
+                "reference": "206bbe23b34081a36bfefc4de2abbc1abcd29ef4",
                 "shasum": ""
             },
             "require": {
-                "consolidation/annotated-command": "^2.12.1|^4.1",
-                "consolidation/config": "^1.2.1",
-                "consolidation/log": "^1.1.1|^2",
-                "consolidation/output-formatters": "^3.5.1|^4.1",
-                "consolidation/self-update": "^1.1.5",
-                "grasmash/yaml-expander": "^1.4",
-                "league/container": "^2.4.1",
-                "php": ">=5.5.0",
-                "symfony/console": "^2.8|^3|^4",
-                "symfony/event-dispatcher": "^2.5|^3|^4",
-                "symfony/filesystem": "^2.5|^3|^4",
-                "symfony/finder": "^2.5|^3|^4|^5",
-                "symfony/process": "^2.5|^3|^4"
+                "consolidation/annotated-command": "^4.3",
+                "consolidation/config": "^1.2.1 || ^2.0.1",
+                "consolidation/log": "^1.1.1 || ^2.0.2",
+                "consolidation/output-formatters": "^4.1.2",
+                "consolidation/self-update": "^2.0",
+                "league/container": "^3.3.1 || ^4.0",
+                "php": ">=7.1.3",
+                "symfony/console": "^4.4.19 || ^5 || ^6",
+                "symfony/event-dispatcher": "^4.4.19 || ^5 || ^6",
+                "symfony/filesystem": "^4.4.9 || ^5 || ^6",
+                "symfony/finder": "^4.4.9 || ^5 || ^6",
+                "symfony/process": "^4.4.9 || ^5 || ^6",
+                "symfony/yaml": "^4.4 || ^5 || ^6"
             },
-            "replace": {
-                "codegyre/robo": "< 1.0"
+            "conflict": {
+                "codegyre/robo": "*"
             },
             "require-dev": {
-                "g1a/composer-test-scenarios": "^3",
                 "natxet/cssmin": "3.0.4",
                 "patchwork/jsqueeze": "^2",
                 "pear/archive_tar": "^1.4.4",
-                "php-coveralls/php-coveralls": "^1",
-                "phpunit/phpunit": "^5.7.27",
-                "squizlabs/php_codesniffer": "^3"
+                "phpunit/phpunit": "^7.5.20 || ^8",
+                "squizlabs/php_codesniffer": "^3.6",
+                "yoast/phpunit-polyfills": "^0.2.0"
             },
             "suggest": {
-                "henrikbjorn/lurker": "For monitoring filesystem changes in taskWatch",
-                "natxet/CssMin": "For minifying CSS files in taskMinify",
+                "natxet/cssmin": "For minifying CSS files in taskMinify",
                 "patchwork/jsqueeze": "For minifying JS files in taskMinify",
-                "pear/archive_tar": "Allows tar archives to be created and extracted in taskPack and taskExtract, respectively."
+                "pear/archive_tar": "Allows tar archives to be created and extracted in taskPack and taskExtract, respectively.",
+                "totten/lurkerlite": "For monitoring filesystem changes in taskWatch"
             },
             "bin": [
                 "robo"
@@ -10833,48 +9637,29 @@
             "type": "library",
             "extra": {
                 "scenarios": {
-                    "finder5": {
-                        "require": {
-                            "symfony/finder": "^5"
-                        },
-                        "config": {
-                            "platform": {
-                                "php": "7.2.5"
-                            }
-                        }
-                    },
                     "symfony4": {
                         "require": {
-                            "symfony/console": "^4"
+                            "symfony/console": "^4.4.11",
+                            "symfony/event-dispatcher": "^4.4.11",
+                            "symfony/filesystem": "^4.4.11",
+                            "symfony/finder": "^4.4.11",
+                            "symfony/process": "^4.4.11",
+                            "phpunit/phpunit": "^6",
+                            "nikic/php-parser": "^2"
                         },
+                        "remove": [
+                            "codeception/phpunit-wrapper"
+                        ],
                         "config": {
                             "platform": {
                                 "php": "7.1.3"
                             }
                         }
-                    },
-                    "symfony2": {
-                        "require": {
-                            "symfony/console": "^2.8"
-                        },
-                        "require-dev": {
-                            "phpunit/phpunit": "^4.8.36"
-                        },
-                        "remove": [
-                            "php-coveralls/php-coveralls"
-                        ],
-                        "config": {
-                            "platform": {
-                                "php": "5.5.9"
-                            }
-                        },
-                        "scenario-options": {
-                            "create-lockfile": "false"
-                        }
                     }
                 },
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-master": "2.x-dev",
+                    "dev-main": "2.x-dev"
                 }
             },
             "autoload": {
@@ -10893,26 +9678,31 @@
                 }
             ],
             "description": "Modern task runner",
-            "time": "2020-10-11T04:51:34+00:00"
+            "support": {
+                "issues": "https://github.com/consolidation/robo/issues",
+                "source": "https://github.com/consolidation/robo/tree/3.0.10"
+            },
+            "time": "2022-02-21T17:19:14+00:00"
         },
         {
             "name": "consolidation/self-update",
-            "version": "1.2.0",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/self-update.git",
-                "reference": "dba6b2c0708f20fa3ba8008a2353b637578849b4"
+                "reference": "8a64bdd8daf5faa8e85f56534dd99caf928164b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/self-update/zipball/dba6b2c0708f20fa3ba8008a2353b637578849b4",
-                "reference": "dba6b2c0708f20fa3ba8008a2353b637578849b4",
+                "url": "https://api.github.com/repos/consolidation/self-update/zipball/8a64bdd8daf5faa8e85f56534dd99caf928164b3",
+                "reference": "8a64bdd8daf5faa8e85f56534dd99caf928164b3",
                 "shasum": ""
             },
             "require": {
+                "composer/semver": "^3.2",
                 "php": ">=5.5.0",
-                "symfony/console": "^2.8|^3|^4|^5",
-                "symfony/filesystem": "^2.5|^3|^4|^5"
+                "symfony/console": "^2.8 || ^3 || ^4 || ^5 || ^6",
+                "symfony/filesystem": "^2.5 || ^3 || ^4 || ^5 || ^6"
             },
             "bin": [
                 "scripts/release"
@@ -10920,7 +9710,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-main": "2.x-dev"
                 }
             },
             "autoload": {
@@ -10943,55 +9733,42 @@
                 }
             ],
             "description": "Provides a self:update command for Symfony Console applications.",
-            "time": "2020-04-13T02:49:20+00:00"
+            "support": {
+                "issues": "https://github.com/consolidation/self-update/issues",
+                "source": "https://github.com/consolidation/self-update/tree/2.0.5"
+            },
+            "time": "2022-02-09T22:44:24+00:00"
         },
         {
             "name": "consolidation/site-alias",
-            "version": "3.0.1",
+            "version": "3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/site-alias.git",
-                "reference": "fd40a03f80f8fd4684b10bef8c8c4ec5a9a9bf26"
+                "reference": "ef2eb7d37e59b3d837b4556d4d8070cb345b378c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/site-alias/zipball/fd40a03f80f8fd4684b10bef8c8c4ec5a9a9bf26",
-                "reference": "fd40a03f80f8fd4684b10bef8c8c4ec5a9a9bf26",
+                "url": "https://api.github.com/repos/consolidation/site-alias/zipball/ef2eb7d37e59b3d837b4556d4d8070cb345b378c",
+                "reference": "ef2eb7d37e59b3d837b4556d4d8070cb345b378c",
                 "shasum": ""
             },
             "require": {
-                "consolidation/config": "^1.2.1|^2",
-                "php": ">=5.5.0"
+                "consolidation/config": "^1.2.1 || ^2",
+                "php": ">=5.5.0",
+                "symfony/finder": "~2.3 || ^3 || ^4.4 || ^5 || ^6"
             },
             "require-dev": {
-                "consolidation/robo": "^1.2.3|^2",
-                "g1a/composer-test-scenarios": "^3",
-                "knplabs/github-api": "^2.7",
-                "php-coveralls/php-coveralls": "^2.2",
-                "php-http/guzzle6-adapter": "^1.1",
-                "phpunit/phpunit": "^6",
-                "squizlabs/php_codesniffer": "^2.8",
-                "symfony/yaml": "~2.3|^3|^4.4|^5"
+                "php-coveralls/php-coveralls": "^2.4.2",
+                "phpunit/phpunit": ">=7",
+                "squizlabs/php_codesniffer": "^3",
+                "symfony/var-dumper": "^4",
+                "yoast/phpunit-polyfills": "^0.2.0"
             },
             "type": "library",
             "extra": {
-                "scenarios": {
-                    "phpunit5": {
-                        "require-dev": {
-                            "phpunit/phpunit": "^5.7.27"
-                        },
-                        "remove": [
-                            "php-coveralls/php-coveralls"
-                        ],
-                        "config": {
-                            "platform": {
-                                "php": "5.6.33"
-                            }
-                        }
-                    }
-                },
                 "branch-alias": {
-                    "dev-master": "3.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -11014,56 +9791,42 @@
                 }
             ],
             "description": "Manage alias records for local and remote sites.",
-            "time": "2020-05-28T00:33:41+00:00"
+            "support": {
+                "issues": "https://github.com/consolidation/site-alias/issues",
+                "source": "https://github.com/consolidation/site-alias/tree/3.1.5"
+            },
+            "time": "2022-02-23T23:59:18+00:00"
         },
         {
             "name": "consolidation/site-process",
-            "version": "2.1.0",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/site-process.git",
-                "reference": "f3211fa4c60671c6f068184221f06f932556e443"
+                "reference": "9ef08d471573d6a56405b06ef6830dd70c883072"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/site-process/zipball/f3211fa4c60671c6f068184221f06f932556e443",
-                "reference": "f3211fa4c60671c6f068184221f06f932556e443",
+                "url": "https://api.github.com/repos/consolidation/site-process/zipball/9ef08d471573d6a56405b06ef6830dd70c883072",
+                "reference": "9ef08d471573d6a56405b06ef6830dd70c883072",
                 "shasum": ""
             },
             "require": {
-                "consolidation/config": "^1.2.1",
+                "consolidation/config": "^1.2.1|^2",
                 "consolidation/site-alias": "^3",
-                "php": ">=5.6.0",
-                "symfony/process": "^3.4"
+                "php": ">=7.1.3",
+                "symfony/console": "^2.8.52|^3|^4.4|^5",
+                "symfony/process": "^4.3.4|^5"
             },
             "require-dev": {
-                "consolidation/robo": "^1.3",
-                "g1a/composer-test-scenarios": "^3",
-                "knplabs/github-api": "^2.7",
-                "php-coveralls/php-coveralls": "^1",
-                "php-http/guzzle6-adapter": "^1.1",
-                "phpunit/phpunit": "^6",
-                "squizlabs/php_codesniffer": "^2.8"
+                "phpunit/phpunit": "^7.5.20|^8.5.14",
+                "squizlabs/php_codesniffer": "^3",
+                "yoast/phpunit-polyfills": "^0.2.0"
             },
             "type": "library",
             "extra": {
-                "scenarios": {
-                    "phpunit5": {
-                        "require-dev": {
-                            "phpunit/phpunit": "^5.7.27"
-                        },
-                        "remove": [
-                            "php-coveralls/php-coveralls"
-                        ],
-                        "config": {
-                            "platform": {
-                                "php": "5.6.33"
-                            }
-                        }
-                    }
-                },
                 "branch-alias": {
-                    "dev-master": "0.x-dev"
+                    "dev-main": "4.x-dev"
                 }
             },
             "autoload": {
@@ -11086,42 +9849,43 @@
                 }
             ],
             "description": "A thin wrapper around the Symfony Process Component that allows applications to use the Site Alias library to specify the target for a remote call.",
-            "time": "2019-09-10T17:56:24+00:00"
+            "support": {
+                "issues": "https://github.com/consolidation/site-process/issues",
+                "source": "https://github.com/consolidation/site-process/tree/4.2.0"
+            },
+            "time": "2022-02-19T04:09:55+00:00"
         },
         {
-            "name": "dflydev/dot-access-configuration",
-            "version": "v1.0.3",
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/dflydev/dflydev-dot-access-configuration.git",
-                "reference": "2e6eb0c8b8830b26bb23defcfc38d4276508fc49"
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-configuration/zipball/2e6eb0c8b8830b26bb23defcfc38d4276508fc49",
-                "reference": "2e6eb0c8b8830b26bb23defcfc38d4276508fc49",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
                 "shasum": ""
             },
             "require": {
-                "dflydev/dot-access-data": "1.*",
-                "dflydev/placeholder-resolver": "1.*",
-                "php": ">=5.3.2"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "symfony/yaml": "~2.1"
+                "composer/composer": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
             },
-            "suggest": {
-                "symfony/yaml": "Required for using the YAML Configuration Builders"
-            },
-            "type": "library",
+            "type": "composer-plugin",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
             },
             "autoload": {
-                "psr-0": {
-                    "Dflydev\\DotAccessConfiguration": "src"
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -11130,23 +9894,41 @@
             ],
             "authors": [
                 {
-                    "name": "Dragonfly Development Inc.",
-                    "email": "info@dflydev.com",
-                    "homepage": "http://dflydev.com"
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
                 },
                 {
-                    "name": "Beau Simensen",
-                    "email": "beau@dflydev.com",
-                    "homepage": "http://beausimensen.com"
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
                 }
             ],
-            "description": "Given a deep data structure representing a configuration, access configuration by dot notation.",
-            "homepage": "https://github.com/dflydev/dflydev-dot-access-configuration",
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
             "keywords": [
-                "config",
-                "configuration"
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
             ],
-            "time": "2018-09-08T23:00:17+00:00"
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2022-02-04T12:51:07+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -11205,85 +9987,38 @@
                 "dot",
                 "notation"
             ],
+            "support": {
+                "issues": "https://github.com/dflydev/dflydev-dot-access-data/issues",
+                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/master"
+            },
             "time": "2017-01-20T21:14:22+00:00"
         },
         {
-            "name": "dflydev/placeholder-resolver",
-            "version": "v1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/dflydev/dflydev-placeholder-resolver.git",
-                "reference": "c498d0cae91b1bb36cc7d60906dab8e62bb7c356"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-placeholder-resolver/zipball/c498d0cae91b1bb36cc7d60906dab8e62bb7c356",
-                "reference": "c498d0cae91b1bb36cc7d60906dab8e62bb7c356",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.2"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Dflydev\\PlaceholderResolver": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Dragonfly Development Inc.",
-                    "email": "info@dflydev.com",
-                    "homepage": "http://dflydev.com"
-                },
-                {
-                    "name": "Beau Simensen",
-                    "email": "beau@dflydev.com",
-                    "homepage": "http://beausimensen.com"
-                }
-            ],
-            "description": "Given a data source representing key => value pairs, resolve placeholders like ${foo.bar} to the value associated with the 'foo.bar' key in the data source.",
-            "homepage": "https://github.com/dflydev/dflydev-placeholder-resolver",
-            "keywords": [
-                "placeholder",
-                "resolver"
-            ],
-            "time": "2012-10-28T21:08:28+00:00"
-        },
-        {
             "name": "doctrine/instantiator",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
-                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^8.0",
+                "doctrine/coding-standard": "^9",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
-                "phpstan/phpstan": "^0.12",
-                "phpstan/phpstan-phpunit": "^0.12",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.22"
             },
             "type": "library",
             "autoload": {
@@ -11308,6 +10043,10 @@
                 "constructor",
                 "instantiate"
             ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
+            },
             "funding": [
                 {
                     "url": "https://www.doctrine-project.org/sponsorship.html",
@@ -11322,26 +10061,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-10T18:47:58+00:00"
+            "time": "2022-03-03T08:28:38+00:00"
         },
         {
             "name": "drupal/coder",
-            "version": "8.3.13",
+            "version": "8.3.15",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/coder.git",
-                "reference": "d3286d571b19633cc296d438c36b9aed195de43c"
+                "reference": "0cfad3a21f1168bdc3030ae73351c31f88abba74"
             },
             "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
                 "ext-mbstring": "*",
-                "php": ">=7.0.8",
+                "php": ">=7.1",
                 "sirbrillig/phpcs-variable-analysis": "^2.10",
-                "squizlabs/php_codesniffer": "^3.5.6",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.6.0",
                 "symfony/yaml": ">=2.0.5"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.12.63",
-                "phpunit/phpunit": "^6.0 || ^7.0"
+                "phpstan/phpstan": "^1.4.9",
+                "phpunit/phpunit": "^7.0 || ^8.0"
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -11361,305 +10102,47 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2021-02-06T10:44:32+00:00"
-        },
-        {
-            "name": "drupal/console",
-            "version": "1.9.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/hechoendrupal/drupal-console.git",
-                "reference": "90053d30f52427edb4e4941a9063acb65b5a2c1e"
+            "support": {
+                "issues": "https://www.drupal.org/project/issues/coder",
+                "source": "https://www.drupal.org/project/coder"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/hechoendrupal/drupal-console/zipball/90053d30f52427edb4e4941a9063acb65b5a2c1e",
-                "reference": "90053d30f52427edb4e4941a9063acb65b5a2c1e",
-                "shasum": ""
-            },
-            "require": {
-                "alchemy/zippy": "~0.4",
-                "composer/installers": "~1.0",
-                "doctrine/annotations": "^1.2",
-                "doctrine/collections": "^1.3",
-                "drupal/console-core": "1.9.7",
-                "drupal/console-extend-plugin": "~0.9.5",
-                "php": ">=7.0.8",
-                "psy/psysh": "0.6.* || ~0.8",
-                "symfony/css-selector": "~3.0|~4.0",
-                "symfony/dom-crawler": "~3.0|~4.0",
-                "symfony/http-foundation": "~3.0|~4.0"
-            },
-            "suggest": {
-                "symfony/thanks": "Thank your favorite PHP projects on GitHub using the CLI",
-                "vlucas/phpdotenv": "Loads environment variables from .env to getenv(), $_ENV and $_SERVER automagically"
-            },
-            "bin": [
-                "bin/drupal"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Drupal\\Console\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "David Flores",
-                    "email": "dmousex@gmail.com",
-                    "homepage": "http://dmouse.net"
-                },
-                {
-                    "name": "Jesus Manuel Olivas",
-                    "email": "jesus.olivas@gmail.com",
-                    "homepage": "http://jmolivas.com"
-                },
-                {
-                    "name": "Eduardo Garcia",
-                    "email": "enzo@enzolutions.com",
-                    "homepage": "http://enzolutions.com/"
-                },
-                {
-                    "name": "Omar Aguirre",
-                    "email": "omersguchigu@gmail.com"
-                },
-                {
-                    "name": "Drupal Console Contributors",
-                    "homepage": "https://github.com/hechoendrupal/drupal-console/graphs/contributors"
-                }
-            ],
-            "description": "The Drupal CLI. A tool to generate boilerplate code, interact with and debug Drupal.",
-            "homepage": "http://drupalconsole.com/",
-            "keywords": [
-                "console",
-                "development",
-                "drupal",
-                "symfony"
-            ],
-            "funding": [
-                {
-                    "url": "https://opencollective.com/drupalconsole",
-                    "type": "open_collective"
-                }
-            ],
-            "time": "2020-11-30T02:09:53+00:00"
-        },
-        {
-            "name": "drupal/console-core",
-            "version": "1.9.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/hechoendrupal/drupal-console-core.git",
-                "reference": "ab3abc2631761c9588230ba88189d9ba4eb9ed63"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/hechoendrupal/drupal-console-core/zipball/ab3abc2631761c9588230ba88189d9ba4eb9ed63",
-                "reference": "ab3abc2631761c9588230ba88189d9ba4eb9ed63",
-                "shasum": ""
-            },
-            "require": {
-                "dflydev/dot-access-configuration": "^1.0",
-                "drupal/console-en": "1.9.7",
-                "guzzlehttp/guzzle": "~6.1",
-                "php": ">=7.0.8",
-                "stecman/symfony-console-completion": "~0.7",
-                "symfony/config": "~3.0|^4.4",
-                "symfony/console": "~3.0|^4.4",
-                "symfony/debug": "~3.0|^4.4",
-                "symfony/dependency-injection": "~3.0|^4.4",
-                "symfony/event-dispatcher": "~3.0|^4.4",
-                "symfony/filesystem": "~3.0|^4.4",
-                "symfony/finder": "~3.0|^4.4",
-                "symfony/process": "~3.0|^4.4",
-                "symfony/translation": "~3.0|^4.4",
-                "symfony/yaml": "~3.0|^4.4",
-                "twig/twig": "^1.38.2|^2.12.0",
-                "webflo/drupal-finder": "^1.0",
-                "webmozart/path-util": "^2.3"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/functions.php"
-                ],
-                "psr-4": {
-                    "Drupal\\Console\\Core\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "David Flores",
-                    "email": "dmousex@gmail.com",
-                    "homepage": "http://dmouse.net"
-                },
-                {
-                    "name": "Jesus Manuel Olivas",
-                    "email": "jesus.olivas@gmail.com",
-                    "homepage": "http://jmolivas.com"
-                },
-                {
-                    "name": "Eduardo Garcia",
-                    "email": "enzo@enzolutions.com",
-                    "homepage": "http://enzolutions.com/"
-                },
-                {
-                    "name": "Omar Aguirre",
-                    "email": "omersguchigu@gmail.com"
-                },
-                {
-                    "name": "Drupal Console Contributors",
-                    "homepage": "https://github.com/hechoendrupal/DrupalConsole/graphs/contributors"
-                }
-            ],
-            "description": "Drupal Console Core",
-            "homepage": "http://drupalconsole.com/",
-            "keywords": [
-                "console",
-                "development",
-                "drupal",
-                "symfony"
-            ],
-            "time": "2020-11-30T01:45:57+00:00"
-        },
-        {
-            "name": "drupal/console-en",
-            "version": "v1.9.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/hechoendrupal/drupal-console-en.git",
-                "reference": "7594601fff153c2799a62bd678ff80749baeee0c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/hechoendrupal/drupal-console-en/zipball/7594601fff153c2799a62bd678ff80749baeee0c",
-                "reference": "7594601fff153c2799a62bd678ff80749baeee0c",
-                "shasum": ""
-            },
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "David Flores",
-                    "email": "dmousex@gmail.com",
-                    "homepage": "http://dmouse.net"
-                },
-                {
-                    "name": "Jesus Manuel Olivas",
-                    "email": "jesus.olivas@gmail.com",
-                    "homepage": "http://jmolivas.com"
-                },
-                {
-                    "name": "Eduardo Garcia",
-                    "email": "enzo@enzolutions.com",
-                    "homepage": "http://enzolutions.com/"
-                },
-                {
-                    "name": "Omar Aguirre",
-                    "email": "omersguchigu@gmail.com"
-                },
-                {
-                    "name": "Drupal Console Contributors",
-                    "homepage": "https://github.com/hechoendrupal/DrupalConsole/graphs/contributors"
-                }
-            ],
-            "description": "Drupal Console English Language",
-            "homepage": "http://drupalconsole.com/",
-            "keywords": [
-                "console",
-                "development",
-                "drupal",
-                "symfony"
-            ],
-            "time": "2020-08-15T03:34:54+00:00"
-        },
-        {
-            "name": "drupal/console-extend-plugin",
-            "version": "0.9.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/hechoendrupal/drupal-console-extend-plugin.git",
-                "reference": "eff6da99cfb5fe1fc60990672d2667c402eb3585"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/hechoendrupal/drupal-console-extend-plugin/zipball/eff6da99cfb5fe1fc60990672d2667c402eb3585",
-                "reference": "eff6da99cfb5fe1fc60990672d2667c402eb3585",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "composer/installers": "^1.2",
-                "symfony/finder": "~3.0|^4.4",
-                "symfony/yaml": "~3.0|^4.4"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Drupal\\Console\\Composer\\Plugin\\Extender"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Drupal\\Console\\Composer\\Plugin\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "Jesus Manuel Olivas",
-                    "email": "jesus.olivas@gmail.com"
-                }
-            ],
-            "description": "Drupal Console Extend Plugin",
-            "time": "2020-11-18T00:15:28+00:00"
+            "time": "2022-04-02T17:56:30+00:00"
         },
         {
             "name": "drupal/core-dev",
-            "version": "8.9.17",
+            "version": "9.3.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drupal/core-dev.git",
-                "reference": "36370b3f42911c09ffb35f08fc72853d20e6efd7"
+                "reference": "d093ec9dd1106069fd01535235dd5797662a61cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drupal/core-dev/zipball/36370b3f42911c09ffb35f08fc72853d20e6efd7",
-                "reference": "36370b3f42911c09ffb35f08fc72853d20e6efd7",
+                "url": "https://api.github.com/repos/drupal/core-dev/zipball/d093ec9dd1106069fd01535235dd5797662a61cb",
+                "reference": "d093ec9dd1106069fd01535235dd5797662a61cb",
                 "shasum": ""
             },
             "require": {
                 "behat/mink": "^1.8",
-                "behat/mink-goutte-driver": "^1.2",
                 "behat/mink-selenium2-driver": "^1.4",
-                "composer/composer": "^1.9.1",
-                "drupal/coder": "^8.3.7",
-                "jcalderonzumba/gastonjs": "^1.0.2",
-                "jcalderonzumba/mink-phantomjs-driver": "^0.3.1",
+                "composer/composer": "^2.0.2",
+                "drupal/coder": "^8.3.10",
+                "easyrdf/easyrdf": "^0.9 || ^1.0",
+                "friends-of-behat/mink-browserkit-driver": "^1.4",
+                "instaclick/php-webdriver": "^1.4.1",
                 "justinrainbow/json-schema": "^5.2",
                 "mikey179/vfsstream": "^1.6.8",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/phpunit": "^6.5 || ^7",
-                "symfony/browser-kit": "^3.4.0",
-                "symfony/css-selector": "^3.4.0",
-                "symfony/debug": "^3.4.0",
-                "symfony/dom-crawler": "^3.4.0 !=3.4.38",
-                "symfony/filesystem": "~3.4.0",
-                "symfony/finder": "~3.4.0",
-                "symfony/lock": "~3.4.0",
-                "symfony/phpunit-bridge": "^3.4.3"
+                "phpspec/prophecy": "^1.12",
+                "phpunit/phpunit": "^8.5.14 || ^9",
+                "symfony/browser-kit": "^4.4",
+                "symfony/css-selector": "^4.4",
+                "symfony/dom-crawler": "^4.4 !=4.4.5",
+                "symfony/error-handler": "^4.4",
+                "symfony/filesystem": "^4.4",
+                "symfony/finder": "^4.4",
+                "symfony/lock": "^4.4",
+                "symfony/phpunit-bridge": "^5.4",
+                "symfony/var-dumper": "^5.4"
             },
             "conflict": {
                 "webflo/drupal-core-require-dev": "*"
@@ -11670,42 +10153,41 @@
                 "GPL-2.0-or-later"
             ],
             "description": "require-dev dependencies from drupal/drupal; use in addition to drupal/core-recommended to run tests from drupal/core.",
-            "time": "2020-05-09T07:53:22+00:00"
+            "support": {
+                "source": "https://github.com/drupal/core-dev/tree/9.3.13"
+            },
+            "time": "2021-11-30T05:41:29+00:00"
         },
         {
             "name": "drupal/drupal-driver",
-            "version": "v1.4.0",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhedstrom/DrupalDriver.git",
-                "reference": "919c6a39ef6a17bdcaf81dcff97b117ecfb6061c"
+                "reference": "000ce86a345bb8decaefdd7f0509825179641221"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhedstrom/DrupalDriver/zipball/919c6a39ef6a17bdcaf81dcff97b117ecfb6061c",
-                "reference": "919c6a39ef6a17bdcaf81dcff97b117ecfb6061c",
+                "url": "https://api.github.com/repos/jhedstrom/DrupalDriver/zipball/000ce86a345bb8decaefdd7f0509825179641221",
+                "reference": "000ce86a345bb8decaefdd7f0509825179641221",
                 "shasum": ""
             },
             "require": {
-                "drupal/core-utility": "^8.4",
-                "php": ">=5.5.9",
-                "symfony/dependency-injection": "~2.6|~3.0",
-                "symfony/process": "~2.5|~3.0"
+                "drupal/core-utility": "^8.4 || ^9 || ^10.0.0-alpha1",
+                "php": ">=7.4",
+                "symfony/dependency-injection": "~2.6|~3.0|~4.4|^6",
+                "symfony/process": "~2.5|~3.0|~4.4|^6"
             },
             "require-dev": {
-                "drupal/coder": "~8.2.0",
+                "dms/phpunit-arraysubset-asserts": "^0.4.0",
+                "drupal/coder": "~8.3.0",
                 "drush-ops/behat-drush-endpoint": "*",
-                "jakub-onderka/php-parallel-lint": "^0.9.2",
-                "mockery/mockery": "0.9.4",
-                "phpspec/phpspec": "~2.0",
-                "phpunit/phpunit": "~4.0"
+                "mockery/mockery": "^0.9.4",
+                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "phpspec/phpspec": "~2.0 || ~4.0 || ~6.1 || dev-main",
+                "phpunit/phpunit": "~6.0 || ~7.0 || ^9"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
             "autoload": {
                 "psr-0": {
                     "Drupal\\Driver": "src/",
@@ -11729,54 +10211,76 @@
                 "test",
                 "web"
             ],
-            "time": "2018-02-09T18:02:28+00:00"
+            "support": {
+                "issues": "https://github.com/jhedstrom/DrupalDriver/issues",
+                "source": "https://github.com/jhedstrom/DrupalDriver/tree/v2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jhedstrom",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-05-16T18:47:08+00:00"
         },
         {
             "name": "drupal/drupal-extension",
-            "version": "v3.4.1",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jhedstrom/drupalextension.git",
-                "reference": "50ff0f413f0dc4732f49638e743f86f45e835e50"
+                "reference": "03c06860db91a2e456e3e7ca170414c2a4a40107"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jhedstrom/drupalextension/zipball/50ff0f413f0dc4732f49638e743f86f45e835e50",
-                "reference": "50ff0f413f0dc4732f49638e743f86f45e835e50",
+                "url": "https://api.github.com/repos/jhedstrom/drupalextension/zipball/03c06860db91a2e456e3e7ca170414c2a4a40107",
+                "reference": "03c06860db91a2e456e3e7ca170414c2a4a40107",
                 "shasum": ""
             },
             "require": {
                 "behat/behat": "~3.2",
                 "behat/mink": "~1.5",
-                "behat/mink-extension": "~2.0",
                 "behat/mink-goutte-driver": "~1.0",
                 "behat/mink-selenium2-driver": "~1.1",
-                "drupal/drupal-driver": "~1.3",
-                "symfony/dependency-injection": "~2.7|~3.0",
-                "symfony/event-dispatcher": "~2.7|~3.0"
+                "drupal/drupal-driver": "^2.1.0",
+                "friends-of-behat/mink-extension": "^2",
+                "symfony/browser-kit": "^3.4|~4.4",
+                "symfony/dependency-injection": "~3.0|~4.4",
+                "symfony/translation": "^3.4|~4.4"
             },
             "require-dev": {
-                "behat/mink-zombie-driver": "^1.2",
-                "jakub-onderka/php-parallel-lint": "^0.9.2",
-                "phpspec/phpspec": "~2.0",
-                "phpunit/phpunit": "3.7.*"
+                "composer/installers": "^1.2",
+                "drupal/coder": "^8.3",
+                "drupal/core-composer-scaffold": "^9.1",
+                "drupal/core-recommended": "^9.1",
+                "drush/drush": "^10.5",
+                "php-parallel-lint/php-parallel-lint": "^1.3",
+                "phpspec/phpspec": "^4.0 || ^6.0 || ^7.0"
             },
             "type": "behat-extension",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                "installer-paths": {
+                    "drupal/core": [
+                        "type:drupal-core"
+                    ]
+                },
+                "drupal-scaffold": {
+                    "locations": {
+                        "web-root": "drupal/"
+                    }
                 }
             },
             "autoload": {
                 "psr-0": {
                     "Drupal\\Drupal": "src/",
                     "Drupal\\Exception": "src/",
+                    "Drupal\\MinkExtension": "src/",
                     "Drupal\\DrupalExtension": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "GPL-2.0+"
+                "GPL-2.0-or-later"
             ],
             "authors": [
                 {
@@ -11799,60 +10303,69 @@
                 "test",
                 "web"
             ],
-            "time": "2017-12-06T20:35:40+00:00"
+            "support": {
+                "issues": "https://github.com/jhedstrom/drupalextension/issues",
+                "source": "https://github.com/jhedstrom/drupalextension/tree/v4.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/jhedstrom",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-04-26T19:55:44+00:00"
         },
         {
             "name": "drush/drush",
-            "version": "10.0.0-alpha1",
+            "version": "10.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/drush-ops/drush.git",
-                "reference": "654aa5d11b139f0ac11cbfd917d5bc658324b703"
+                "reference": "0a570a16ec63259eb71195aba5feab532318b337"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/drush-ops/drush/zipball/654aa5d11b139f0ac11cbfd917d5bc658324b703",
-                "reference": "654aa5d11b139f0ac11cbfd917d5bc658324b703",
+                "url": "https://api.github.com/repos/drush-ops/drush/zipball/0a570a16ec63259eb71195aba5feab532318b337",
+                "reference": "0a570a16ec63259eb71195aba5feab532318b337",
                 "shasum": ""
             },
             "require": {
-                "chi-teck/drupal-code-generator": "^1.28.1",
-                "composer/semver": "^1.4",
-                "consolidation/annotated-command": "^2.12",
+                "chi-teck/drupal-code-generator": "^1.32.1",
+                "composer/semver": "^1.4 || ^3",
                 "consolidation/config": "^1.2",
                 "consolidation/filter-via-dot-access-data": "^1",
-                "consolidation/output-formatters": "^3.3.1",
-                "consolidation/robo": "^1.4.6",
+                "consolidation/robo": "^1.4.11 || ^2 || ^3",
                 "consolidation/site-alias": "^3.0.0@stable",
-                "consolidation/site-process": "^2.0.3",
+                "consolidation/site-process": "^2.1 || ^4",
+                "enlightn/security-checker": "^1",
                 "ext-dom": "*",
                 "grasmash/yaml-expander": "^1.1.1",
-                "league/container": "~2",
+                "guzzlehttp/guzzle": "^6.3 || ^7.0",
+                "league/container": "^2.5 || ^3.4",
                 "php": ">=7.1.3",
                 "psr/log": "~1.0",
-                "psy/psysh": "~0.6",
-                "symfony/console": "^3.4",
-                "symfony/event-dispatcher": "^3.4",
-                "symfony/finder": "^3.4 || ^4.0",
-                "symfony/process": "^3.4",
-                "symfony/var-dumper": "^3.4 || ^4.0",
-                "symfony/yaml": "^3.4",
-                "webflo/drupal-finder": "^1.1",
+                "psy/psysh": ">=0.6 <0.11",
+                "symfony/event-dispatcher": "^3.4 || ^4.0",
+                "symfony/finder": "^3.4 || ^4.0 || ^5",
+                "symfony/var-dumper": "^3.4 || ^4.0 || ^5.0",
+                "symfony/yaml": "^3.4 || ^4.0",
+                "webflo/drupal-finder": "^1.2",
                 "webmozart/path-util": "^2.1.0"
             },
+            "conflict": {
+                "drupal/migrate_run": "*",
+                "drupal/migrate_tools": "<= 5"
+            },
             "require-dev": {
-                "composer/installers": "^1.2",
+                "composer/installers": "^1.7",
                 "cweagans/composer-patches": "~1.0",
+                "david-garcia/phpwhois": "4.3.0",
                 "drupal/alinks": "1.0.0",
-                "drupal/devel": "^2",
-                "drupal/empty_theme": "1.0",
-                "g1a/composer-test-scenarios": "^3",
-                "lox/xhprof": "dev-master",
-                "phpunit/phpunit": "^4.8.36 || ^6.1",
+                "drupal/core-recommended": "^8.8",
+                "phpunit/phpunit": ">=7.5.20",
                 "squizlabs/php_codesniffer": "^2.7 || ^3",
                 "vlucas/phpdotenv": "^2.4",
-                "webflo/drupal-core-require-dev": "8.7.x-dev",
-                "webflo/drupal-core-strict": "8.7.x-dev"
+                "yoast/phpunit-polyfills": "^0.2.0"
             },
             "bin": [
                 "drush"
@@ -11884,9 +10397,6 @@
                     "sut/drush/contrib/{$name}": [
                         "type:drupal-drush"
                     ]
-                },
-                "branch-alias": {
-                    "dev-master": "10.x-dev"
                 }
             },
             "autoload": {
@@ -11935,36 +10445,190 @@
             ],
             "description": "Drush is a command line shell and scripting interface for Drupal, a veritable Swiss Army knife designed to make life easier for those of us who spend some of our working hours hacking away at the command prompt.",
             "homepage": "http://www.drush.org",
-            "time": "2019-07-25T03:11:31+00:00"
+            "support": {
+                "forum": "http://drupal.stackexchange.com/questions/tagged/drush",
+                "irc": "irc://irc.freenode.org/drush",
+                "issues": "https://github.com/drush-ops/drush/issues",
+                "slack": "https://drupal.slack.com/messages/C62H9CWQM",
+                "source": "https://github.com/drush-ops/drush/tree/10.6.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/weitzman",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-15T17:09:54+00:00"
         },
         {
-            "name": "fabpot/goutte",
-            "version": "v3.2.3",
+            "name": "easyrdf/easyrdf",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/FriendsOfPHP/Goutte.git",
-                "reference": "3f0eaf0a40181359470651f1565b3e07e3dd31b8"
+                "url": "https://github.com/easyrdf/easyrdf.git",
+                "reference": "c7b0a9dbcb211eb7de03ee99ff5b52d17f2a8e64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/Goutte/zipball/3f0eaf0a40181359470651f1565b3e07e3dd31b8",
-                "reference": "3f0eaf0a40181359470651f1565b3e07e3dd31b8",
+                "url": "https://api.github.com/repos/easyrdf/easyrdf/zipball/c7b0a9dbcb211eb7de03ee99ff5b52d17f2a8e64",
+                "reference": "c7b0a9dbcb211eb7de03ee99ff5b52d17f2a8e64",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "ext-pcre": "*",
+                "ext-xmlreader": "*",
+                "lib-libxml": "*",
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "code-lts/doctum": "^5",
+                "ml/json-ld": "~1.0",
+                "phpunit/phpunit": "^7",
+                "semsol/arc2": "^2.4",
+                "squizlabs/php_codesniffer": "3.*",
+                "zendframework/zend-http": "~2.3"
+            },
+            "suggest": {
+                "ml/json-ld": "~1.0",
+                "semsol/arc2": "~2.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "EasyRdf\\": "lib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nicholas Humfrey",
+                    "email": "njh@aelius.com",
+                    "homepage": "http://www.aelius.com/njh/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Alexey Zakhlestin",
+                    "email": "indeyets@gmail.com",
+                    "homepage": "http://indeyets.ru/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "EasyRdf is a PHP library designed to make it easy to consume and produce RDF.",
+            "homepage": "http://www.easyrdf.org/",
+            "keywords": [
+                "Linked Data",
+                "RDF",
+                "Semantic Web",
+                "Turtle",
+                "rdfa",
+                "sparql"
+            ],
+            "support": {
+                "forum": "http://groups.google.com/group/easyrdf/",
+                "issues": "http://github.com/easyrdf/easyrdf/issues",
+                "source": "https://github.com/easyrdf/easyrdf/tree/1.1.1"
+            },
+            "time": "2020-12-02T08:47:31+00:00"
+        },
+        {
+            "name": "enlightn/security-checker",
+            "version": "v1.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/enlightn/security-checker.git",
+                "reference": "196bacc76e7a72a63d0e1220926dbb190272db97"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/enlightn/security-checker/zipball/196bacc76e7a72a63d0e1220926dbb190272db97",
+                "reference": "196bacc76e7a72a63d0e1220926dbb190272db97",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^6.3|^7.0",
+                "php": ">=5.6",
+                "symfony/console": "^3.4|^4|^5|^6",
+                "symfony/finder": "^3|^4|^5|^6",
+                "symfony/process": "^3.4|^4|^5|^6",
+                "symfony/yaml": "^3.4|^4|^5|^6"
+            },
+            "require-dev": {
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^2.18|^3.0",
+                "phpunit/phpunit": "^5.5|^6|^7|^8|^9"
+            },
+            "bin": [
+                "security-checker"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Enlightn\\SecurityChecker\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paras Malhotra",
+                    "email": "paras@laravel-enlightn.com"
+                },
+                {
+                    "name": "Miguel Piedrafita",
+                    "email": "soy@miguelpiedrafita.com"
+                }
+            ],
+            "description": "A PHP dependency vulnerabilities scanner based on the Security Advisories Database.",
+            "keywords": [
+                "package",
+                "php",
+                "scanner",
+                "security",
+                "security advisories",
+                "vulnerability scanner"
+            ],
+            "support": {
+                "issues": "https://github.com/enlightn/security-checker/issues",
+                "source": "https://github.com/enlightn/security-checker/tree/v1.10.0"
+            },
+            "time": "2022-02-21T22:40:16+00:00"
+        },
+        {
+            "name": "fabpot/goutte",
+            "version": "v3.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/Goutte.git",
+                "reference": "80a23b64f44d54dd571d114c473d9d7e9ed84ca5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/Goutte/zipball/80a23b64f44d54dd571d114c473d9d7e9ed84ca5",
+                "reference": "80a23b64f44d54dd571d114c473d9d7e9ed84ca5",
                 "shasum": ""
             },
             "require": {
                 "guzzlehttp/guzzle": "^6.0",
-                "php": ">=5.5.0",
-                "symfony/browser-kit": "~2.1|~3.0|~4.0",
-                "symfony/css-selector": "~2.1|~3.0|~4.0",
-                "symfony/dom-crawler": "~2.1|~3.0|~4.0"
+                "php": ">=7.1.3",
+                "symfony/browser-kit": "^4.4|^5.0",
+                "symfony/css-selector": "^4.4|^5.0",
+                "symfony/dom-crawler": "^4.4|^5.0"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "^3.3 || ^4"
+                "symfony/phpunit-bridge": "^5.0"
             },
             "type": "application",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -11990,7 +10654,135 @@
             "keywords": [
                 "scraper"
             ],
-            "time": "2018-06-29T15:13:57+00:00"
+            "support": {
+                "issues": "https://github.com/FriendsOfPHP/Goutte/issues",
+                "source": "https://github.com/FriendsOfPHP/Goutte/tree/v3.3.1"
+            },
+            "time": "2020-11-01T09:30:18+00:00"
+        },
+        {
+            "name": "friends-of-behat/mink-browserkit-driver",
+            "version": "v1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfBehat/MinkBrowserKitDriver.git",
+                "reference": "b3c29f18fe20487846e4c2733b066ec5e47f4f76"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfBehat/MinkBrowserKitDriver/zipball/b3c29f18fe20487846e4c2733b066ec5e47f4f76",
+                "reference": "b3c29f18fe20487846e4c2733b066ec5e47f4f76",
+                "shasum": ""
+            },
+            "require": {
+                "behat/mink": "^1.7",
+                "php": "^7.4|^8.0",
+                "symfony/browser-kit": "^4.4|^5.0|^6.0",
+                "symfony/dom-crawler": "^4.4|^5.0|^6.0"
+            },
+            "replace": {
+                "behat/mink-browserkit-driver": "self.version"
+            },
+            "require-dev": {
+                "friends-of-behat/mink-driver-testsuite": "dev-master",
+                "symfony/http-kernel": "^4.4|^5.0|^6.0"
+            },
+            "type": "mink-driver",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Behat\\Mink\\Driver\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                }
+            ],
+            "description": "Symfony2 BrowserKit driver for Mink framework",
+            "homepage": "http://mink.behat.org/",
+            "keywords": [
+                "Mink",
+                "Symfony2",
+                "browser",
+                "testing"
+            ],
+            "support": {
+                "source": "https://github.com/FriendsOfBehat/MinkBrowserKitDriver/tree/v1.6.1"
+            },
+            "time": "2021-12-13T10:41:57+00:00"
+        },
+        {
+            "name": "friends-of-behat/mink-extension",
+            "version": "2.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfBehat/MinkExtension.git",
+                "reference": "80f7849ba53867181b7e412df9210e12fba50177"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfBehat/MinkExtension/zipball/80f7849ba53867181b7e412df9210e12fba50177",
+                "reference": "80f7849ba53867181b7e412df9210e12fba50177",
+                "shasum": ""
+            },
+            "require": {
+                "behat/behat": "^3.0.5",
+                "behat/mink": "^1.5",
+                "php": ">=5.3.2",
+                "symfony/config": "^2.7|^3.0|^4.0"
+            },
+            "require-dev": {
+                "behat/mink-goutte-driver": "^1.1",
+                "phpspec/phpspec": "^2.0"
+            },
+            "type": "behat-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Behat\\MinkExtension": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com"
+                },
+                {
+                    "name": "Christophe Coevoet",
+                    "email": "stof@notk.org"
+                }
+            ],
+            "description": "Mink extension for Behat",
+            "homepage": "http://extensions.behat.org/mink",
+            "keywords": [
+                "browser",
+                "gui",
+                "test",
+                "web"
+            ],
+            "support": {
+                "source": "https://github.com/FriendsOfBehat/MinkExtension/tree/2.3.1"
+            },
+            "time": "2018-02-06T15:36:30+00:00"
         },
         {
             "name": "grasmash/expander",
@@ -12037,6 +10829,10 @@
                 }
             ],
             "description": "Expands internal property references in PHP arrays file.",
+            "support": {
+                "issues": "https://github.com/grasmash/expander/issues",
+                "source": "https://github.com/grasmash/expander/tree/master"
+            },
             "time": "2017-12-21T22:14:55+00:00"
         },
         {
@@ -12085,20 +10881,24 @@
                 }
             ],
             "description": "Expands internal property references in a yaml file.",
+            "support": {
+                "issues": "https://github.com/grasmash/yaml-expander/issues",
+                "source": "https://github.com/grasmash/yaml-expander/tree/master"
+            },
             "time": "2017-12-16T16:06:03+00:00"
         },
         {
             "name": "instaclick/php-webdriver",
-            "version": "1.4.9",
+            "version": "1.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/instaclick/php-webdriver.git",
-                "reference": "961b12178cb71f8667afaf2f66ab3e000e060e1c"
+                "reference": "200b8df772b74d604bebf25ef42ad6f8ee6380a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/instaclick/php-webdriver/zipball/961b12178cb71f8667afaf2f66ab3e000e060e1c",
-                "reference": "961b12178cb71f8667afaf2f66ab3e000e060e1c",
+                "url": "https://api.github.com/repos/instaclick/php-webdriver/zipball/200b8df772b74d604bebf25ef42ad6f8ee6380a9",
+                "reference": "200b8df772b74d604bebf25ef42ad6f8ee6380a9",
                 "shasum": ""
             },
             "require": {
@@ -12106,8 +10906,8 @@
                 "php": ">=5.3.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8",
-                "satooshi/php-coveralls": "^1.0||^2.0"
+                "phpunit/phpunit": "^8.5 || ^9.5",
+                "satooshi/php-coveralls": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
@@ -12144,41 +10944,46 @@
                 "webdriver",
                 "webtest"
             ],
-            "time": "2021-06-28T22:23:20+00:00"
+            "support": {
+                "issues": "https://github.com/instaclick/php-webdriver/issues",
+                "source": "https://github.com/instaclick/php-webdriver/tree/1.4.14"
+            },
+            "time": "2022-04-19T02:06:59+00:00"
         },
         {
-            "name": "jcalderonzumba/gastonjs",
-            "version": "v1.2.0",
+            "name": "justinrainbow/json-schema",
+            "version": "5.2.12",
             "source": {
                 "type": "git",
-                "url": "https://github.com/jcalderonzumba/gastonjs.git",
-                "reference": "575a9c18d8b87990c37252e8d9707b29f0a313f3"
+                "url": "https://github.com/justinrainbow/json-schema.git",
+                "reference": "ad87d5a5ca981228e0e205c2bc7dfb8e24559b60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jcalderonzumba/gastonjs/zipball/575a9c18d8b87990c37252e8d9707b29f0a313f3",
-                "reference": "575a9c18d8b87990c37252e8d9707b29f0a313f3",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/ad87d5a5ca981228e0e205c2bc7dfb8e24559b60",
+                "reference": "ad87d5a5ca981228e0e205c2bc7dfb8e24559b60",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "~5.0|~6.0",
-                "php": ">=5.4"
+                "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.6",
-                "silex/silex": "~1.2",
-                "symfony/phpunit-bridge": "~2.7",
-                "symfony/process": "~2.1"
+                "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
+                "json-schema/json-schema-test-suite": "1.2.0",
+                "phpunit/phpunit": "^4.8.35"
             },
-            "type": "phantomjs-api",
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Zumba\\GastonJS\\": "src"
+                    "JsonSchema\\": "src/JsonSchema/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -12187,111 +10992,69 @@
             ],
             "authors": [
                 {
-                    "name": "Juan Francisco Calderón Zumba",
-                    "email": "juanfcz@gmail.com",
-                    "homepage": "http://github.com/jcalderonzumba"
-                }
-            ],
-            "description": "PhantomJS API based server for webpage automation",
-            "homepage": "https://github.com/jcalderonzumba/gastonjs",
-            "keywords": [
-                "api",
-                "automation",
-                "browser",
-                "headless",
-                "phantomjs"
-            ],
-            "time": "2017-03-31T07:31:47+00:00"
-        },
-        {
-            "name": "jcalderonzumba/mink-phantomjs-driver",
-            "version": "v0.3.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/jcalderonzumba/MinkPhantomJSDriver.git",
-                "reference": "008f43670e94acd39273d15add1e7348eb23848d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/jcalderonzumba/MinkPhantomJSDriver/zipball/008f43670e94acd39273d15add1e7348eb23848d",
-                "reference": "008f43670e94acd39273d15add1e7348eb23848d",
-                "shasum": ""
-            },
-            "require": {
-                "behat/mink": "~1.7",
-                "jcalderonzumba/gastonjs": "~1.0",
-                "php": ">=5.4",
-                "twig/twig": "~1.20|~2.0"
-            },
-            "require-dev": {
-                "mink/driver-testsuite": "dev-master",
-                "phpunit/phpunit": "~4.6"
-            },
-            "type": "mink-driver",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zumba\\Mink\\Driver\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
                 {
-                    "name": "Juan Francisco Calderón Zumba",
-                    "email": "juanfcz@gmail.com",
-                    "homepage": "http://github.com/jcalderonzumba"
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
                 }
             ],
-            "description": "PhantomJS driver for Mink framework",
-            "homepage": "http://mink.behat.org/",
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/justinrainbow/json-schema",
             "keywords": [
-                "ajax",
-                "browser",
-                "headless",
-                "javascript",
-                "phantomjs",
-                "testing"
+                "json",
+                "schema"
             ],
-            "time": "2016-12-01T10:57:30+00:00"
+            "support": {
+                "issues": "https://github.com/justinrainbow/json-schema/issues",
+                "source": "https://github.com/justinrainbow/json-schema/tree/5.2.12"
+            },
+            "time": "2022-04-13T08:02:27+00:00"
         },
         {
             "name": "league/container",
-            "version": "2.4.1",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/container.git",
-                "reference": "43f35abd03a12977a60ffd7095efd6a7808488c0"
+                "reference": "84ecbc2dbecc31bd23faf759a0e329ee49abddbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/container/zipball/43f35abd03a12977a60ffd7095efd6a7808488c0",
-                "reference": "43f35abd03a12977a60ffd7095efd6a7808488c0",
+                "url": "https://api.github.com/repos/thephpleague/container/zipball/84ecbc2dbecc31bd23faf759a0e329ee49abddbd",
+                "reference": "84ecbc2dbecc31bd23faf759a0e329ee49abddbd",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.2",
-                "php": "^5.4.0 || ^7.0"
+                "php": "^7.0 || ^8.0",
+                "psr/container": "^1.0.0"
             },
             "provide": {
-                "container-interop/container-interop-implementation": "^1.2",
                 "psr/container-implementation": "^1.0"
             },
             "replace": {
                 "orno/di": "~2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*"
+                "phpunit/phpunit": "^6.0 || ^7.0",
+                "roave/security-advisories": "dev-latest",
+                "scrutinizer/ocular": "^1.8",
+                "squizlabs/php_codesniffer": "^3.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
+                    "dev-master": "3.x-dev",
+                    "dev-3.x": "3.x-dev",
                     "dev-2.x": "2.x-dev",
                     "dev-1.x": "1.x-dev"
                 }
@@ -12324,20 +11087,30 @@
                 "provider",
                 "service"
             ],
-            "time": "2017-05-10T09:20:27+00:00"
+            "support": {
+                "issues": "https://github.com/thephpleague/container/issues",
+                "source": "https://github.com/thephpleague/container/tree/3.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/philipobenito",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-09T08:23:52+00:00"
         },
         {
             "name": "mikey179/vfsstream",
-            "version": "v1.6.9",
+            "version": "v1.6.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bovigo/vfsStream.git",
-                "reference": "2257e326dc3d0f50e55d0a90f71e37899f029718"
+                "reference": "250c0825537d501e327df879fb3d4cd751933b85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/2257e326dc3d0f50e55d0a90f71e37899f029718",
-                "reference": "2257e326dc3d0f50e55d0a90f71e37899f029718",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/250c0825537d501e327df879fb3d4cd751933b85",
+                "reference": "250c0825537d501e327df879fb3d4cd751933b85",
                 "shasum": ""
             },
             "require": {
@@ -12370,41 +11143,47 @@
             ],
             "description": "Virtual file system to mock the real file system in unit tests.",
             "homepage": "http://vfs.bovigo.org/",
-            "time": "2021-07-16T08:08:02+00:00"
+            "support": {
+                "issues": "https://github.com/bovigo/vfsStream/issues",
+                "source": "https://github.com/bovigo/vfsStream/tree/master",
+                "wiki": "https://github.com/bovigo/vfsStream/wiki"
+            },
+            "time": "2021-09-25T08:05:01+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.2",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
-                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
-            "replace": {
-                "myclabs/deep-copy": "self.version"
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
             },
             "require-dev": {
-                "doctrine/collections": "^1.0",
-                "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^7.1"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
             "autoload": {
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                },
                 "files": [
                     "src/DeepCopy/deep_copy.php"
-                ]
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -12418,73 +11197,17 @@
                 "object",
                 "object graph"
             ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+            },
             "funding": [
                 {
                     "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T09:40:50+00:00"
-        },
-        {
-            "name": "palantirnet/palantir-behat-extension",
-            "version": "dev-drupal8-file-revisited",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/palantirnet/palantir-behat-extension.git",
-                "reference": "ffd260ca93f1724ae0c9887749eb736346cd2aa5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/palantirnet/palantir-behat-extension/zipball/ffd260ca93f1724ae0c9887749eb736346cd2aa5",
-                "reference": "ffd260ca93f1724ae0c9887749eb736346cd2aa5",
-                "shasum": ""
-            },
-            "require": {
-                "drupal/drupal-extension": "3.*"
-            },
-            "require-dev": {
-                "leaphub/phpcs-symfony2-standard": "^2.0",
-                "squizlabs/php_codesniffer": "^2.4"
-            },
-            "type": "behat-extension",
-            "autoload": {
-                "psr-0": {
-                    "Palantirnet\\PalantirBehatExtension\\": "src/"
-                }
-            },
-            "license": [
-                "proprietary"
-            ],
-            "authors": [
-                {
-                    "name": "Palantir.net",
-                    "email": "white@palantir.net",
-                    "homepage": "https://palantir.net",
-                    "role": "Company"
-                },
-                {
-                    "name": "Bec White",
-                    "email": "white@palantir.net",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Kelsey Bentham",
-                    "email": "bentham@palantir.net",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Additional step definitions for testing Drupal sites using Behat.",
-            "homepage": "https://github.com/palantirnet/palantir-behat-extension",
-            "keywords": [
-                "behat",
-                "drupal"
-            ],
-            "support": {
-                "source": "https://github.com/palantirnet/palantir-behat-extension/tree/drupal8-file-revisited",
-                "issues": "https://github.com/palantirnet/palantir-behat-extension/issues"
-            },
-            "time": "2016-08-10T14:27:16+00:00"
+            "time": "2022-03-03T13:19:32+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -12528,28 +11251,29 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.3",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
-                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^2.0",
-                "php": "^5.6 || ^7.0"
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -12579,24 +11303,28 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2018-07-08T19:23:20+00:00"
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+            },
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "2.0.1",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
-                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -12626,7 +11354,11 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2018-07-08T19:19:57+00:00"
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -12740,16 +11472,16 @@
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706"
+                "reference": "77a32518733312af16a44300404e945338981de3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/93ebd0014cab80c4ea9f5e297ea48672f1b87706",
-                "reference": "93ebd0014cab80c4ea9f5e297ea48672f1b87706",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/77a32518733312af16a44300404e945338981de3",
+                "reference": "77a32518733312af16a44300404e945338981de3",
                 "shasum": ""
             },
             "require": {
@@ -12784,9 +11516,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.6.1"
             },
-            "time": "2022-01-04T19:58:01+00:00"
+            "time": "2022-03-15T21:29:03+00:00"
         },
         {
             "name": "phpmd/phpmd",
@@ -12856,33 +11588,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.13.0",
+            "version": "v1.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
-                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
+                "reference": "bbcd7380b0ebf3961ee21409db7b38bc31d69a13",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.1",
+                "php": "^7.2 || ~8.0, <8.2",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^6.0",
+                "phpspec/phpspec": "^6.0 || ^7.0",
                 "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -12915,44 +11647,96 @@
                 "spy",
                 "stub"
             ],
-            "time": "2021-03-17T13:42:18+00:00"
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/v1.15.0"
+            },
+            "time": "2021-12-08T12:19:24+00:00"
         },
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "6.1.4",
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "981cc368a216c988e862a75e526b6076987d1b50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
-                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/981cc368a216c988e862a75e526b6076987d1b50",
+                "reference": "981cc368a216c988e862a75e526b6076987d1b50",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.5.1"
+            },
+            "time": "2022-05-05T11:32:40+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.15",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
+                "reference": "2e9da11878c4202f97915c1cb4bb1ca318a63f5f",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.1",
-                "phpunit/php-file-iterator": "^2.0",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^3.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1 || ^4.0",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "nikic/php-parser": "^4.13.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0.3",
+                "sebastian/version": "^3.0.1",
+                "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-xdebug": "^2.6.0"
+                "ext-pcov": "*",
+                "ext-xdebug": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1-dev"
+                    "dev-master": "9.2-dev"
                 }
             },
             "autoload": {
@@ -12978,32 +11762,42 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-10-31T16:06:48+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.15"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-03-07T09:28:20+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.4",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "28af674ff175d0768a5a978e6de83f697d4a7f05"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/28af674ff175d0768a5a978e6de83f697d4a7f05",
-                "reference": "28af674ff175d0768a5a978e6de83f697d4a7f05",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -13028,32 +11822,107 @@
                 "filesystem",
                 "iterator"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2021-07-19T06:46:01+00:00"
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -13075,32 +11944,42 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.3",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662"
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/2454ae1765516d20c4ffe103d85a58a9a3bd5662",
-                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -13124,119 +12003,69 @@
             "keywords": [
                 "timer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:20:02+00:00"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "3.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/472b687829041c24b25f475e14c2f38a09edf1c2",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "abandoned": true,
-            "time": "2020-11-30T08:38:46+00:00"
+            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.20",
+            "version": "9.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
+                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
-                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/12bc8879fb65aef2138b26fc633cb1e3620cffba",
+                "reference": "12bc8879fb65aef2138b26fc633cb1e3620cffba",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.1",
+                "doctrine/instantiator": "^1.3.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.7",
-                "phar-io/manifest": "^1.0.2",
-                "phar-io/version": "^2.0",
-                "php": "^7.1",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^6.0.7",
-                "phpunit/php-file-iterator": "^2.0.1",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^2.1",
-                "sebastian/comparator": "^3.0",
-                "sebastian/diff": "^3.0",
-                "sebastian/environment": "^4.0",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^2.0",
-                "sebastian/version": "^2.0.1"
-            },
-            "conflict": {
-                "phpunit/phpunit-mock-objects": "*"
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.10.1",
+                "phar-io/manifest": "^2.0.3",
+                "phar-io/version": "^3.0.2",
+                "php": ">=7.3",
+                "phpspec/prophecy": "^1.12.1",
+                "phpunit/php-code-coverage": "^9.2.13",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.5",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.3",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^3.0",
+                "sebastian/version": "^3.0.2"
             },
             "require-dev": {
-                "ext-pdo": "*"
+                "ext-pdo": "*",
+                "phpspec/prophecy-phpunit": "^2.0.1"
             },
             "suggest": {
                 "ext-soap": "*",
-                "ext-xdebug": "*",
-                "phpunit/php-invoker": "^2.0"
+                "ext-xdebug": "*"
             },
             "bin": [
                 "phpunit"
@@ -13244,10 +12073,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.5-dev"
+                    "dev-master": "9.5-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
                 "classmap": [
                     "src/"
                 ]
@@ -13270,20 +12102,34 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-01-08T08:45:45+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.20"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-04-01T12:37:26+00:00"
         },
         {
             "name": "psy/psysh",
-            "version": "v0.10.8",
+            "version": "v0.10.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "e4573f47750dd6c92dca5aee543fa77513cbd8d3"
+                "reference": "a0d9981aa07ecfcbea28e4bfa868031cca121e7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/e4573f47750dd6c92dca5aee543fa77513cbd8d3",
-                "reference": "e4573f47750dd6c92dca5aee543fa77513cbd8d3",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/a0d9981aa07ecfcbea28e4bfa868031cca121e7d",
+                "reference": "a0d9981aa07ecfcbea28e4bfa868031cca121e7d",
                 "shasum": ""
             },
             "require": {
@@ -13341,32 +12187,224 @@
                 "interactive",
                 "shell"
             ],
-            "time": "2021-04-10T16:23:39+00:00"
+            "support": {
+                "issues": "https://github.com/bobthecow/psysh/issues",
+                "source": "https://github.com/bobthecow/psysh/tree/v0.10.12"
+            },
+            "time": "2021-11-30T14:05:36+00:00"
         },
         {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.2",
+            "name": "react/promise",
+            "version": "v2.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619"
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "234f8fd1023c9158e2314fa9d7d0e6a83db42910"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/1de8cd5c010cb153fcd68b8d0f64606f523f7619",
-                "reference": "1de8cd5c010cb153fcd68b8d0f64606f523f7619",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/234f8fd1023c9158e2314fa9d7d0e6a83db42910",
+                "reference": "234f8fd1023c9158e2314fa9d7d0e6a83db42910",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v2.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/WyriHaximus",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-11T10:27:51+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:08:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -13386,40 +12424,44 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:15:22+00:00"
+            "time": "2020-09-28T05:30:19+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.3",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758"
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1071dfcef776a57013124ff35e1fc41ccd294758",
-                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55f4261989e546dc112258c7a75935a81a7ce382",
+                "reference": "55f4261989e546dc112258c7a75935a81a7ce382",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1",
-                "sebastian/diff": "^3.0",
-                "sebastian/exporter": "^3.1"
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -13456,39 +12498,100 @@
                 "compare",
                 "equality"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:04:30+00:00"
+            "time": "2020-10-26T15:49:45+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "3.0.3",
+            "name": "sebastian/complexity",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
-                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "nikic/php-parser": "^4.7",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5 || ^8.0",
-                "symfony/process": "^2 || ^3.3 || ^4"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T15:52:27+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -13518,33 +12621,37 @@
                 "unidiff",
                 "unified diff"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:59:04+00:00"
+            "time": "2020-10-26T13:10:38+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "4.2.4",
+            "version": "5.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0"
+                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
-                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -13552,7 +12659,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.2-dev"
+                    "dev-master": "5.1-dev"
                 }
             },
             "autoload": {
@@ -13577,40 +12684,44 @@
                 "environment",
                 "hhvm"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:53:42+00:00"
+            "time": "2022-04-03T09:37:03+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.3",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e"
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/6b853149eab67d4da22291d36f5b0631c0fd856e",
-                "reference": "6b853149eab67d4da22291d36f5b0631c0fd856e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "sebastian/recursion-context": "^3.0"
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -13645,38 +12756,45 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:47:53+00:00"
+            "time": "2021-11-11T14:18:36+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -13684,7 +12802,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -13707,34 +12825,101 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-14T08:28:10+00:00"
         },
         {
-            "name": "sebastian/object-enumerator",
-            "version": "3.0.4",
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2"
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
-                "reference": "e67f6d32ebd0c749cf9d1dbd9f226c727043cdf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "nikic/php-parser": "^4.6",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-28T06:42:11+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -13754,38 +12939,42 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:40:27+00:00"
+            "time": "2020-10-26T13:12:34+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.2",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d"
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
-                "reference": "9b8772b9cbd456ab45d4a598d2dd1a1bced6363d",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -13805,38 +12994,42 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:37:18+00:00"
+            "time": "2020-10-26T13:14:26+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.1",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb"
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/367dcba38d6e1977be014dc4b22f47a484dac7fb",
-                "reference": "367dcba38d6e1977be014dc4b22f47a484dac7fb",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -13864,35 +13057,42 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:34:24+00:00"
+            "time": "2020-10-26T13:17:30+00:00"
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "2.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3"
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/31d35ca87926450c44eae7e2611d45a7a65ea8b3",
-                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -13912,35 +13112,95 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T07:30:19+00:00"
+            "time": "2020-09-28T06:45:17+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "2.0.1",
+            "name": "sebastian/type",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
+                "reference": "b233b84bc4465aff7b57cf1c4bc75c86d00d6dad",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-03-15T09:54:48+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -13961,20 +13221,142 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.2",
+            "name": "seld/jsonlint",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "3fad28475bfbdbf8aa5c440f8a8f89824983d85e"
+                "url": "https://github.com/Seldaek/jsonlint.git",
+                "reference": "4211420d25eba80712bff236a98960ef68b866b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/3fad28475bfbdbf8aa5c440f8a8f89824983d85e",
-                "reference": "3fad28475bfbdbf8aa5c440f8a8f89824983d85e",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/4211420d25eba80712bff236a98960ef68b866b7",
+                "reference": "4211420d25eba80712bff236a98960ef68b866b7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.5",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^8.5.13"
+            },
+            "bin": [
+                "bin/jsonlint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "JSON Linter",
+            "keywords": [
+                "json",
+                "linter",
+                "parser",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/jsonlint/issues",
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/seld/jsonlint",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-04-01T13:37:23+00:00"
+        },
+        {
+            "name": "seld/phar-utils",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/phar-utils.git",
+                "reference": "9f3452c93ff423469c0d56450431562ca423dcee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/phar-utils/zipball/9f3452c93ff423469c0d56450431562ca423dcee",
+                "reference": "9f3452c93ff423469c0d56450431562ca423dcee",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Seld\\PharUtils\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "PHAR file format utilities, for when PHP phars you up",
+            "keywords": [
+                "phar"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/phar-utils/issues",
+                "source": "https://github.com/Seldaek/phar-utils/tree/1.2.0"
+            },
+            "time": "2021-12-10T11:20:11+00:00"
+        },
+        {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.11.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "c921498b474212fe4552928bbeb68d70250ce5e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/c921498b474212fe4552928bbeb68d70250ce5e8",
+                "reference": "c921498b474212fe4552928bbeb68d70250ce5e8",
                 "shasum": ""
             },
             "require": {
@@ -14009,74 +13391,98 @@
                 }
             ],
             "description": "A PHPCS sniff to detect problems with variables.",
-            "time": "2021-07-06T23:45:17+00:00"
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
+                "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
+                "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
+            },
+            "time": "2022-02-21T17:01:13+00:00"
         },
         {
-            "name": "stecman/symfony-console-completion",
-            "version": "0.11.0",
+            "name": "slevomat/coding-standard",
+            "version": "7.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/stecman/symfony-console-completion.git",
-                "reference": "a9502dab59405e275a9f264536c4e1cb61fc3518"
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "b4f96a8beea515d2d89141b7b9ad72f526d84071"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stecman/symfony-console-completion/zipball/a9502dab59405e275a9f264536c4e1cb61fc3518",
-                "reference": "a9502dab59405e275a9f264536c4e1cb61fc3518",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/b4f96a8beea515d2d89141b7b9ad72f526d84071",
+                "reference": "b4f96a8beea515d2d89141b7b9ad72f526d84071",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2",
-                "symfony/console": "~2.3 || ~3.0 || ~4.0 || ~5.0"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.5.1",
+                "squizlabs/php_codesniffer": "^3.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8.36 || ~5.7 || ~6.4"
+                "phing/phing": "2.17.3",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.4.10|1.6.7",
+                "phpstan/phpstan-deprecation-rules": "1.0.0",
+                "phpstan/phpstan-phpunit": "1.0.0|1.1.1",
+                "phpstan/phpstan-strict-rules": "1.2.3",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.5.20"
             },
-            "type": "library",
+            "type": "phpcodesniffer-standard",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.10.x-dev"
+                    "dev-master": "7.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Stecman\\Component\\Symfony\\Console\\BashCompletion\\": "src/"
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "authors": [
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/7.2.0"
+            },
+            "funding": [
                 {
-                    "name": "Stephen Holdaway",
-                    "email": "stephen@stecman.co.nz"
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
                 }
             ],
-            "description": "Automatic BASH completion for Symfony Console Component based applications.",
-            "time": "2019-11-24T17:03:06+00:00"
+            "time": "2022-05-06T10:58:42+00:00"
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v3.4.47",
+            "version": "v4.4.37",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
-                "reference": "9590bd3d3f9fa2f28d34b713ed4765a8cc8ad15c"
+                "reference": "6e81008cac62369871cb6b8de64576ed138e3998"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/9590bd3d3f9fa2f28d34b713ed4765a8cc8ad15c",
-                "reference": "9590bd3d3f9fa2f28d34b713ed4765a8cc8ad15c",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/6e81008cac62369871cb6b8de64576ed138e3998",
+                "reference": "6e81008cac62369871cb6b8de64576ed138e3998",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/dom-crawler": "~2.8|~3.0|~4.0"
+                "php": ">=7.1.3",
+                "symfony/dom-crawler": "^3.4|^4.0|^5.0",
+                "symfony/polyfill-php80": "^1.16"
             },
             "require-dev": {
-                "symfony/css-selector": "~2.8|~3.0|~4.0",
-                "symfony/process": "~2.8|~3.0|~4.0"
+                "symfony/css-selector": "^3.4|^4.0|^5.0",
+                "symfony/http-client": "^4.3|^5.0",
+                "symfony/mime": "^4.3|^5.0",
+                "symfony/process": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/process": ""
@@ -14104,8 +13510,11 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony BrowserKit Component",
+            "description": "Simulates the behavior of a web browser, allowing you to make requests, click on links and submit forms programmatically",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/browser-kit/tree/v4.4.37"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -14120,24 +13529,103 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2022-01-02T09:41:36+00:00"
         },
         {
-            "name": "symfony/css-selector",
-            "version": "v3.4.47",
+            "name": "symfony/config",
+            "version": "v4.4.41",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/css-selector.git",
-                "reference": "da3d9da2ce0026771f5fe64cb332158f1bd2bc33"
+                "url": "https://github.com/symfony/config.git",
+                "reference": "9d031eb2d4292aed117b0f7fafd5c436dcf3dfd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/da3d9da2ce0026771f5fe64cb332158f1bd2bc33",
-                "reference": "da3d9da2ce0026771f5fe64cb332158f1bd2bc33",
+                "url": "https://api.github.com/repos/symfony/config/zipball/9d031eb2d4292aed117b0f7fafd5c436dcf3dfd7",
+                "reference": "9d031eb2d4292aed117b0f7fafd5c436dcf3dfd7",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8"
+                "php": ">=7.1.3",
+                "symfony/filesystem": "^3.4|^4.0|^5.0",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/polyfill-php81": "^1.22"
+            },
+            "conflict": {
+                "symfony/finder": "<3.4"
+            },
+            "require-dev": {
+                "symfony/event-dispatcher": "^3.4|^4.0|^5.0",
+                "symfony/finder": "^3.4|^4.0|^5.0",
+                "symfony/messenger": "^4.1|^5.0",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/yaml": "^3.4|^4.0|^5.0"
+            },
+            "suggest": {
+                "symfony/yaml": "To use the yaml reference dumper"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/config/tree/v4.4.41"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-04-12T15:19:55+00:00"
+        },
+        {
+            "name": "symfony/css-selector",
+            "version": "v4.4.37",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/css-selector.git",
+                "reference": "0628e6c6d7c92f1a7bae543959bdc17347be2436"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/0628e6c6d7c92f1a7bae543959bdc17347be2436",
+                "reference": "0628e6c6d7c92f1a7bae543959bdc17347be2436",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/polyfill-php80": "^1.16"
             },
             "type": "library",
             "autoload": {
@@ -14166,8 +13654,11 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony CssSelector Component",
+            "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/css-selector/tree/v4.4.37"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -14182,29 +13673,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2022-01-02T09:41:36+00:00"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v3.4.47",
+            "version": "v4.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "ef97bcfbae5b384b4ca6c8d57b617722f15241a6"
+                "reference": "4e9215a8b533802ba84a3cc5bd3c43103e7a6dc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/ef97bcfbae5b384b4ca6c8d57b617722f15241a6",
-                "reference": "ef97bcfbae5b384b4ca6c8d57b617722f15241a6",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/4e9215a8b533802ba84a3cc5bd3c43103e7a6dc3",
+                "reference": "4e9215a8b533802ba84a3cc5bd3c43103e7a6dc3",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": ">=7.1.3",
                 "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.0"
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "conflict": {
+                "masterminds/html5": "<2.6"
             },
             "require-dev": {
-                "symfony/css-selector": "~2.8|~3.0|~4.0"
+                "masterminds/html5": "^2.6",
+                "symfony/css-selector": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/css-selector": ""
@@ -14232,8 +13728,11 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony DomCrawler Component",
+            "description": "Eases DOM navigation for HTML and XML documents",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/dom-crawler/tree/v4.4.39"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -14248,28 +13747,157 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2022-02-25T10:38:15+00:00"
         },
         {
-            "name": "symfony/lock",
-            "version": "v3.4.47",
+            "name": "symfony/filesystem",
+            "version": "v4.4.39",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/lock.git",
-                "reference": "8d451ed419a3d5d503bd491437b447fd4c549ceb"
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "72a5b35fecaa670b13954e6eaf414acbe2a67b35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/lock/zipball/8d451ed419a3d5d503bd491437b447fd4c549ceb",
-                "reference": "8d451ed419a3d5d503bd491437b447fd4c549ceb",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/72a5b35fecaa670b13954e6eaf414acbe2a67b35",
+                "reference": "72a5b35fecaa670b13954e6eaf414acbe2a67b35",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "psr/log": "~1.0",
-                "symfony/polyfill-php70": "~1.0"
+                "php": ">=7.1.3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v4.4.39"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-25T10:38:15+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v4.4.41",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "40790bdf293b462798882ef6da72bb49a4a6633a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/40790bdf293b462798882ef6da72bb49a4a6633a",
+                "reference": "40790bdf293b462798882ef6da72bb49a4a6633a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v4.4.41"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-04-14T15:36:10+00:00"
+        },
+        {
+            "name": "symfony/lock",
+            "version": "v4.4.40",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/lock.git",
+                "reference": "ec23fb51d9b531f7fcd2279afe5b474e624c2445"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/lock/zipball/ec23fb51d9b531f7fcd2279afe5b474e624c2445",
+                "reference": "ec23fb51d9b531f7fcd2279afe5b474e624c2445",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "psr/log": "^1|^2|^3",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "conflict": {
+                "doctrine/dbal": "<2.6"
             },
             "require-dev": {
+                "doctrine/dbal": "^2.6|^3.0",
                 "predis/predis": "~1.0"
             },
             "type": "library",
@@ -14295,7 +13923,7 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Lock Component",
+            "description": "Creates and manages locks, a mechanism to provide exclusive access to a shared resource",
             "homepage": "https://symfony.com",
             "keywords": [
                 "cas",
@@ -14305,6 +13933,9 @@
                 "redlock",
                 "semaphore"
             ],
+            "support": {
+                "source": "https://github.com/symfony/lock/tree/v4.4.40"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -14319,30 +13950,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2022-03-22T11:09:53+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",
-            "version": "v3.4.47",
+            "version": "v5.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/phpunit-bridge.git",
-                "reference": "120273ad5d03a8deee08ca9260e2598f288f2bac"
+                "reference": "cec05218b4fd847b87dce5b3560b288096c36950"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/120273ad5d03a8deee08ca9260e2598f288f2bac",
-                "reference": "120273ad5d03a8deee08ca9260e2598f288f2bac",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/cec05218b4fd847b87dce5b3560b288096c36950",
+                "reference": "cec05218b4fd847b87dce5b3560b288096c36950",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1.3",
+                "symfony/deprecation-contracts": "^2.1|^3"
             },
             "conflict": {
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0|<6.4,>=6.0|9.1.2"
+                "phpunit/phpunit": "<7.5|9.1.2"
+            },
+            "require-dev": {
+                "symfony/error-handler": "^4.4|^5.0|^6.0"
             },
             "suggest": {
-                "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
+                "symfony/error-handler": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
             },
             "bin": [
                 "bin/simple-phpunit"
@@ -14379,8 +14014,11 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony PHPUnit Bridge",
+            "description": "Provides utilities for PHPUnit, especially user deprecation notices management",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/phpunit-bridge/tree/v5.4.8"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -14395,48 +14033,44 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-13T16:28:59+00:00"
+            "time": "2022-04-12T15:48:08+00:00"
         },
         {
-            "name": "symfony/var-dumper",
-            "version": "v3.4.47",
+            "name": "symfony/polyfill-php81",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "0719f6cf4633a38b2c1585140998579ce23b4b7d"
+                "url": "https://github.com/symfony/polyfill-php81.git",
+                "reference": "5de4ba2d41b15f9bd0e19b2ab9674135813ec98f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/0719f6cf4633a38b2c1585140998579ce23b4b7d",
-                "reference": "0719f6cf4633a38b2c1585140998579ce23b4b7d",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/5de4ba2d41b15f9bd0e19b2ab9674135813ec98f",
+                "reference": "5de4ba2d41b15f9bd0e19b2ab9674135813ec98f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
-                "symfony/polyfill-mbstring": "~1.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
-            },
-            "require-dev": {
-                "ext-iconv": "*",
-                "twig/twig": "~1.34|~2.4"
-            },
-            "suggest": {
-                "ext-iconv": "To convert non-UTF-8 strings to UTF-8 (or symfony/polyfill-iconv in case ext-iconv cannot be used).",
-                "ext-intl": "To show region name in time zone dump",
-                "ext-symfony_debug": ""
+                "php": ">=7.1"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
             "autoload": {
                 "files": [
-                    "Resources/functions/dump.php"
+                    "bootstrap.php"
                 ],
                 "psr-4": {
-                    "Symfony\\Component\\VarDumper\\": ""
+                    "Symfony\\Polyfill\\Php81\\": ""
                 },
-                "exclude-from-classmap": [
-                    "/Tests/"
+                "classmap": [
+                    "Resources/stubs"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -14453,14 +14087,16 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
             "homepage": "https://symfony.com",
             "keywords": [
-                "debug",
-                "dump"
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v3.4.47"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -14476,20 +14112,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-24T10:57:07+00:00"
+            "time": "2021-09-13T13:58:11+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
@@ -14516,7 +14152,17 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2020-07-12T23:59:07+00:00"
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -14620,6 +14266,11 @@
                 }
             ],
             "description": "A robust cross-platform utility for normalizing, comparing and modifying file paths.",
+            "support": {
+                "issues": "https://github.com/webmozart/path-util/issues",
+                "source": "https://github.com/webmozart/path-util/tree/2.3.0"
+            },
+            "abandoned": "symfony/filesystem",
             "time": "2015-12-17T08:42:14+00:00"
         }
     ],
@@ -14630,9 +14281,7 @@
         "drupal/captcha": 20,
         "drupal/libraries": 10,
         "drupal/switch_page_theme": 20,
-        "drupal/twig_extensions": 20,
-        "midcamp/hatter": 20,
-        "palantirnet/palantir-behat-extension": 20
+        "drupal/twig_extensions": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15c7b5d9204a7ff96c69cfb32c7a88a7",
+    "content-hash": "2feccce89a89fa0124d65d47069103ae",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2848,26 +2848,26 @@
         },
         {
             "name": "drupal/redirect",
-            "version": "1.5.0",
+            "version": "1.7.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/redirect.git",
-                "reference": "8.x-1.5"
+                "reference": "8.x-1.7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/redirect-8.x-1.5.zip",
-                "reference": "8.x-1.5",
-                "shasum": "7940acfb28bd802235d159f1c7a9a58e89dd3d15"
+                "url": "https://ftp.drupal.org/files/projects/redirect-8.x-1.7.zip",
+                "reference": "8.x-1.7",
+                "shasum": "013b2541a5ef0cf423a3caa1ae89cc5866504877"
             },
             "require": {
-                "drupal/core": "^8.7.7 || ^9"
+                "drupal/core": "^8.8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.5",
-                    "datestamp": "1576656784",
+                    "version": "8.x-1.7",
+                    "datestamp": "1639380488",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2876,7 +2876,7 @@
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
             "license": [
-                "GPL-2.0+"
+                "GPL-2.0-or-later"
             ],
             "authors": [
                 {

--- a/conf/drupal/config/automated_cron.settings.yml
+++ b/conf/drupal/config/automated_cron.settings.yml
@@ -1,3 +1,3 @@
-interval: 10800
 _core:
   default_config_hash: fUksROt4FfkAU9BV4hV2XvhTBSS2nTNrZS4U7S-tKrs
+interval: 10800

--- a/conf/drupal/config/block.block.bartik_account_menu.yml
+++ b/conf/drupal/config/block.block.bartik_account_menu.yml
@@ -19,8 +19,8 @@ plugin: 'system_menu_block:account'
 settings:
   id: 'system_menu_block:account'
   label: 'User account menu'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 1
   expand_all_items: false

--- a/conf/drupal/config/block.block.bartik_branding.yml
+++ b/conf/drupal/config/block.block.bartik_branding.yml
@@ -17,8 +17,8 @@ plugin: system_branding_block
 settings:
   id: system_branding_block
   label: 'Site branding'
-  provider: system
   label_display: '0'
+  provider: system
   use_site_logo: true
   use_site_name: true
   use_site_slogan: true

--- a/conf/drupal/config/block.block.bartik_breadcrumbs.yml
+++ b/conf/drupal/config/block.block.bartik_breadcrumbs.yml
@@ -17,6 +17,6 @@ plugin: system_breadcrumb_block
 settings:
   id: system_breadcrumb_block
   label: Breadcrumbs
-  provider: system
   label_display: '0'
+  provider: system
 visibility: {  }

--- a/conf/drupal/config/block.block.bartik_content.yml
+++ b/conf/drupal/config/block.block.bartik_content.yml
@@ -17,6 +17,6 @@ plugin: system_main_block
 settings:
   id: system_main_block
   label: 'Main page content'
-  provider: system
   label_display: '0'
+  provider: system
 visibility: {  }

--- a/conf/drupal/config/block.block.bartik_footer.yml
+++ b/conf/drupal/config/block.block.bartik_footer.yml
@@ -19,8 +19,8 @@ plugin: 'system_menu_block:footer'
 settings:
   id: 'system_menu_block:footer'
   label: 'Footer menu'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 0
   expand_all_items: false

--- a/conf/drupal/config/block.block.bartik_help.yml
+++ b/conf/drupal/config/block.block.bartik_help.yml
@@ -17,6 +17,6 @@ plugin: help_block
 settings:
   id: help_block
   label: Help
-  provider: help
   label_display: '0'
+  provider: help
 visibility: {  }

--- a/conf/drupal/config/block.block.bartik_local_actions.yml
+++ b/conf/drupal/config/block.block.bartik_local_actions.yml
@@ -15,6 +15,6 @@ plugin: local_actions_block
 settings:
   id: local_actions_block
   label: 'Primary admin actions'
-  provider: core
   label_display: '0'
+  provider: core
 visibility: {  }

--- a/conf/drupal/config/block.block.bartik_local_tasks.yml
+++ b/conf/drupal/config/block.block.bartik_local_tasks.yml
@@ -15,8 +15,8 @@ plugin: local_tasks_block
 settings:
   id: local_tasks_block
   label: Tabs
-  provider: core
   label_display: '0'
+  provider: core
   primary: true
   secondary: true
 visibility: {  }

--- a/conf/drupal/config/block.block.bartik_main_menu.yml
+++ b/conf/drupal/config/block.block.bartik_main_menu.yml
@@ -19,8 +19,8 @@ plugin: 'system_menu_block:main'
 settings:
   id: 'system_menu_block:main'
   label: 'Main navigation'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 1
   expand_all_items: false

--- a/conf/drupal/config/block.block.bartik_messages.yml
+++ b/conf/drupal/config/block.block.bartik_messages.yml
@@ -17,6 +17,6 @@ plugin: system_messages_block
 settings:
   id: system_messages_block
   label: 'Status messages'
-  provider: system
   label_display: '0'
+  provider: system
 visibility: {  }

--- a/conf/drupal/config/block.block.bartik_page_title.yml
+++ b/conf/drupal/config/block.block.bartik_page_title.yml
@@ -15,6 +15,6 @@ plugin: page_title_block
 settings:
   id: page_title_block
   label: 'Page title'
-  provider: core
   label_display: '0'
+  provider: core
 visibility: {  }

--- a/conf/drupal/config/block.block.bartik_powered.yml
+++ b/conf/drupal/config/block.block.bartik_powered.yml
@@ -17,6 +17,6 @@ plugin: system_powered_by_block
 settings:
   id: system_powered_by_block
   label: 'Powered by Drupal'
-  provider: system
   label_display: '0'
+  provider: system
 visibility: {  }

--- a/conf/drupal/config/block.block.bartik_search.yml
+++ b/conf/drupal/config/block.block.bartik_search.yml
@@ -17,7 +17,7 @@ plugin: search_form_block
 settings:
   id: search_form_block
   label: Search
-  provider: search
   label_display: visible
+  provider: search
   page_id: ''
 visibility: {  }

--- a/conf/drupal/config/block.block.bartik_tools.yml
+++ b/conf/drupal/config/block.block.bartik_tools.yml
@@ -19,8 +19,8 @@ plugin: 'system_menu_block:tools'
 settings:
   id: 'system_menu_block:tools'
   label: Tools
-  provider: system
   label_display: visible
+  provider: system
   level: 1
   depth: 0
   expand_all_items: false

--- a/conf/drupal/config/block.block.event_news.yml
+++ b/conf/drupal/config/block.block.event_news.yml
@@ -18,13 +18,13 @@ plugin: 'views_block:event_news-block_1'
 settings:
   id: 'views_block:event_news-block_1'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
   views_label: ''
   items_per_page: none
 visibility:
   request_path:
     id: request_path
-    pages: '/taxonomy/term/*'
     negate: false
     context_mapping: {  }
+    pages: '/taxonomy/term/*'

--- a/conf/drupal/config/block.block.event_sponsors.yml
+++ b/conf/drupal/config/block.block.event_sponsors.yml
@@ -18,13 +18,13 @@ plugin: 'views_block:event_sponsors-block_1'
 settings:
   id: 'views_block:event_sponsors-block_1'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
   views_label: ''
   items_per_page: none
 visibility:
   request_path:
     id: request_path
-    pages: '/taxonomy/term/*'
     negate: false
     context_mapping: {  }
+    pages: '/taxonomy/term/*'

--- a/conf/drupal/config/block.block.event_sub_events.yml
+++ b/conf/drupal/config/block.block.event_sub_events.yml
@@ -18,13 +18,13 @@ plugin: 'views_block:event_sub_events-block_1'
 settings:
   id: 'views_block:event_sub_events-block_1'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
   views_label: ''
   items_per_page: none
 visibility:
   request_path:
     id: request_path
-    pages: '/taxonomy/term/*'
     negate: false
     context_mapping: {  }
+    pages: '/taxonomy/term/*'

--- a/conf/drupal/config/block.block.event_venue.yml
+++ b/conf/drupal/config/block.block.event_venue.yml
@@ -18,13 +18,13 @@ plugin: 'views_block:event_venue-block_1'
 settings:
   id: 'views_block:event_venue-block_1'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
   views_label: ''
   items_per_page: none
 visibility:
   request_path:
     id: request_path
-    pages: '/taxonomy/term/*'
     negate: false
     context_mapping: {  }
+    pages: '/taxonomy/term/*'

--- a/conf/drupal/config/block.block.hatter_2019_account_menu.yml
+++ b/conf/drupal/config/block.block.hatter_2019_account_menu.yml
@@ -19,8 +19,8 @@ plugin: 'system_menu_block:account'
 settings:
   id: 'system_menu_block:account'
   label: 'User account menu'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 1
   expand_all_items: false

--- a/conf/drupal/config/block.block.hatter_2019_addajobbutton.yml
+++ b/conf/drupal/config/block.block.hatter_2019_addajobbutton.yml
@@ -19,23 +19,23 @@ plugin: 'block_content:de1557a6-167f-41a3-945d-05e977e71f1c'
 settings:
   id: 'block_content:de1557a6-167f-41a3-945d-05e977e71f1c'
   label: 'Add a Job Button'
-  provider: block_content
   label_display: '0'
+  provider: block_content
   status: true
   info: ''
   view_mode: full
 visibility:
   request_path:
     id: request_path
-    pages: /jobs
     negate: false
     context_mapping: {  }
+    pages: /jobs
   user_role:
     id: user_role
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'
     roles:
       content_editor: content_editor
       administrator: administrator
       sponsor: sponsor
-    negate: false
-    context_mapping:
-      user: '@user.current_user_context:current_user'

--- a/conf/drupal/config/block.block.hatter_2019_branding.yml
+++ b/conf/drupal/config/block.block.hatter_2019_branding.yml
@@ -17,14 +17,14 @@ plugin: system_branding_block
 settings:
   id: system_branding_block
   label: 'Site branding'
-  provider: system
   label_display: '0'
+  provider: system
   use_site_logo: true
   use_site_name: true
   use_site_slogan: true
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: false
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.hatter_2019_breadcrumbs.yml
+++ b/conf/drupal/config/block.block.hatter_2019_breadcrumbs.yml
@@ -17,6 +17,6 @@ plugin: system_breadcrumb_block
 settings:
   id: system_breadcrumb_block
   label: Breadcrumbs
-  provider: system
   label_display: '0'
+  provider: system
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_2019_content.yml
+++ b/conf/drupal/config/block.block.hatter_2019_content.yml
@@ -17,11 +17,11 @@ plugin: system_main_block
 settings:
   id: system_main_block
   label: 'Main page content'
-  provider: system
   label_display: '0'
+  provider: system
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: true
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.hatter_2019_eventlabelblock.yml
+++ b/conf/drupal/config/block.block.hatter_2019_eventlabelblock.yml
@@ -16,11 +16,14 @@ plugin: event_label_block
 settings:
   id: event_label_block
   label: 'Event label block'
-  provider: midcamp_event_label_block
   label_display: '0'
+  provider: midcamp_event_label_block
 visibility:
   'entity_bundle:node':
     id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
     bundles:
       summit: summit
       article: article
@@ -30,6 +33,3 @@ visibility:
       topic: topic
       training: training
       venue: venue
-    negate: false
-    context_mapping:
-      node: '@node.node_route_context:node'

--- a/conf/drupal/config/block.block.hatter_2019_footer.yml
+++ b/conf/drupal/config/block.block.hatter_2019_footer.yml
@@ -17,8 +17,8 @@ plugin: 'system_menu_block:footer'
 settings:
   id: 'system_menu_block:footer'
   label: Footer
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 0
   expand_all_items: false

--- a/conf/drupal/config/block.block.hatter_2019_footerbranding.yml
+++ b/conf/drupal/config/block.block.hatter_2019_footerbranding.yml
@@ -17,8 +17,8 @@ plugin: 'block_content:2f35417b-1d83-40cb-a971-3683805002ae'
 settings:
   id: 'block_content:2f35417b-1d83-40cb-a971-3683805002ae'
   label: 'Footer Branding'
-  provider: block_content
   label_display: '0'
+  provider: block_content
   status: true
   info: ''
   view_mode: full

--- a/conf/drupal/config/block.block.hatter_2019_help.yml
+++ b/conf/drupal/config/block.block.hatter_2019_help.yml
@@ -17,6 +17,6 @@ plugin: help_block
 settings:
   id: help_block
   label: Help
-  provider: help
   label_display: '0'
+  provider: help
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_2019_local_actions.yml
+++ b/conf/drupal/config/block.block.hatter_2019_local_actions.yml
@@ -15,6 +15,6 @@ plugin: local_actions_block
 settings:
   id: local_actions_block
   label: 'Primary admin actions'
-  provider: core
   label_display: '0'
+  provider: core
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_2019_main_menu.yml
+++ b/conf/drupal/config/block.block.hatter_2019_main_menu.yml
@@ -19,14 +19,14 @@ plugin: 'system_menu_block:main'
 settings:
   id: 'system_menu_block:main'
   label: 'Main navigation'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 2
   expand_all_items: false
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/*\r\n/2018"
     negate: false
     context_mapping: {  }
+    pages: "/2018/*\r\n/2018"

--- a/conf/drupal/config/block.block.hatter_2019_messages.yml
+++ b/conf/drupal/config/block.block.hatter_2019_messages.yml
@@ -17,6 +17,6 @@ plugin: system_messages_block
 settings:
   id: system_messages_block
   label: 'Status messages'
-  provider: system
   label_display: '0'
+  provider: system
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_2019_midcamp2019.yml
+++ b/conf/drupal/config/block.block.hatter_2019_midcamp2019.yml
@@ -18,14 +18,14 @@ plugin: 'block_content:718a2f09-3a75-462a-9c04-3e21f78a81bb'
 settings:
   id: 'block_content:718a2f09-3a75-462a-9c04-3e21f78a81bb'
   label: 'MidCamp 2019'
-  provider: block_content
   label_display: '0'
+  provider: block_content
   status: true
   info: ''
   view_mode: full
 visibility:
   request_path:
     id: request_path
-    pages: /2020
     negate: false
     context_mapping: {  }
+    pages: /2020

--- a/conf/drupal/config/block.block.hatter_2019_midcamp2019navigation.yml
+++ b/conf/drupal/config/block.block.hatter_2019_midcamp2019navigation.yml
@@ -17,14 +17,14 @@ plugin: 'system_menu_block:midcamp-2019-navigation'
 settings:
   id: 'system_menu_block:midcamp-2019-navigation'
   label: 'Midcamp 2019 Navigation'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 2
   expand_all_items: false
 visibility:
   request_path:
     id: request_path
-    pages: "/2019/*\r\n/2019"
     negate: false
     context_mapping: {  }
+    pages: "/2019/*\r\n/2019"

--- a/conf/drupal/config/block.block.hatter_2019_midcamp2020navigation.yml
+++ b/conf/drupal/config/block.block.hatter_2019_midcamp2020navigation.yml
@@ -17,14 +17,14 @@ plugin: 'system_menu_block:midcamp-2020-navigation'
 settings:
   id: 'system_menu_block:midcamp-2020-navigation'
   label: 'Midcamp 2020 Navigation'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 2
   expand_all_items: true
 visibility:
   request_path:
     id: request_path
-    pages: "/2020/*\r\n/2020"
     negate: false
     context_mapping: {  }
+    pages: "/2020/*\r\n/2020"

--- a/conf/drupal/config/block.block.hatter_2019_page_title.yml
+++ b/conf/drupal/config/block.block.hatter_2019_page_title.yml
@@ -17,11 +17,11 @@ plugin: page_title_block
 settings:
   id: page_title_block
   label: 'Page title'
-  provider: core
   label_display: '0'
+  provider: core
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: true
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.hatter_2019_powered.yml
+++ b/conf/drupal/config/block.block.hatter_2019_powered.yml
@@ -17,6 +17,6 @@ plugin: system_powered_by_block
 settings:
   id: system_powered_by_block
   label: 'Powered by Drupal'
-  provider: system
   label_display: '0'
+  provider: system
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_2019_search.yml
+++ b/conf/drupal/config/block.block.hatter_2019_search.yml
@@ -17,7 +17,7 @@ plugin: search_form_block
 settings:
   id: search_form_block
   label: Search
-  provider: search
   label_display: visible
+  provider: search
   page_id: ''
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_2019_socialfooter.yml
+++ b/conf/drupal/config/block.block.hatter_2019_socialfooter.yml
@@ -17,8 +17,8 @@ plugin: 'block_content:c87b75b7-23fd-45ac-ae17-af7efa9c87a8'
 settings:
   id: 'block_content:c87b75b7-23fd-45ac-ae17-af7efa9c87a8'
   label: 'Social Footer'
-  provider: block_content
   label_display: '0'
+  provider: block_content
   status: true
   info: ''
   view_mode: full

--- a/conf/drupal/config/block.block.hatter_2019_tabs.yml
+++ b/conf/drupal/config/block.block.hatter_2019_tabs.yml
@@ -13,8 +13,8 @@ plugin: local_tasks_block
 settings:
   id: local_tasks_block
   label: Tabs
-  provider: core
   label_display: '0'
+  provider: core
   primary: true
   secondary: true
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_2019_tools.yml
+++ b/conf/drupal/config/block.block.hatter_2019_tools.yml
@@ -19,8 +19,8 @@ plugin: 'system_menu_block:tools'
 settings:
   id: 'system_menu_block:tools'
   label: Tools
-  provider: system
   label_display: visible
+  provider: system
   level: 1
   depth: 0
   expand_all_items: false

--- a/conf/drupal/config/block.block.hatter_2019_views_block__attendees_block_2.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__attendees_block_2.yml
@@ -18,13 +18,13 @@ plugin: 'views_block:attendees-block_2'
 settings:
   id: 'views_block:attendees-block_2'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
   views_label: ''
   items_per_page: none
 visibility:
   request_path:
     id: request_path
-    pages: /2019/sponsors
     negate: false
     context_mapping: {  }
+    pages: /2019/sponsors

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_news_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_news_block_1.yml
@@ -17,8 +17,8 @@ plugin: 'views_block:event_news-block_1'
 settings:
   id: 'views_block:event_news-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
   views_label: ''
   items_per_page: none
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_1.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_1'
 settings:
   id: 'views_block:event_sponsors-block_1'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2020*\r\n/2019*\r\n/2018*\r\n<front>"
     negate: false
     context_mapping: {  }
+    pages: "/2020*\r\n/2019*\r\n/2018*\r\n<front>"

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_10.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_10.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_10'
 settings:
   id: 'views_block:event_sponsors-block_10'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: /2020/sponsors
     negate: false
     context_mapping: {  }
+    pages: /2020/sponsors

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_11.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_11.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_11'
 settings:
   id: 'views_block:event_sponsors-block_11'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: /2020/sponsors
     negate: false
     context_mapping: {  }
+    pages: /2020/sponsors

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_2.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_2.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_2'
 settings:
   id: 'views_block:event_sponsors-block_2'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/sponsors\r\n/2019/sponsors"
     negate: false
     context_mapping: {  }
+    pages: "/2018/sponsors\r\n/2019/sponsors"

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_3.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_3.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_3'
 settings:
   id: 'views_block:event_sponsors-block_3'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }
+    pages: '/*/sponsors'

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_4.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_4.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_4'
 settings:
   id: 'views_block:event_sponsors-block_4'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }
+    pages: '/*/sponsors'

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_5.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_5.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_5'
 settings:
   id: 'views_block:event_sponsors-block_5'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/sponsors\r\n/2019/sponsors"
     negate: false
     context_mapping: {  }
+    pages: "/2018/sponsors\r\n/2019/sponsors"

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_6.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_6.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_6'
 settings:
   id: 'views_block:event_sponsors-block_6'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }
+    pages: '/*/sponsors'

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_7.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_7.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_7'
 settings:
   id: 'views_block:event_sponsors-block_7'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }
+    pages: '/*/sponsors'

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_8.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_8.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_8'
 settings:
   id: 'views_block:event_sponsors-block_8'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/sponsors\r\n/2019/sponsors"
     negate: false
     context_mapping: {  }
+    pages: "/2018/sponsors\r\n/2019/sponsors"

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_9.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sponsors_block_9.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_9'
 settings:
   id: 'views_block:event_sponsors-block_9'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: /2020/sponsors
     negate: false
     context_mapping: {  }
+    pages: /2020/sponsors

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_sub_events_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_sub_events_block_1.yml
@@ -17,9 +17,9 @@ plugin: 'views_block:event_sub_events-block_1'
 settings:
   id: 'views_block:event_sub_events-block_1'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_2019_views_block__event_venue_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__event_venue_block_1.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_venue-block_1'
 settings:
   id: 'views_block:event_venue-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2019*\r\n/2018*\r\n"
     negate: false
     context_mapping: {  }
+    pages: "/2019*\r\n/2018*\r\n"

--- a/conf/drupal/config/block.block.hatter_2019_views_block__jobs_board_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__jobs_board_block_1.yml
@@ -18,16 +18,16 @@ plugin: 'views_block:jobs_board-block_1'
 settings:
   id: 'views_block:jobs_board-block_1'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   'entity_bundle:node':
     id: 'entity_bundle:node'
-    bundles:
-      sponsor: sponsor
     negate: false
     context_mapping:
       node: '@node.node_route_context:node'
+    bundles:
+      sponsor: sponsor

--- a/conf/drupal/config/block.block.hatter_2019_views_block__speakers_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__speakers_block_1.yml
@@ -18,13 +18,13 @@ plugin: 'views_block:speakers-block_1'
 settings:
   id: 'views_block:speakers-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
   views_label: ''
   items_per_page: none
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: true
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.hatter_2019_views_block__summits_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__summits_block_1.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:summits-block_1'
 settings:
   id: 'views_block:summits-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/summits'
     negate: false
     context_mapping: {  }
+    pages: '/*/summits'

--- a/conf/drupal/config/block.block.hatter_2019_views_block__training_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_2019_views_block__training_block_1.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:training-block_1'
 settings:
   id: 'views_block:training-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/training'
     negate: false
     context_mapping: {  }
+    pages: '/*/training'

--- a/conf/drupal/config/block.block.hatter_2019_webform.yml
+++ b/conf/drupal/config/block.block.hatter_2019_webform.yml
@@ -18,14 +18,14 @@ plugin: webform_block
 settings:
   id: webform_block
   label: 'Lightning Talk Sign Up'
-  provider: webform
   label_display: visible
+  provider: webform
   webform_id: lightning_talk_sign_up
   default_data: ''
   redirect: false
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/topic-proposal/lightning-talks\r\n/2019/topic-proposal/lightning-talks"
     negate: false
     context_mapping: {  }
+    pages: "/2018/topic-proposal/lightning-talks\r\n/2019/topic-proposal/lightning-talks"

--- a/conf/drupal/config/block.block.hatter_account_menu.yml
+++ b/conf/drupal/config/block.block.hatter_account_menu.yml
@@ -19,8 +19,8 @@ plugin: 'system_menu_block:account'
 settings:
   id: 'system_menu_block:account'
   label: 'User account menu'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 1
   expand_all_items: false

--- a/conf/drupal/config/block.block.hatter_addajobbutton.yml
+++ b/conf/drupal/config/block.block.hatter_addajobbutton.yml
@@ -19,23 +19,23 @@ plugin: 'block_content:de1557a6-167f-41a3-945d-05e977e71f1c'
 settings:
   id: 'block_content:de1557a6-167f-41a3-945d-05e977e71f1c'
   label: 'Add a Job Button'
-  provider: block_content
   label_display: '0'
+  provider: block_content
   status: true
   info: ''
   view_mode: full
 visibility:
   request_path:
     id: request_path
-    pages: /jobs
     negate: false
     context_mapping: {  }
+    pages: /jobs
   user_role:
     id: user_role
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'
     roles:
       content_editor: content_editor
       administrator: administrator
       sponsor: sponsor
-    negate: false
-    context_mapping:
-      user: '@user.current_user_context:current_user'

--- a/conf/drupal/config/block.block.hatter_base_account_menu.yml
+++ b/conf/drupal/config/block.block.hatter_base_account_menu.yml
@@ -19,8 +19,8 @@ plugin: 'system_menu_block:account'
 settings:
   id: 'system_menu_block:account'
   label: 'User account menu'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 1
   expand_all_items: false

--- a/conf/drupal/config/block.block.hatter_base_addajobbutton.yml
+++ b/conf/drupal/config/block.block.hatter_base_addajobbutton.yml
@@ -19,23 +19,23 @@ plugin: 'block_content:de1557a6-167f-41a3-945d-05e977e71f1c'
 settings:
   id: 'block_content:de1557a6-167f-41a3-945d-05e977e71f1c'
   label: 'Add a Job Button'
-  provider: block_content
   label_display: '0'
+  provider: block_content
   status: true
   info: ''
   view_mode: full
 visibility:
   request_path:
     id: request_path
-    pages: /jobs
     negate: false
     context_mapping: {  }
+    pages: /jobs
   user_role:
     id: user_role
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'
     roles:
       content_editor: content_editor
       administrator: administrator
       sponsor: sponsor
-    negate: false
-    context_mapping:
-      user: '@user.current_user_context:current_user'

--- a/conf/drupal/config/block.block.hatter_base_branding.yml
+++ b/conf/drupal/config/block.block.hatter_base_branding.yml
@@ -17,14 +17,14 @@ plugin: system_branding_block
 settings:
   id: system_branding_block
   label: 'Site branding'
-  provider: system
   label_display: '0'
+  provider: system
   use_site_logo: true
   use_site_name: true
   use_site_slogan: true
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: false
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.hatter_base_breadcrumbs.yml
+++ b/conf/drupal/config/block.block.hatter_base_breadcrumbs.yml
@@ -17,6 +17,6 @@ plugin: system_breadcrumb_block
 settings:
   id: system_breadcrumb_block
   label: Breadcrumbs
-  provider: system
   label_display: '0'
+  provider: system
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_base_content.yml
+++ b/conf/drupal/config/block.block.hatter_base_content.yml
@@ -17,11 +17,11 @@ plugin: system_main_block
 settings:
   id: system_main_block
   label: 'Main page content'
-  provider: system
   label_display: '0'
+  provider: system
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: true
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.hatter_base_eventlabelblock.yml
+++ b/conf/drupal/config/block.block.hatter_base_eventlabelblock.yml
@@ -16,11 +16,14 @@ plugin: event_label_block
 settings:
   id: event_label_block
   label: 'Event label block'
-  provider: midcamp_event_label_block
   label_display: '0'
+  provider: midcamp_event_label_block
 visibility:
   'entity_bundle:node':
     id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
     bundles:
       summit: summit
       article: article
@@ -30,6 +33,3 @@ visibility:
       topic: topic
       training: training
       venue: venue
-    negate: false
-    context_mapping:
-      node: '@node.node_route_context:node'

--- a/conf/drupal/config/block.block.hatter_base_footer.yml
+++ b/conf/drupal/config/block.block.hatter_base_footer.yml
@@ -17,8 +17,8 @@ plugin: 'system_menu_block:footer'
 settings:
   id: 'system_menu_block:footer'
   label: Footer
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 0
   expand_all_items: false

--- a/conf/drupal/config/block.block.hatter_base_footerbranding.yml
+++ b/conf/drupal/config/block.block.hatter_base_footerbranding.yml
@@ -17,8 +17,8 @@ plugin: 'block_content:2f35417b-1d83-40cb-a971-3683805002ae'
 settings:
   id: 'block_content:2f35417b-1d83-40cb-a971-3683805002ae'
   label: 'Footer Branding'
-  provider: block_content
   label_display: '0'
+  provider: block_content
   status: true
   info: ''
   view_mode: full

--- a/conf/drupal/config/block.block.hatter_base_help.yml
+++ b/conf/drupal/config/block.block.hatter_base_help.yml
@@ -17,6 +17,6 @@ plugin: help_block
 settings:
   id: help_block
   label: Help
-  provider: help
   label_display: '0'
+  provider: help
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_base_local_actions.yml
+++ b/conf/drupal/config/block.block.hatter_base_local_actions.yml
@@ -15,6 +15,6 @@ plugin: local_actions_block
 settings:
   id: local_actions_block
   label: 'Primary admin actions'
-  provider: core
   label_display: '0'
+  provider: core
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_base_main_menu.yml
+++ b/conf/drupal/config/block.block.hatter_base_main_menu.yml
@@ -19,14 +19,14 @@ plugin: 'system_menu_block:main'
 settings:
   id: 'system_menu_block:main'
   label: 'Main navigation'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 2
   expand_all_items: false
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/*\r\n/2018"
     negate: false
     context_mapping: {  }
+    pages: "/2018/*\r\n/2018"

--- a/conf/drupal/config/block.block.hatter_base_messages.yml
+++ b/conf/drupal/config/block.block.hatter_base_messages.yml
@@ -17,6 +17,6 @@ plugin: system_messages_block
 settings:
   id: system_messages_block
   label: 'Status messages'
-  provider: system
   label_display: '0'
+  provider: system
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_base_midcamp2019.yml
+++ b/conf/drupal/config/block.block.hatter_base_midcamp2019.yml
@@ -18,14 +18,14 @@ plugin: 'block_content:718a2f09-3a75-462a-9c04-3e21f78a81bb'
 settings:
   id: 'block_content:718a2f09-3a75-462a-9c04-3e21f78a81bb'
   label: 'MidCamp 2019'
-  provider: block_content
   label_display: '0'
+  provider: block_content
   status: true
   info: ''
   view_mode: full
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: false
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.hatter_base_midcamp2019navigation.yml
+++ b/conf/drupal/config/block.block.hatter_base_midcamp2019navigation.yml
@@ -17,14 +17,14 @@ plugin: 'system_menu_block:midcamp-2019-navigation'
 settings:
   id: 'system_menu_block:midcamp-2019-navigation'
   label: 'Midcamp 2019 Navigation'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 2
   expand_all_items: false
 visibility:
   request_path:
     id: request_path
-    pages: "/2019/*\r\n/2019"
     negate: false
     context_mapping: {  }
+    pages: "/2019/*\r\n/2019"

--- a/conf/drupal/config/block.block.hatter_base_midcamp2020navigation.yml
+++ b/conf/drupal/config/block.block.hatter_base_midcamp2020navigation.yml
@@ -17,14 +17,14 @@ plugin: 'system_menu_block:midcamp-2020-navigation'
 settings:
   id: 'system_menu_block:midcamp-2020-navigation'
   label: 'Midcamp 2020 Navigation'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 2
   expand_all_items: true
 visibility:
   request_path:
     id: request_path
-    pages: "/2018*\r\n/2019*"
     negate: true
     context_mapping: {  }
+    pages: "/2018*\r\n/2019*"

--- a/conf/drupal/config/block.block.hatter_base_page_title.yml
+++ b/conf/drupal/config/block.block.hatter_base_page_title.yml
@@ -17,11 +17,11 @@ plugin: page_title_block
 settings:
   id: page_title_block
   label: 'Page title'
-  provider: core
   label_display: '0'
+  provider: core
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: true
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.hatter_base_powered.yml
+++ b/conf/drupal/config/block.block.hatter_base_powered.yml
@@ -17,6 +17,6 @@ plugin: system_powered_by_block
 settings:
   id: system_powered_by_block
   label: 'Powered by Drupal'
-  provider: system
   label_display: '0'
+  provider: system
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_base_search.yml
+++ b/conf/drupal/config/block.block.hatter_base_search.yml
@@ -17,7 +17,7 @@ plugin: search_form_block
 settings:
   id: search_form_block
   label: Search
-  provider: search
   label_display: visible
+  provider: search
   page_id: ''
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_base_socialfooter.yml
+++ b/conf/drupal/config/block.block.hatter_base_socialfooter.yml
@@ -17,8 +17,8 @@ plugin: 'block_content:c87b75b7-23fd-45ac-ae17-af7efa9c87a8'
 settings:
   id: 'block_content:c87b75b7-23fd-45ac-ae17-af7efa9c87a8'
   label: 'Social Footer'
-  provider: block_content
   label_display: '0'
+  provider: block_content
   status: true
   info: ''
   view_mode: full

--- a/conf/drupal/config/block.block.hatter_base_tabs.yml
+++ b/conf/drupal/config/block.block.hatter_base_tabs.yml
@@ -13,8 +13,8 @@ plugin: local_tasks_block
 settings:
   id: local_tasks_block
   label: Tabs
-  provider: core
   label_display: '0'
+  provider: core
   primary: true
   secondary: true
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_base_tools.yml
+++ b/conf/drupal/config/block.block.hatter_base_tools.yml
@@ -19,8 +19,8 @@ plugin: 'system_menu_block:tools'
 settings:
   id: 'system_menu_block:tools'
   label: Tools
-  provider: system
   label_display: visible
+  provider: system
   level: 1
   depth: 0
   expand_all_items: false

--- a/conf/drupal/config/block.block.hatter_base_training_feedback_form.yml
+++ b/conf/drupal/config/block.block.hatter_base_training_feedback_form.yml
@@ -18,14 +18,14 @@ plugin: webform_block
 settings:
   id: webform_block
   label: 'Provide feedback on this training'
-  provider: webform
   label_display: visible
+  provider: webform
   webform_id: training_feedback_2019
   default_data: ''
   redirect: false
 visibility:
   request_path:
     id: request_path
-    pages: '/2019/training-proposal/*'
     negate: false
     context_mapping: {  }
+    pages: '/2019/training-proposal/*'

--- a/conf/drupal/config/block.block.hatter_base_views_block__attendees_block_2.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__attendees_block_2.yml
@@ -18,13 +18,13 @@ plugin: 'views_block:attendees-block_2'
 settings:
   id: 'views_block:attendees-block_2'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
   views_label: ''
   items_per_page: none
 visibility:
   request_path:
     id: request_path
-    pages: /2019/sponsors
     negate: false
     context_mapping: {  }
+    pages: /2019/sponsors

--- a/conf/drupal/config/block.block.hatter_base_views_block__event_news_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__event_news_block_1.yml
@@ -17,8 +17,8 @@ plugin: 'views_block:event_news-block_1'
 settings:
   id: 'views_block:event_news-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
   views_label: ''
   items_per_page: none
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_1.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_1'
 settings:
   id: 'views_block:event_sponsors-block_1'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "2018*\r\n<front>"
     negate: true
     context_mapping: {  }
+    pages: "2018*\r\n<front>"

--- a/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_10.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_10.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_10'
 settings:
   id: 'views_block:event_sponsors-block_10'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: /2020/sponsors
     negate: false
     context_mapping: {  }
+    pages: /2020/sponsors

--- a/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_11.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_11.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_11'
 settings:
   id: 'views_block:event_sponsors-block_11'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: /2020/sponsors
     negate: false
     context_mapping: {  }
+    pages: /2020/sponsors

--- a/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_2.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_2.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_2'
 settings:
   id: 'views_block:event_sponsors-block_2'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/sponsors\r\n/2019/sponsors"
     negate: false
     context_mapping: {  }
+    pages: "/2018/sponsors\r\n/2019/sponsors"

--- a/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_3.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_3.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_3'
 settings:
   id: 'views_block:event_sponsors-block_3'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }
+    pages: '/*/sponsors'

--- a/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_4.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_4.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_4'
 settings:
   id: 'views_block:event_sponsors-block_4'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }
+    pages: '/*/sponsors'

--- a/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_5.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_5.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_5'
 settings:
   id: 'views_block:event_sponsors-block_5'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/sponsors\r\n/2019/sponsors"
     negate: false
     context_mapping: {  }
+    pages: "/2018/sponsors\r\n/2019/sponsors"

--- a/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_6.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_6.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_6'
 settings:
   id: 'views_block:event_sponsors-block_6'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }
+    pages: '/*/sponsors'

--- a/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_7.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_7.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_7'
 settings:
   id: 'views_block:event_sponsors-block_7'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }
+    pages: '/*/sponsors'

--- a/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_8.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_8.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_8'
 settings:
   id: 'views_block:event_sponsors-block_8'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/sponsors\r\n/2019/sponsors"
     negate: false
     context_mapping: {  }
+    pages: "/2018/sponsors\r\n/2019/sponsors"

--- a/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_9.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__event_sponsors_block_9.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_9'
 settings:
   id: 'views_block:event_sponsors-block_9'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: /2020/sponsors
     negate: false
     context_mapping: {  }
+    pages: /2020/sponsors

--- a/conf/drupal/config/block.block.hatter_base_views_block__event_sub_events_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__event_sub_events_block_1.yml
@@ -17,9 +17,9 @@ plugin: 'views_block:event_sub_events-block_1'
 settings:
   id: 'views_block:event_sub_events-block_1'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_base_views_block__event_venue_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__event_venue_block_1.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_venue-block_1'
 settings:
   id: 'views_block:event_venue-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2019*\r\n<front>"
     negate: true
     context_mapping: {  }
+    pages: "/2019*\r\n<front>"

--- a/conf/drupal/config/block.block.hatter_base_views_block__jobs_board_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__jobs_board_block_1.yml
@@ -18,16 +18,16 @@ plugin: 'views_block:jobs_board-block_1'
 settings:
   id: 'views_block:jobs_board-block_1'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   'entity_bundle:node':
     id: 'entity_bundle:node'
-    bundles:
-      sponsor: sponsor
     negate: false
     context_mapping:
       node: '@node.node_route_context:node'
+    bundles:
+      sponsor: sponsor

--- a/conf/drupal/config/block.block.hatter_base_views_block__speakers_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__speakers_block_1.yml
@@ -18,13 +18,13 @@ plugin: 'views_block:speakers-block_1'
 settings:
   id: 'views_block:speakers-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
   views_label: ''
   items_per_page: none
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: true
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.hatter_base_views_block__summits_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__summits_block_1.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:summits-block_1'
 settings:
   id: 'views_block:summits-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/summits'
     negate: false
     context_mapping: {  }
+    pages: '/*/summits'

--- a/conf/drupal/config/block.block.hatter_base_views_block__training_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_base_views_block__training_block_1.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:training-block_1'
 settings:
   id: 'views_block:training-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/training'
     negate: false
     context_mapping: {  }
+    pages: '/*/training'

--- a/conf/drupal/config/block.block.hatter_base_webform.yml
+++ b/conf/drupal/config/block.block.hatter_base_webform.yml
@@ -18,14 +18,14 @@ plugin: webform_block
 settings:
   id: webform_block
   label: 'Lightning Talk Sign Up'
-  provider: webform
   label_display: visible
+  provider: webform
   webform_id: lightning_talk_sign_up
   default_data: ''
   redirect: false
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/topic-proposal/lightning-talks\r\n/2019/topic-proposal/lightning-talks"
     negate: false
     context_mapping: {  }
+    pages: "/2018/topic-proposal/lightning-talks\r\n/2019/topic-proposal/lightning-talks"

--- a/conf/drupal/config/block.block.hatter_branding.yml
+++ b/conf/drupal/config/block.block.hatter_branding.yml
@@ -17,14 +17,14 @@ plugin: system_branding_block
 settings:
   id: system_branding_block
   label: 'Site branding'
-  provider: system
   label_display: '0'
+  provider: system
   use_site_logo: true
   use_site_name: true
   use_site_slogan: true
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: false
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.hatter_breadcrumbs.yml
+++ b/conf/drupal/config/block.block.hatter_breadcrumbs.yml
@@ -17,6 +17,6 @@ plugin: system_breadcrumb_block
 settings:
   id: system_breadcrumb_block
   label: Breadcrumbs
-  provider: system
   label_display: '0'
+  provider: system
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_content.yml
+++ b/conf/drupal/config/block.block.hatter_content.yml
@@ -17,11 +17,11 @@ plugin: system_main_block
 settings:
   id: system_main_block
   label: 'Main page content'
-  provider: system
   label_display: '0'
+  provider: system
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: true
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.hatter_eventlabelblock.yml
+++ b/conf/drupal/config/block.block.hatter_eventlabelblock.yml
@@ -16,11 +16,14 @@ plugin: event_label_block
 settings:
   id: event_label_block
   label: 'Event label block'
-  provider: midcamp_event_label_block
   label_display: '0'
+  provider: midcamp_event_label_block
 visibility:
   'entity_bundle:node':
     id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
     bundles:
       summit: summit
       article: article
@@ -30,6 +33,3 @@ visibility:
       topic: topic
       training: training
       venue: venue
-    negate: false
-    context_mapping:
-      node: '@node.node_route_context:node'

--- a/conf/drupal/config/block.block.hatter_footer.yml
+++ b/conf/drupal/config/block.block.hatter_footer.yml
@@ -17,8 +17,8 @@ plugin: 'system_menu_block:footer'
 settings:
   id: 'system_menu_block:footer'
   label: Footer
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 0
   expand_all_items: false

--- a/conf/drupal/config/block.block.hatter_footerbranding.yml
+++ b/conf/drupal/config/block.block.hatter_footerbranding.yml
@@ -17,8 +17,8 @@ plugin: 'block_content:2f35417b-1d83-40cb-a971-3683805002ae'
 settings:
   id: 'block_content:2f35417b-1d83-40cb-a971-3683805002ae'
   label: 'Footer Branding'
-  provider: block_content
   label_display: '0'
+  provider: block_content
   status: true
   info: ''
   view_mode: full

--- a/conf/drupal/config/block.block.hatter_help.yml
+++ b/conf/drupal/config/block.block.hatter_help.yml
@@ -17,6 +17,6 @@ plugin: help_block
 settings:
   id: help_block
   label: Help
-  provider: help
   label_display: '0'
+  provider: help
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_local_actions.yml
+++ b/conf/drupal/config/block.block.hatter_local_actions.yml
@@ -15,6 +15,6 @@ plugin: local_actions_block
 settings:
   id: local_actions_block
   label: 'Primary admin actions'
-  provider: core
   label_display: '0'
+  provider: core
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_main_menu.yml
+++ b/conf/drupal/config/block.block.hatter_main_menu.yml
@@ -19,14 +19,14 @@ plugin: 'system_menu_block:main'
 settings:
   id: 'system_menu_block:main'
   label: 'Main navigation'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 2
   expand_all_items: false
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/*\r\n/2018"
     negate: false
     context_mapping: {  }
+    pages: "/2018/*\r\n/2018"

--- a/conf/drupal/config/block.block.hatter_messages.yml
+++ b/conf/drupal/config/block.block.hatter_messages.yml
@@ -17,6 +17,6 @@ plugin: system_messages_block
 settings:
   id: system_messages_block
   label: 'Status messages'
-  provider: system
   label_display: '0'
+  provider: system
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_midcamp2019.yml
+++ b/conf/drupal/config/block.block.hatter_midcamp2019.yml
@@ -18,14 +18,14 @@ plugin: 'block_content:718a2f09-3a75-462a-9c04-3e21f78a81bb'
 settings:
   id: 'block_content:718a2f09-3a75-462a-9c04-3e21f78a81bb'
   label: 'MidCamp 2019'
-  provider: block_content
   label_display: '0'
+  provider: block_content
   status: true
   info: ''
   view_mode: full
 visibility:
   request_path:
     id: request_path
-    pages: /2020
     negate: false
     context_mapping: {  }
+    pages: /2020

--- a/conf/drupal/config/block.block.hatter_midcamp2019navigation.yml
+++ b/conf/drupal/config/block.block.hatter_midcamp2019navigation.yml
@@ -17,14 +17,14 @@ plugin: 'system_menu_block:midcamp-2019-navigation'
 settings:
   id: 'system_menu_block:midcamp-2019-navigation'
   label: 'Midcamp 2019 Navigation'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 2
   expand_all_items: false
 visibility:
   request_path:
     id: request_path
-    pages: "/2019/*\r\n/2019"
     negate: false
     context_mapping: {  }
+    pages: "/2019/*\r\n/2019"

--- a/conf/drupal/config/block.block.hatter_midcamp2020navigation.yml
+++ b/conf/drupal/config/block.block.hatter_midcamp2020navigation.yml
@@ -17,14 +17,14 @@ plugin: 'system_menu_block:midcamp-2020-navigation'
 settings:
   id: 'system_menu_block:midcamp-2020-navigation'
   label: 'Midcamp 2020 Navigation'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 2
   expand_all_items: true
 visibility:
   request_path:
     id: request_path
-    pages: "/2020/*\r\n/2020"
     negate: false
     context_mapping: {  }
+    pages: "/2020/*\r\n/2020"

--- a/conf/drupal/config/block.block.hatter_page_title.yml
+++ b/conf/drupal/config/block.block.hatter_page_title.yml
@@ -17,11 +17,11 @@ plugin: page_title_block
 settings:
   id: page_title_block
   label: 'Page title'
-  provider: core
   label_display: '0'
+  provider: core
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: true
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.hatter_powered.yml
+++ b/conf/drupal/config/block.block.hatter_powered.yml
@@ -17,6 +17,6 @@ plugin: system_powered_by_block
 settings:
   id: system_powered_by_block
   label: 'Powered by Drupal'
-  provider: system
   label_display: '0'
+  provider: system
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_search.yml
+++ b/conf/drupal/config/block.block.hatter_search.yml
@@ -17,7 +17,7 @@ plugin: search_form_block
 settings:
   id: search_form_block
   label: Search
-  provider: search
   label_display: visible
+  provider: search
   page_id: ''
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_socialfooter.yml
+++ b/conf/drupal/config/block.block.hatter_socialfooter.yml
@@ -17,8 +17,8 @@ plugin: 'block_content:c87b75b7-23fd-45ac-ae17-af7efa9c87a8'
 settings:
   id: 'block_content:c87b75b7-23fd-45ac-ae17-af7efa9c87a8'
   label: 'Social Footer'
-  provider: block_content
   label_display: '0'
+  provider: block_content
   status: true
   info: ''
   view_mode: full

--- a/conf/drupal/config/block.block.hatter_tabs.yml
+++ b/conf/drupal/config/block.block.hatter_tabs.yml
@@ -13,8 +13,8 @@ plugin: local_tasks_block
 settings:
   id: local_tasks_block
   label: Tabs
-  provider: core
   label_display: '0'
+  provider: core
   primary: true
   secondary: true
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_tools.yml
+++ b/conf/drupal/config/block.block.hatter_tools.yml
@@ -19,8 +19,8 @@ plugin: 'system_menu_block:tools'
 settings:
   id: 'system_menu_block:tools'
   label: Tools
-  provider: system
   label_display: visible
+  provider: system
   level: 1
   depth: 0
   expand_all_items: false

--- a/conf/drupal/config/block.block.hatter_training_feedback_form.yml
+++ b/conf/drupal/config/block.block.hatter_training_feedback_form.yml
@@ -18,14 +18,14 @@ plugin: webform_block
 settings:
   id: webform_block
   label: 'Provide feedback on this training'
-  provider: webform
   label_display: visible
+  provider: webform
   webform_id: training_feedback_2019
   default_data: ''
   redirect: false
 visibility:
   request_path:
     id: request_path
-    pages: '/2019/training-proposal/*'
     negate: false
     context_mapping: {  }
+    pages: '/2019/training-proposal/*'

--- a/conf/drupal/config/block.block.hatter_views_block__attendees_block_2.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__attendees_block_2.yml
@@ -18,13 +18,13 @@ plugin: 'views_block:attendees-block_2'
 settings:
   id: 'views_block:attendees-block_2'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
   views_label: ''
   items_per_page: none
 visibility:
   request_path:
     id: request_path
-    pages: /2019/sponsors
     negate: false
     context_mapping: {  }
+    pages: /2019/sponsors

--- a/conf/drupal/config/block.block.hatter_views_block__event_news_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_news_block_1.yml
@@ -17,8 +17,8 @@ plugin: 'views_block:event_news-block_1'
 settings:
   id: 'views_block:event_news-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
   views_label: ''
   items_per_page: none
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_1.yml
@@ -17,9 +17,9 @@ plugin: 'views_block:event_sponsors-block_1'
 settings:
   id: 'views_block:event_sponsors-block_1'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_10.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_10.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_10'
 settings:
   id: 'views_block:event_sponsors-block_10'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2020/sponsors\r\n/2021/sponsors"
     negate: false
     context_mapping: {  }
+    pages: "/2020/sponsors\r\n/2021/sponsors"

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_11.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_11.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_11'
 settings:
   id: 'views_block:event_sponsors-block_11'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: /2020/sponsors
     negate: false
     context_mapping: {  }
+    pages: /2020/sponsors

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_2.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_2.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_2'
 settings:
   id: 'views_block:event_sponsors-block_2'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/sponsors\r\n/2019/sponsors"
     negate: false
     context_mapping: {  }
+    pages: "/2018/sponsors\r\n/2019/sponsors"

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_3.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_3.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_3'
 settings:
   id: 'views_block:event_sponsors-block_3'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/sponsors\r\n/2019/sponsors\r\n/2020/sponsors\r\n/2021/sponsors"
     negate: false
     context_mapping: {  }
+    pages: "/2018/sponsors\r\n/2019/sponsors\r\n/2020/sponsors\r\n/2021/sponsors"

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_4.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_4.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_4'
 settings:
   id: 'views_block:event_sponsors-block_4'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }
+    pages: '/*/sponsors'

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_5.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_5.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_5'
 settings:
   id: 'views_block:event_sponsors-block_5'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/sponsors\r\n/2019/sponsors"
     negate: false
     context_mapping: {  }
+    pages: "/2018/sponsors\r\n/2019/sponsors"

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_6.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_6.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_6'
 settings:
   id: 'views_block:event_sponsors-block_6'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }
+    pages: '/*/sponsors'

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_7.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_7.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_7'
 settings:
   id: 'views_block:event_sponsors-block_7'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/sponsors'
     negate: false
     context_mapping: {  }
+    pages: '/*/sponsors'

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_8.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_8.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_8'
 settings:
   id: 'views_block:event_sponsors-block_8'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/sponsors\r\n/2019/sponsors"
     negate: false
     context_mapping: {  }
+    pages: "/2018/sponsors\r\n/2019/sponsors"

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_9.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_9.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_sponsors-block_9'
 settings:
   id: 'views_block:event_sponsors-block_9'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: "/2020/sponsors\r\n/2021/sponsors"
     negate: false
     context_mapping: {  }
+    pages: "/2020/sponsors\r\n/2021/sponsors"

--- a/conf/drupal/config/block.block.hatter_views_block__event_sub_events_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sub_events_block_1.yml
@@ -17,9 +17,9 @@ plugin: 'views_block:event_sub_events-block_1'
 settings:
   id: 'views_block:event_sub_events-block_1'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility: {  }

--- a/conf/drupal/config/block.block.hatter_views_block__event_venue_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_venue_block_1.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:event_venue-block_1'
 settings:
   id: 'views_block:event_venue-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/2018*'
     negate: false
     context_mapping: {  }
+    pages: '/2018*'

--- a/conf/drupal/config/block.block.hatter_views_block__jobs_board_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__jobs_board_block_1.yml
@@ -18,16 +18,16 @@ plugin: 'views_block:jobs_board-block_1'
 settings:
   id: 'views_block:jobs_board-block_1'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   'entity_bundle:node':
     id: 'entity_bundle:node'
-    bundles:
-      sponsor: sponsor
     negate: false
     context_mapping:
       node: '@node.node_route_context:node'
+    bundles:
+      sponsor: sponsor

--- a/conf/drupal/config/block.block.hatter_views_block__speakers_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__speakers_block_1.yml
@@ -18,13 +18,13 @@ plugin: 'views_block:speakers-block_1'
 settings:
   id: 'views_block:speakers-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
   views_label: ''
   items_per_page: none
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: true
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.hatter_views_block__summits_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__summits_block_1.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:summits-block_1'
 settings:
   id: 'views_block:summits-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/summits'
     negate: false
     context_mapping: {  }
+    pages: '/*/summits'

--- a/conf/drupal/config/block.block.hatter_views_block__training_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__training_block_1.yml
@@ -18,14 +18,14 @@ plugin: 'views_block:training-block_1'
 settings:
   id: 'views_block:training-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   request_path:
     id: request_path
-    pages: '/*/training'
     negate: false
     context_mapping: {  }
+    pages: '/*/training'

--- a/conf/drupal/config/block.block.hatter_webform.yml
+++ b/conf/drupal/config/block.block.hatter_webform.yml
@@ -18,14 +18,14 @@ plugin: webform_block
 settings:
   id: webform_block
   label: 'Lightning Talk Sign Up'
-  provider: webform
   label_display: visible
+  provider: webform
   webform_id: lightning_talk_sign_up
   default_data: ''
   redirect: false
 visibility:
   request_path:
     id: request_path
-    pages: "/2018/topic-proposal/lightning-talks\r\n/2019/topic-proposal/lightning-talks"
     negate: false
     context_mapping: {  }
+    pages: "/2018/topic-proposal/lightning-talks\r\n/2019/topic-proposal/lightning-talks"

--- a/conf/drupal/config/block.block.midcamp2021.yml
+++ b/conf/drupal/config/block.block.midcamp2021.yml
@@ -18,14 +18,14 @@ plugin: 'block_content:a54a0659-0ed4-46e8-afe3-55cdd97cd855'
 settings:
   id: 'block_content:a54a0659-0ed4-46e8-afe3-55cdd97cd855'
   label: 'MidCamp 2021'
-  provider: block_content
   label_display: '0'
+  provider: block_content
   status: true
   info: ''
   view_mode: full
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: false
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.midcamp2021_2.yml
+++ b/conf/drupal/config/block.block.midcamp2021_2.yml
@@ -18,14 +18,14 @@ plugin: 'block_content:a54a0659-0ed4-46e8-afe3-55cdd97cd855'
 settings:
   id: 'block_content:a54a0659-0ed4-46e8-afe3-55cdd97cd855'
   label: 'MidCamp 2021'
-  provider: block_content
   label_display: '0'
+  provider: block_content
   status: true
   info: ''
   view_mode: full
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: false
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.midcamp2021_3.yml
+++ b/conf/drupal/config/block.block.midcamp2021_3.yml
@@ -18,14 +18,14 @@ plugin: 'block_content:a54a0659-0ed4-46e8-afe3-55cdd97cd855'
 settings:
   id: 'block_content:a54a0659-0ed4-46e8-afe3-55cdd97cd855'
   label: 'MidCamp 2021'
-  provider: block_content
   label_display: '0'
+  provider: block_content
   status: true
   info: ''
   view_mode: full
 visibility:
   request_path:
     id: request_path
-    pages: "/2021/*\r\n<front>"
     negate: false
     context_mapping: {  }
+    pages: "/2021/*\r\n<front>"

--- a/conf/drupal/config/block.block.midcamp2021navigation.yml
+++ b/conf/drupal/config/block.block.midcamp2021navigation.yml
@@ -17,14 +17,14 @@ plugin: 'system_menu_block:midcamp-2021-navigation'
 settings:
   id: 'system_menu_block:midcamp-2021-navigation'
   label: 'Midcamp 2021 Navigation'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 2
   expand_all_items: true
 visibility:
   request_path:
     id: request_path
-    pages: "/2018*\r\n/2019*\r\n/2020*"
     negate: true
     context_mapping: {  }
+    pages: "/2018*\r\n/2019*\r\n/2020*"

--- a/conf/drupal/config/block.block.midcamp2021navigation_2.yml
+++ b/conf/drupal/config/block.block.midcamp2021navigation_2.yml
@@ -17,14 +17,14 @@ plugin: 'system_menu_block:midcamp-2021-navigation'
 settings:
   id: 'system_menu_block:midcamp-2021-navigation'
   label: 'Midcamp 2021 Navigation'
-  provider: system
   label_display: '0'
+  provider: system
   level: 1
   depth: 2
   expand_all_items: false
 visibility:
   request_path:
     id: request_path
-    pages: "/2018*\r\n/2019*\r\n/2020*"
     negate: true
     context_mapping: {  }
+    pages: "/2018*\r\n/2019*\r\n/2020*"

--- a/conf/drupal/config/block.block.midcamp2021survey.yml
+++ b/conf/drupal/config/block.block.midcamp2021survey.yml
@@ -18,14 +18,14 @@ plugin: 'block_content:c2c340aa-3a74-490e-a0bb-5bb747b2e1b9'
 settings:
   id: 'block_content:c2c340aa-3a74-490e-a0bb-5bb747b2e1b9'
   label: 'MidCamp 2021 Survey'
-  provider: block_content
   label_display: '0'
+  provider: block_content
   status: true
   info: ''
   view_mode: full
 visibility:
   request_path:
     id: request_path
-    pages: "/2021/*\r\n<front>"
     negate: false
     context_mapping: {  }
+    pages: "/2021/*\r\n<front>"

--- a/conf/drupal/config/block.block.seven_breadcrumbs.yml
+++ b/conf/drupal/config/block.block.seven_breadcrumbs.yml
@@ -17,6 +17,6 @@ plugin: system_breadcrumb_block
 settings:
   id: system_breadcrumb_block
   label: Breadcrumbs
-  provider: system
   label_display: '0'
+  provider: system
 visibility: {  }

--- a/conf/drupal/config/block.block.seven_content.yml
+++ b/conf/drupal/config/block.block.seven_content.yml
@@ -17,6 +17,6 @@ plugin: system_main_block
 settings:
   id: system_main_block
   label: 'Main page content'
-  provider: system
   label_display: '0'
+  provider: system
 visibility: {  }

--- a/conf/drupal/config/block.block.seven_help.yml
+++ b/conf/drupal/config/block.block.seven_help.yml
@@ -17,6 +17,6 @@ plugin: help_block
 settings:
   id: help_block
   label: Help
-  provider: help
   label_display: '0'
+  provider: help
 visibility: {  }

--- a/conf/drupal/config/block.block.seven_local_actions.yml
+++ b/conf/drupal/config/block.block.seven_local_actions.yml
@@ -15,6 +15,6 @@ plugin: local_actions_block
 settings:
   id: local_actions_block
   label: 'Primary admin actions'
-  provider: core
   label_display: '0'
+  provider: core
 visibility: {  }

--- a/conf/drupal/config/block.block.seven_login.yml
+++ b/conf/drupal/config/block.block.seven_login.yml
@@ -17,6 +17,6 @@ plugin: user_login_block
 settings:
   id: user_login_block
   label: 'User login'
-  provider: user
   label_display: visible
+  provider: user
 visibility: {  }

--- a/conf/drupal/config/block.block.seven_messages.yml
+++ b/conf/drupal/config/block.block.seven_messages.yml
@@ -17,6 +17,6 @@ plugin: system_messages_block
 settings:
   id: system_messages_block
   label: 'Status messages'
-  provider: system
   label_display: '0'
+  provider: system
 visibility: {  }

--- a/conf/drupal/config/block.block.seven_page_title.yml
+++ b/conf/drupal/config/block.block.seven_page_title.yml
@@ -15,6 +15,6 @@ plugin: page_title_block
 settings:
   id: page_title_block
   label: 'Page title'
-  provider: core
   label_display: '0'
+  provider: core
 visibility: {  }

--- a/conf/drupal/config/block.block.seven_primary_local_tasks.yml
+++ b/conf/drupal/config/block.block.seven_primary_local_tasks.yml
@@ -15,8 +15,8 @@ plugin: local_tasks_block
 settings:
   id: local_tasks_block
   label: 'Primary tabs'
-  provider: core
   label_display: '0'
+  provider: core
   primary: true
   secondary: false
 visibility: {  }

--- a/conf/drupal/config/block.block.seven_secondary_local_tasks.yml
+++ b/conf/drupal/config/block.block.seven_secondary_local_tasks.yml
@@ -15,8 +15,8 @@ plugin: local_tasks_block
 settings:
   id: local_tasks_block
   label: 'Secondary tabs'
-  provider: core
   label_display: '0'
+  provider: core
   primary: false
   secondary: true
 visibility: {  }

--- a/conf/drupal/config/block.block.views_block__attendees_2020_block_1.yml
+++ b/conf/drupal/config/block.block.views_block__attendees_2020_block_1.yml
@@ -18,13 +18,13 @@ plugin: 'views_block:attendees_2020-block_1'
 settings:
   id: 'views_block:attendees_2020-block_1'
   label: ''
-  provider: views
   label_display: visible
+  provider: views
   views_label: ''
   items_per_page: none
 visibility:
   request_path:
     id: request_path
-    pages: /2020/sponsors
     negate: false
     context_mapping: {  }
+    pages: /2020/sponsors

--- a/conf/drupal/config/block.block.views_block__live_sessions_block_1.yml
+++ b/conf/drupal/config/block.block.views_block__live_sessions_block_1.yml
@@ -18,13 +18,13 @@ plugin: 'views_block:live_sessions-block_1'
 settings:
   id: 'views_block:live_sessions-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
   views_label: ''
   items_per_page: none
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: false
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.views_block__live_sessions_block_1_2.yml
+++ b/conf/drupal/config/block.block.views_block__live_sessions_block_1_2.yml
@@ -18,13 +18,13 @@ plugin: 'views_block:live_sessions-block_1'
 settings:
   id: 'views_block:live_sessions-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
   views_label: ''
   items_per_page: none
 visibility:
   request_path:
     id: request_path
-    pages: '<front>'
     negate: false
     context_mapping: {  }
+    pages: '<front>'

--- a/conf/drupal/config/block.block.views_block__session_feedback_block_1.yml
+++ b/conf/drupal/config/block.block.views_block__session_feedback_block_1.yml
@@ -18,16 +18,16 @@ plugin: 'views_block:session_feedback-block_1'
 settings:
   id: 'views_block:session_feedback-block_1'
   label: ''
-  provider: views
   label_display: '0'
+  provider: views
+  context_mapping: {  }
   views_label: ''
   items_per_page: none
-  context_mapping: {  }
 visibility:
   'entity_bundle:node':
     id: 'entity_bundle:node'
-    bundles:
-      topic: topic
     negate: false
     context_mapping:
       node: '@node.node_route_context:node'
+    bundles:
+      topic: topic

--- a/conf/drupal/config/captcha.settings.yml
+++ b/conf/drupal/config/captcha.settings.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: _UaIWu0_ZD3lUs97wlFC2Koi-o7Bex69Xr9q36nJtkY
 enabled_default: 0
 default_challenge: recaptcha/reCAPTCHA
 description: 'This question is for testing whether or not you are a human visitor and to prevent automated spam submissions.'
@@ -8,5 +10,3 @@ default_validation: 1
 persistence: 0
 enable_stats: true
 log_wrong_responses: true
-_core:
-  default_config_hash: _UaIWu0_ZD3lUs97wlFC2Koi-o7Bex69Xr9q36nJtkY

--- a/conf/drupal/config/config_ignore.settings.yml
+++ b/conf/drupal/config/config_ignore.settings.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk
 ignored_config_entities:
   0: 'mailchimp.settings:api_key'
   2: 'mailchimp.settings:connected_id'
@@ -7,5 +9,3 @@ ignored_config_entities:
   10: 'recaptcha.settings:site_key'
   12: 'recaptcha.settings:secret_key'
   14: 'tito.settings:tito_api_token'
-_core:
-  default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/conf/drupal/config/contact.settings.yml
+++ b/conf/drupal/config/contact.settings.yml
@@ -1,7 +1,7 @@
+_core:
+  default_config_hash: U69DBeuvXuNVOC15rVNaBjDPK2fWFbo9v4takdYSSO8
 default_form: feedback
 flood:
   limit: 5
   interval: 3600
 user_default_enabled: false
-_core:
-  default_config_hash: U69DBeuvXuNVOC15rVNaBjDPK2fWFbo9v4takdYSSO8

--- a/conf/drupal/config/core.entity_form_display.block_content.basic.default.yml
+++ b/conf/drupal/config/core.entity_form_display.block_content.basic.default.yml
@@ -17,19 +17,19 @@ content:
   body:
     type: text_textarea_with_summary
     weight: -4
+    region: content
     settings:
       rows: 9
       summary_rows: 3
       placeholder: ''
       show_summary: false
     third_party_settings: {  }
-    region: content
   info:
     type: string_textfield
     weight: -5
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    region: content
 hidden: {  }

--- a/conf/drupal/config/core.entity_form_display.comment.comment.default.yml
+++ b/conf/drupal/config/core.entity_form_display.comment.comment.default.yml
@@ -22,17 +22,17 @@ content:
   comment_body:
     type: text_textarea
     weight: 11
+    region: content
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-    region: content
   subject:
     type: string_textfield
     weight: 10
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    region: content
 hidden: {  }

--- a/conf/drupal/config/core.entity_form_display.contact_message.feedback.default.yml
+++ b/conf/drupal/config/core.entity_form_display.contact_message.feedback.default.yml
@@ -11,27 +11,27 @@ mode: default
 content:
   copy:
     weight: 50
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   mail:
     weight: -40
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   message:
     type: string_textarea
     weight: 0
+    region: content
     settings:
       rows: 12
       placeholder: ''
     third_party_settings: {  }
-    region: content
   name:
     weight: -50
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   preview:
     weight: 40
     region: content
@@ -40,9 +40,9 @@ content:
   subject:
     type: string_textfield
     weight: -10
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    region: content
 hidden: {  }

--- a/conf/drupal/config/core.entity_form_display.media.file.default.yml
+++ b/conf/drupal/config/core.entity_form_display.media.file.default.yml
@@ -20,12 +20,12 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_media_file:
-    settings:
-      progress_indicator: throbber
-    third_party_settings: {  }
     type: file_generic
     weight: 0
     region: content
+    settings:
+      progress_indicator: throbber
+    third_party_settings: {  }
   path:
     type: path
     weight: 30
@@ -34,20 +34,20 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    settings:
-      display_label: true
     weight: 100
     region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
     weight: 5
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
-    region: content
     third_party_settings: {  }
 hidden:
   name: true

--- a/conf/drupal/config/core.entity_form_display.media.image.default.yml
+++ b/conf/drupal/config/core.entity_form_display.media.image.default.yml
@@ -21,13 +21,13 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_media_image:
+    type: image_image
+    weight: 0
+    region: content
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
-    type: image_image
-    weight: 0
-    region: content
   path:
     type: path
     weight: 30
@@ -36,20 +36,20 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    settings:
-      display_label: true
     weight: 100
     region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
     weight: 5
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
-    region: content
     third_party_settings: {  }
 hidden:
   name: true

--- a/conf/drupal/config/core.entity_form_display.media.remote_video.default.yml
+++ b/conf/drupal/config/core.entity_form_display.media.remote_video.default.yml
@@ -22,11 +22,11 @@ content:
   field_media_oembed_video:
     type: oembed_textfield
     weight: 0
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    region: content
   path:
     type: path
     weight: 30
@@ -35,20 +35,20 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    settings:
-      display_label: true
     weight: 100
     region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
     weight: 5
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
-    region: content
     third_party_settings: {  }
 hidden:
   name: true

--- a/conf/drupal/config/core.entity_form_display.media.video.default.yml
+++ b/conf/drupal/config/core.entity_form_display.media.video.default.yml
@@ -22,9 +22,9 @@ content:
   field_media_video_embed_field:
     type: video_embed_field_textfield
     weight: 31
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   name:
     type: string_textfield
     weight: -5
@@ -41,19 +41,19 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    settings:
-      display_label: true
     weight: 100
     region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
     weight: 5
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
-    region: content
     third_party_settings: {  }
 hidden: {  }

--- a/conf/drupal/config/core.entity_form_display.media.video.media_library.yml
+++ b/conf/drupal/config/core.entity_form_display.media.video.media_library.yml
@@ -13,12 +13,12 @@ mode: media_library
 content:
   name:
     type: string_textfield
+    weight: 0
+    region: content
     settings:
       size: 60
       placeholder: ''
-    weight: 0
     third_party_settings: {  }
-    region: content
 hidden:
   created: true
   field_media_video_embed_field: true

--- a/conf/drupal/config/core.entity_form_display.node.article.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.article.default.yml
@@ -26,19 +26,20 @@ content:
   created:
     type: datetime_timestamp
     weight: 7
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_article_news:
+    type: boolean_checkbox
     weight: 2
+    region: content
     settings:
       display_label: false
     third_party_settings: {  }
-    type: boolean_checkbox
-    region: content
   field_article_paragraphs:
     type: entity_reference_paragraphs
     weight: 4
+    region: content
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -47,67 +48,66 @@ content:
       form_display_mode: default
       default_paragraph_type: ''
     third_party_settings: {  }
-    region: content
   field_article_summary:
+    type: string_textarea
     weight: 3
+    region: content
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-    type: string_textarea
-    region: content
   field_event:
+    type: entity_reference_autocomplete
     weight: 12
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   field_meta_tags:
+    type: metatag_firehose
     weight: 101
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: metatag_firehose
-    region: content
   field_planet:
+    type: boolean_checkbox
     weight: 1
+    region: content
     settings:
       display_label: true
     third_party_settings: {  }
-    type: boolean_checkbox
-    region: content
   field_tags:
     type: entity_reference_autocomplete_tags
     weight: 5
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    region: content
   path:
     type: path
     weight: 10
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   promote:
     type: boolean_checkbox
+    weight: 8
+    region: content
     settings:
       display_label: true
-    weight: 8
     third_party_settings: {  }
-    region: content
   publish_on:
     type: datetime_timestamp_no_default
     weight: 13
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   scheduler_settings:
     weight: 11
     region: content
@@ -115,42 +115,42 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
+    weight: 15
+    region: content
     settings:
       display_label: true
-    weight: 15
     third_party_settings: {  }
-    region: content
   sticky:
     type: boolean_checkbox
+    weight: 9
+    region: content
     settings:
       display_label: true
-    weight: 9
     third_party_settings: {  }
-    region: content
   title:
     type: string_textfield
     weight: 0
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 6
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    region: content
   unpublish_on:
     type: datetime_timestamp_no_default
     weight: 14
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   url_redirects:
     weight: 50
     region: content

--- a/conf/drupal/config/core.entity_form_display.node.attendee.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.attendee.default.yml
@@ -31,109 +31,109 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_attendee_id:
+    type: string_textfield
     weight: 122
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_display_on_site:
+    type: boolean_checkbox
     weight: 125
+    region: content
     settings:
       display_label: true
     third_party_settings: {  }
-    type: boolean_checkbox
-    region: content
   field_drupal_user_account:
+    type: entity_reference_autocomplete
     weight: 132
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   field_email:
-    weight: 121
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
     type: email_default
+    weight: 121
     region: content
+    settings:
+      placeholder: ''
+      size: 60
+    third_party_settings: {  }
   field_event:
+    type: entity_reference_autocomplete
     weight: 130
+    region: content
     settings:
       match_operator: CONTAINS
-      size: 60
-      placeholder: ''
       match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   field_first_name:
+    type: string_textfield
     weight: 127
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_job_title:
+    type: string_textfield
     weight: 126
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_last_name:
+    type: string_textfield
     weight: 128
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_name:
+    type: string_textfield
     weight: 123
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_organization:
+    type: string_textfield
     weight: 124
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_ticket_state:
+    type: string_textfield
     weight: 129
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_ticket_type:
+    type: string_textfield
     weight: 131
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   moderation_state:
     type: moderation_state_default
     weight: 100
-    settings: {  }
     region: content
+    settings: {  }
     third_party_settings: {  }
   path:
     type: path
@@ -143,10 +143,10 @@ content:
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    settings:
-      display_label: true
     weight: 15
     region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
@@ -156,17 +156,17 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    settings:
-      display_label: true
     weight: 120
     region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    settings:
-      display_label: true
     weight: 16
     region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
@@ -179,12 +179,12 @@ content:
   uid:
     type: entity_reference_autocomplete
     weight: 5
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
-    region: content
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
@@ -194,7 +194,7 @@ content:
     third_party_settings: {  }
   url_redirects:
     weight: 50
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden: {  }

--- a/conf/drupal/config/core.entity_form_display.node.eventbrite_event.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.eventbrite_event.default.yml
@@ -21,48 +21,48 @@ content:
   body:
     type: text_textarea_with_summary
     weight: 31
+    region: content
     settings:
       rows: 9
       summary_rows: 3
       placeholder: ''
       show_summary: false
     third_party_settings: {  }
-    region: content
   created:
     type: datetime_timestamp
     weight: 10
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   eventbrite_event_id:
     type: string_textfield
     weight: 101
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    region: content
   eventbrite_event_status:
     type: string_textfield
     weight: 102
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    region: content
   path:
     type: path
     weight: 30
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   promote:
     type: boolean_checkbox
+    weight: 15
+    region: content
     settings:
       display_label: true
-    weight: 15
     third_party_settings: {  }
-    region: content
   publish_on:
     type: datetime_timestamp_no_default
     weight: 30
@@ -71,36 +71,36 @@ content:
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    settings:
-      display_label: true
     weight: 120
     region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
+    weight: 16
+    region: content
     settings:
       display_label: true
-    weight: 16
     third_party_settings: {  }
-    region: content
   title:
     type: string_textfield
     weight: -5
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    region: content
   unpublish_on:
     type: datetime_timestamp_no_default
     weight: 30
@@ -109,7 +109,7 @@ content:
     third_party_settings: {  }
   url_redirects:
     weight: 50
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden: {  }

--- a/conf/drupal/config/core.entity_form_display.node.job.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.job.default.yml
@@ -25,124 +25,124 @@ content:
   created:
     type: datetime_timestamp
     weight: 8
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_event:
+    type: entity_reference_autocomplete
     weight: 101
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   field_job_description:
+    type: text_textarea_with_summary
     weight: 5
+    region: content
     settings:
       rows: 9
       summary_rows: 3
       placeholder: ''
       show_summary: false
     third_party_settings: {  }
-    type: text_textarea_with_summary
-    region: content
   field_job_link:
+    type: link_default
     weight: 6
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
-    region: content
   field_job_location:
+    type: string_textfield
     weight: 2
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_job_skill_level:
+    type: options_select
     weight: 4
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: options_select
-    region: content
   field_job_type:
+    type: options_select
     weight: 3
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: options_select
-    region: content
   field_sponsor_company:
+    type: entity_reference_autocomplete
     weight: 1
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   path:
     type: path
     weight: 9
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   promote:
     type: boolean_checkbox
+    weight: 11
+    region: content
     settings:
       display_label: true
-    weight: 11
     third_party_settings: {  }
-    region: content
   publish_on:
     type: datetime_timestamp_no_default
     weight: 12
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   status:
     type: boolean_checkbox
+    weight: 14
+    region: content
     settings:
       display_label: true
-    weight: 14
     third_party_settings: {  }
-    region: content
   sticky:
     type: boolean_checkbox
+    weight: 10
+    region: content
     settings:
       display_label: true
-    weight: 10
     third_party_settings: {  }
-    region: content
   title:
     type: string_textfield
     weight: 0
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 7
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    region: content
   unpublish_on:
     type: datetime_timestamp_no_default
     weight: 13
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   url_redirects:
     weight: 50
     region: content

--- a/conf/drupal/config/core.entity_form_display.node.page.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.page.default.yml
@@ -22,28 +22,29 @@ content:
   created:
     type: datetime_timestamp
     weight: 3
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_event:
+    type: entity_reference_autocomplete
     weight: 123
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   field_meta_tags:
+    type: metatag_firehose
     weight: 122
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: metatag_firehose
-    region: content
   field_page_paragraphs:
     type: entity_reference_paragraphs
     weight: 1
+    region: content
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -51,64 +52,63 @@ content:
       add_mode: dropdown
       form_display_mode: default
     third_party_settings: {  }
-    region: content
   path:
     type: path
     weight: 6
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   promote:
     type: boolean_checkbox
+    weight: 4
+    region: content
     settings:
       display_label: true
-    weight: 4
     third_party_settings: {  }
-    region: content
   publish_on:
     type: datetime_timestamp_no_default
     weight: 30
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   status:
     type: boolean_checkbox
+    weight: 121
+    region: content
     settings:
       display_label: true
-    weight: 121
     third_party_settings: {  }
-    region: content
   sticky:
     type: boolean_checkbox
+    weight: 5
+    region: content
     settings:
       display_label: true
-    weight: 5
     third_party_settings: {  }
-    region: content
   title:
     type: string_textfield
     weight: 0
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 2
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    region: content
   unpublish_on:
     type: datetime_timestamp_no_default
     weight: 30
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   url_redirects:
     weight: 50
     region: content

--- a/conf/drupal/config/core.entity_form_display.node.sponsor.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.sponsor.default.yml
@@ -26,114 +26,114 @@ content:
   body:
     type: text_textarea_with_summary
     weight: 4
+    region: content
     settings:
       rows: 9
       summary_rows: 3
       placeholder: ''
       show_summary: false
     third_party_settings: {  }
-    region: content
   created:
     type: datetime_timestamp
     weight: 6
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_event:
+    type: entity_reference_autocomplete
     weight: 26
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   field_image:
+    type: image_image
     weight: 1
+    region: content
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
-    type: image_image
-    region: content
   field_link:
+    type: link_default
     weight: 2
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
-    region: content
   field_meta_tags:
-    weight: 122
-    settings: {  }
-    third_party_settings: {  }
     type: metatag_firehose
+    weight: 122
     region: content
-  field_sponsor_level:
-    weight: 3
     settings: {  }
     third_party_settings: {  }
+  field_sponsor_level:
     type: options_buttons
+    weight: 3
     region: content
+    settings: {  }
+    third_party_settings: {  }
   path:
     type: path
     weight: 9
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   promote:
     type: boolean_checkbox
+    weight: 7
+    region: content
     settings:
       display_label: true
-    weight: 7
     third_party_settings: {  }
-    region: content
   publish_on:
     type: datetime_timestamp_no_default
     weight: 30
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   status:
     type: boolean_checkbox
+    weight: 121
+    region: content
     settings:
       display_label: true
-    weight: 121
     third_party_settings: {  }
-    region: content
   sticky:
     type: boolean_checkbox
+    weight: 8
+    region: content
     settings:
       display_label: true
-    weight: 8
     third_party_settings: {  }
-    region: content
   title:
     type: string_textfield
     weight: 0
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 5
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    region: content
   unpublish_on:
     type: datetime_timestamp_no_default
     weight: 30
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   url_redirects:
     weight: 50
     region: content

--- a/conf/drupal/config/core.entity_form_display.node.summit.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.summit.default.yml
@@ -23,59 +23,59 @@ content:
   body:
     type: text_textarea_with_summary
     weight: 3
+    region: content
     settings:
       rows: 9
       summary_rows: 3
       placeholder: ''
       show_summary: false
     third_party_settings: {  }
-    region: content
   field_event:
     type: entity_reference_autocomplete
     weight: 8
     region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
   field_meta_tags:
+    type: metatag_firehose
     weight: 7
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: metatag_firehose
-    region: content
   field_people:
+    type: entity_reference_autocomplete
     weight: 2
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   field_registration_link:
+    type: link_default
     weight: 4
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
-    region: content
   field_track:
+    type: options_buttons
     weight: 1
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: options_buttons
-    region: content
   status:
     type: boolean_checkbox
-    settings:
-      display_label: true
     weight: 6
     region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield

--- a/conf/drupal/config/core.entity_form_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.topic.default.yml
@@ -34,13 +34,13 @@ content:
   body:
     type: text_textarea_with_summary
     weight: 7
+    region: content
     settings:
       rows: 9
       summary_rows: 3
       placeholder: ''
       show_summary: false
     third_party_settings: {  }
-    region: content
   created:
     type: datetime_timestamp
     weight: 13
@@ -48,30 +48,30 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_captions:
+    type: text_textarea
     weight: 11
+    region: content
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-    type: text_textarea
-    region: content
   field_feedback_form:
+    type: webform_entity_reference_select
     weight: 16
+    region: content
     settings:
       default_data: true
     third_party_settings: {  }
-    type: webform_entity_reference_select
-    region: content
   field_people:
+    type: entity_reference_autocomplete
     weight: 6
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   field_presenter_slides:
     type: file_generic
     weight: 14
@@ -80,43 +80,43 @@ content:
       progress_indicator: throbber
     third_party_settings: {  }
   field_schedule_location:
-    weight: 4
-    settings: {  }
-    third_party_settings: {  }
     type: options_select
+    weight: 4
     region: content
+    settings: {  }
+    third_party_settings: {  }
   field_schedule_time:
-    weight: 3
-    settings: {  }
-    third_party_settings: {  }
     type: daterange_default
+    weight: 3
     region: content
+    settings: {  }
+    third_party_settings: {  }
   field_session_length:
+    type: options_buttons
     weight: 2
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: options_buttons
-    region: content
   field_topic_type:
+    type: options_buttons
     weight: 1
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: options_buttons
-    region: content
   field_track:
+    type: options_buttons
     weight: 5
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: options_buttons
-    region: content
   field_transcript:
+    type: link_default
     weight: 10
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
-    region: content
   field_video:
     type: video_embed_field_textfield
     weight: 15
@@ -133,20 +133,20 @@ content:
   title:
     type: string_textfield
     weight: 0
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 12
     region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
   url_redirects:
     weight: 9

--- a/conf/drupal/config/core.entity_form_display.node.training.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.training.default.yml
@@ -24,58 +24,58 @@ content:
   body:
     type: text_textarea_with_summary
     weight: 3
+    region: content
     settings:
       rows: 9
       summary_rows: 3
       placeholder: ''
       show_summary: false
     third_party_settings: {  }
-    region: content
   field_event:
     type: entity_reference_autocomplete
     weight: 7
     region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
   field_people:
+    type: entity_reference_autocomplete_tags
     weight: 2
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    type: entity_reference_autocomplete_tags
-    region: content
   field_registration_link:
+    type: link_default
     weight: 4
+    region: content
     settings:
       placeholder_url: 'Eventbrite Link'
       placeholder_title: 'Register Today'
     third_party_settings: {  }
-    type: link_default
-    region: content
   field_track:
-    weight: 1
-    settings: {  }
-    third_party_settings: {  }
     type: options_buttons
+    weight: 1
     region: content
-  field_video:
-    weight: 6
     settings: {  }
     third_party_settings: {  }
+  field_video:
     type: video_embed_field_textfield
+    weight: 6
     region: content
+    settings: {  }
+    third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
     weight: 8
-    settings: {  }
     region: content
+    settings: {  }
     third_party_settings: {  }
   title:
     type: string_textfield

--- a/conf/drupal/config/core.entity_form_display.node.venue.default.yml
+++ b/conf/drupal/config/core.entity_form_display.node.venue.default.yml
@@ -23,45 +23,46 @@ content:
   created:
     type: datetime_timestamp
     weight: 2
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   field_address:
+    type: address_default
     weight: 6
+    region: content
     settings:
       default_country: null
     third_party_settings: {  }
-    type: address_default
-    region: content
   field_event:
+    type: entity_reference_autocomplete
     weight: 123
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   field_meta_tags:
+    type: metatag_firehose
     weight: 122
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: metatag_firehose
-    region: content
   field_venue_events:
+    type: entity_reference_autocomplete
     weight: 8
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   field_venue_paragraphs:
     type: entity_reference_paragraphs
     weight: 7
+    region: content
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -69,64 +70,63 @@ content:
       add_mode: dropdown
       form_display_mode: default
     third_party_settings: {  }
-    region: content
   path:
     type: path
     weight: 5
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   promote:
     type: boolean_checkbox
+    weight: 3
+    region: content
     settings:
       display_label: true
-    weight: 3
     third_party_settings: {  }
-    region: content
   publish_on:
     type: datetime_timestamp_no_default
     weight: 30
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   status:
     type: boolean_checkbox
+    weight: 121
+    region: content
     settings:
       display_label: true
-    weight: 121
     third_party_settings: {  }
-    region: content
   sticky:
     type: boolean_checkbox
+    weight: 4
+    region: content
     settings:
       display_label: true
-    weight: 4
     third_party_settings: {  }
-    region: content
   title:
     type: string_textfield
     weight: 0
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    region: content
   uid:
     type: entity_reference_autocomplete
     weight: 1
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    region: content
   unpublish_on:
     type: datetime_timestamp_no_default
     weight: 30
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   url_redirects:
     weight: 50
     region: content

--- a/conf/drupal/config/core.entity_form_display.paragraph.contact_form.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.contact_form.default.yml
@@ -11,15 +11,15 @@ bundle: contact_form
 mode: default
 content:
   field_contact:
+    type: entity_reference_autocomplete
     weight: 0
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
 hidden:
   created: true
   status: true

--- a/conf/drupal/config/core.entity_form_display.paragraph.paragraphs_columns_even.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.paragraphs_columns_even.default.yml
@@ -15,6 +15,7 @@ content:
   field_column_content:
     type: entity_reference_paragraphs
     weight: 0
+    region: content
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -22,7 +23,6 @@ content:
       add_mode: dropdown
       form_display_mode: default
     third_party_settings: {  }
-    region: content
 hidden:
   created: true
   status: true

--- a/conf/drupal/config/core.entity_form_display.paragraph.paragraphs_columns_uneven_2.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.paragraphs_columns_uneven_2.default.yml
@@ -16,6 +16,7 @@ content:
   field_column_content_2:
     type: entity_reference_paragraphs
     weight: 1
+    region: content
     settings:
       title: Paragraph
       title_plural: Paragraphs
@@ -23,13 +24,12 @@ content:
       add_mode: dropdown
       form_display_mode: default
     third_party_settings: {  }
-    region: content
   field_grid_style:
+    type: options_select
     weight: 0
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: options_select
-    region: content
 hidden:
   created: true
   status: true

--- a/conf/drupal/config/core.entity_form_display.paragraph.paragraphs_image.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.paragraphs_image.default.yml
@@ -14,13 +14,13 @@ bundle: paragraphs_image
 mode: default
 content:
   field_paragraph_image:
+    type: image_image
     weight: 0
+    region: content
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
-    type: image_image
-    region: content
 hidden:
   created: true
   status: true

--- a/conf/drupal/config/core.entity_form_display.paragraph.paragraphs_text.default.yml
+++ b/conf/drupal/config/core.entity_form_display.paragraph.paragraphs_text.default.yml
@@ -13,13 +13,13 @@ bundle: paragraphs_text
 mode: default
 content:
   field_paragraph_text:
+    type: text_textarea
     weight: 0
+    region: content
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-    type: text_textarea
-    region: content
 hidden:
   created: true
   status: true

--- a/conf/drupal/config/core.entity_form_display.taxonomy_term.event.default.yml
+++ b/conf/drupal/config/core.entity_form_display.taxonomy_term.event.default.yml
@@ -28,16 +28,16 @@ third_party_settings:
         - field_tito_slug
         - field_event_id
         - field_event_status
+      label: Tito
+      region: content
       parent_name: ''
       weight: 9
       format_type: fieldset
       format_settings:
-        id: ''
         classes: ''
+        id: ''
         description: 'Enter the event "slug" from Tito.  The rest of the fields will be populated automatically. '
         required_fields: false
-      label: Tito
-      region: content
 id: taxonomy_term.event.default
 targetEntityType: taxonomy_term
 bundle: event
@@ -46,99 +46,99 @@ content:
   description:
     type: text_textarea
     weight: 3
+    region: content
     settings:
-      placeholder: ''
       rows: 5
+      placeholder: ''
     third_party_settings: {  }
-    region: content
   field_banner_cta_anonymous:
+    type: link_default
     weight: 7
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
-    region: content
   field_banner_cta_authenticated:
+    type: link_default
     weight: 8
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
-    region: content
   field_date:
+    type: daterange_default
     weight: 1
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: daterange_default
-    region: content
   field_date_has_time:
+    type: boolean_checkbox
     weight: 2
+    region: content
     settings:
       display_label: true
     third_party_settings: {  }
-    type: boolean_checkbox
-    region: content
   field_event_id:
+    type: string_textfield
     weight: 11
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_event_status:
+    type: string_textfield
     weight: 12
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_image:
+    type: image_image
     weight: 5
+    region: content
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
-    type: image_image
-    region: content
   field_social_media:
+    type: link_default
     weight: 6
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
-    region: content
   field_tito_slug:
+    type: string_textfield
     weight: 10
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   name:
     type: string_textfield
     weight: 0
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    region: content
   path:
     type: path
     weight: 4
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
   status:
     type: boolean_checkbox
-    settings:
-      display_label: true
     weight: 100
     region: content
+    settings:
+      display_label: true
     third_party_settings: {  }
 hidden: {  }

--- a/conf/drupal/config/core.entity_form_display.taxonomy_term.location.default.yml
+++ b/conf/drupal/config/core.entity_form_display.taxonomy_term.location.default.yml
@@ -23,13 +23,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
   field_link:
+    type: link_default
     weight: 31
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
-    region: content
   name:
     type: string_textfield
     weight: -5

--- a/conf/drupal/config/core.entity_form_display.taxonomy_term.sponsor_packages.default.yml
+++ b/conf/drupal/config/core.entity_form_display.taxonomy_term.sponsor_packages.default.yml
@@ -17,37 +17,37 @@ content:
   description:
     type: text_textarea
     weight: 3
+    region: content
     settings:
-      placeholder: ''
       rows: 5
+      placeholder: ''
     third_party_settings: {  }
-    region: content
   field_sponsor_package_price:
+    type: number
     weight: 1
+    region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
-    type: number
-    region: content
   field_sponsor_package_qty_avail:
+    type: number
     weight: 2
+    region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
-    type: number
-    region: content
   name:
     type: string_textfield
     weight: 0
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    region: content
   path:
     type: path
     weight: 4
+    region: content
     settings: {  }
     third_party_settings: {  }
-    region: content
 hidden: {  }

--- a/conf/drupal/config/core.entity_form_display.user.user.default.yml
+++ b/conf/drupal/config/core.entity_form_display.user.user.default.yml
@@ -37,48 +37,48 @@ third_party_settings:
         - timezone
         - google_analytics
         - field_eventbrite_email
+      label: 'Profile Settings'
+      region: content
       parent_name: ''
       weight: 3
       format_type: details
       format_settings:
-        id: ''
         classes: ''
+        id: ''
         open: false
         required_fields: true
-      label: 'Profile Settings'
-      region: content
     group_links:
       children:
         - field_do_profile
         - field_site
         - field_twitter
         - path
+      label: 'Links, Links and more Links'
+      region: content
       parent_name: ''
       weight: 2
       format_type: details
       format_settings:
-        id: ''
         classes: ''
+        id: ''
         open: false
         required_fields: true
-      label: 'Links, Links and more Links'
-      region: content
     group_essentials:
       children:
         - account
         - field_mailing_list
         - field_name
         - field_tracks
+      label: Essentials
+      region: content
       parent_name: ''
       weight: 0
       format_type: details
       format_settings:
-        id: ''
         classes: ''
+        id: ''
         open: true
         required_fields: true
-      label: Essentials
-      region: content
     group_all_about_you:
       children:
         - user_picture
@@ -87,16 +87,16 @@ third_party_settings:
         - field_organization
         - field_company_url
         - field_company_logo
+      label: 'All About You'
+      region: content
       parent_name: ''
       weight: 1
       format_type: details
       format_settings:
-        id: ''
         classes: ''
+        id: ''
         open: false
         required_fields: true
-      label: 'All About You'
-      region: content
 _core:
   default_config_hash: LLAieeozVsoZDb-2PbFxRJpQqnKmpR7-4OoRJnduz-U
 id: user.user.default
@@ -115,117 +115,117 @@ content:
     settings: {  }
     third_party_settings: {  }
   field_bio:
+    type: text_textarea
     weight: 3
+    region: content
     settings:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
-    type: text_textarea
-    region: content
   field_company_logo:
+    type: image_image
     weight: 7
+    region: content
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
-    type: image_image
-    region: content
   field_company_url:
+    type: link_default
     weight: 6
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
-    region: content
   field_do_profile:
+    type: link_default
     weight: 15
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
-    region: content
   field_eventbrite_email:
-    weight: 8
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
     type: email_default
+    weight: 8
     region: content
+    settings:
+      placeholder: ''
+      size: 60
+    third_party_settings: {  }
   field_leadership_year:
+    type: entity_reference_autocomplete
     weight: 21
+    region: content
     settings:
       match_operator: CONTAINS
       match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   field_mailing_list:
-    weight: 5
-    settings: {  }
-    third_party_settings: {  }
     type: mailchimp_lists_select
+    weight: 5
     region: content
-  field_name:
-    weight: 6
     settings: {  }
     third_party_settings: {  }
+  field_name:
     type: name_default
+    weight: 6
     region: content
+    settings: {  }
+    third_party_settings: {  }
   field_organization:
+    type: entity_reference_autocomplete
     weight: 5
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   field_organizer_year:
+    type: entity_reference_autocomplete
     weight: 20
+    region: content
     settings:
       match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
-      match_limit: 10
     third_party_settings: {  }
-    type: entity_reference_autocomplete
-    region: content
   field_site:
+    type: link_default
     weight: 16
+    region: content
     settings:
       placeholder_url: ''
       placeholder_title: ''
     third_party_settings: {  }
-    type: link_default
-    region: content
   field_title:
+    type: string_textfield
     weight: 4
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   field_tracks:
+    type: options_buttons
     weight: 7
+    region: content
     settings: {  }
     third_party_settings: {  }
-    type: options_buttons
-    region: content
   field_twitter:
+    type: string_textfield
     weight: 17
+    region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-    type: string_textfield
-    region: content
   google_analytics:
     weight: 7
     region: content
@@ -249,10 +249,10 @@ content:
     third_party_settings: {  }
   user_picture:
     type: image_image
+    weight: 2
+    region: content
     settings:
       progress_indicator: throbber
       preview_image_style: thumbnail
     third_party_settings: {  }
-    weight: 2
-    region: content
 hidden: {  }

--- a/conf/drupal/config/core.entity_form_mode.media.media_library.yml
+++ b/conf/drupal/config/core.entity_form_mode.media.media_library.yml
@@ -2,11 +2,11 @@ uuid: 26f7aac5-9361-4807-880e-d5f7fdb6950e
 langcode: en
 status: true
 dependencies:
+  module:
+    - media
   enforced:
     module:
       - media_library
-  module:
-    - media
 _core:
   default_config_hash: pkq0uj-IoqEQRBOP_ddUDV0ZJ-dKQ_fLcppsEDF2UO8
 id: media.media_library

--- a/conf/drupal/config/core.entity_view_display.block_content.basic.default.yml
+++ b/conf/drupal/config/core.entity_view_display.block_content.basic.default.yml
@@ -15,10 +15,10 @@ bundle: basic
 mode: default
 content:
   body:
-    label: hidden
     type: text_default
-    weight: 0
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden: {  }

--- a/conf/drupal/config/core.entity_view_display.comment.comment.default.yml
+++ b/conf/drupal/config/core.entity_view_display.comment.comment.default.yml
@@ -15,11 +15,11 @@ bundle: comment
 mode: default
 content:
   comment_body:
-    label: hidden
     type: text_default
-    weight: 0
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
   links:
     weight: 100

--- a/conf/drupal/config/core.entity_view_display.contact_message.feedback.default.yml
+++ b/conf/drupal/config/core.entity_view_display.contact_message.feedback.default.yml
@@ -11,9 +11,9 @@ mode: default
 content:
   message:
     type: basic_string
-    weight: 0
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden: {  }

--- a/conf/drupal/config/core.entity_view_display.media.file.default.yml
+++ b/conf/drupal/config/core.entity_view_display.media.file.default.yml
@@ -13,10 +13,10 @@ bundle: file
 mode: default
 content:
   field_media_file:
+    type: file_default
     label: visually_hidden
     settings: {  }
     third_party_settings: {  }
-    type: file_default
     weight: 1
     region: content
 hidden:

--- a/conf/drupal/config/core.entity_view_display.media.image.default.yml
+++ b/conf/drupal/config/core.entity_view_display.media.image.default.yml
@@ -14,12 +14,12 @@ bundle: image
 mode: default
 content:
   field_media_image:
+    type: image
     label: visually_hidden
     settings:
-      image_style: ''
       image_link: file
+      image_style: ''
     third_party_settings: {  }
-    type: image
     weight: 1
     region: content
 hidden:

--- a/conf/drupal/config/core.entity_view_display.media.remote_video.default.yml
+++ b/conf/drupal/config/core.entity_view_display.media.remote_video.default.yml
@@ -14,12 +14,12 @@ mode: default
 content:
   field_media_oembed_video:
     type: oembed
-    weight: 0
     label: hidden
     settings:
       max_width: 0
       max_height: 0
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   created: true

--- a/conf/drupal/config/core.entity_view_display.media.video.default.yml
+++ b/conf/drupal/config/core.entity_view_display.media.video.default.yml
@@ -16,48 +16,48 @@ bundle: video
 mode: default
 content:
   created:
-    label: hidden
     type: timestamp
-    weight: 0
-    region: content
+    label: hidden
     settings:
       date_format: medium
       custom_date_format: ''
       timezone: ''
     third_party_settings: {  }
+    weight: 0
+    region: content
   field_media_video_embed_field:
     type: video_embed_field_video
-    weight: 2
     label: above
     settings:
+      autoplay: true
       responsive: true
       width: 854
       height: 480
-      autoplay: true
     third_party_settings: {  }
+    weight: 2
     region: content
   name:
-    label: hidden
     type: string
-    weight: -5
-    region: content
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
+    weight: -5
+    region: content
   thumbnail:
     type: image
-    weight: 1
     label: hidden
     settings:
-      image_style: thumbnail
       image_link: ''
-    region: content
+      image_style: thumbnail
     third_party_settings: {  }
-  uid:
-    label: hidden
-    type: author
-    weight: 0
+    weight: 1
     region: content
+  uid:
+    type: author
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 0
+    region: content
 hidden: {  }

--- a/conf/drupal/config/core.entity_view_display.media.video.media_library.yml
+++ b/conf/drupal/config/core.entity_view_display.media.video.media_library.yml
@@ -18,10 +18,10 @@ content:
     type: image
     label: hidden
     settings:
-      image_style: medium
       image_link: ''
-    weight: 0
+      image_style: medium
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   created: true

--- a/conf/drupal/config/core.entity_view_display.node.article.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.article.default.yml
@@ -23,18 +23,18 @@ mode: default
 content:
   field_article_paragraphs:
     type: entity_reference_revisions_entity_view
-    weight: 0
     label: hidden
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
+    weight: 0
     region: content
   links:
-    weight: 1
-    region: content
     settings: {  }
     third_party_settings: {  }
+    weight: 1
+    region: content
 hidden:
   field_article_news: true
   field_article_summary: true

--- a/conf/drupal/config/core.entity_view_display.node.article.rss.yml
+++ b/conf/drupal/config/core.entity_view_display.node.article.rss.yml
@@ -23,18 +23,18 @@ mode: rss
 content:
   field_article_paragraphs:
     type: entity_reference_revisions_entity_view
-    weight: 0
-    region: content
     label: hidden
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
-  links:
-    weight: 1
+    weight: 0
     region: content
+  links:
     settings: {  }
     third_party_settings: {  }
+    weight: 1
+    region: content
 hidden:
   field_article_news: true
   field_article_summary: true

--- a/conf/drupal/config/core.entity_view_display.node.article.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.article.teaser.yml
@@ -22,11 +22,11 @@ mode: teaser
 content:
   field_article_summary:
     type: basic_string
-    weight: 0
-    region: content
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 0
+    region: content
 hidden:
   field_article_news: true
   field_article_paragraphs: true

--- a/conf/drupal/config/core.entity_view_display.node.attendee.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.attendee.default.yml
@@ -24,42 +24,42 @@ bundle: attendee
 mode: default
 content:
   field_event:
-    weight: 4
+    type: entity_reference_label
     label: inline
     settings:
       link: true
     third_party_settings: {  }
-    type: entity_reference_label
+    weight: 4
     region: content
   field_job_title:
-    weight: 2
+    type: string
     label: inline
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 2
     region: content
   field_name:
-    weight: 1
+    type: string
     label: inline
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 1
     region: content
   field_organization:
-    weight: 3
+    type: string
     label: inline
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 3
     region: content
   links:
-    weight: 0
-    region: content
     settings: {  }
     third_party_settings: {  }
+    weight: 0
+    region: content
 hidden:
   field_attendee_id: true
   field_display_on_site: true

--- a/conf/drupal/config/core.entity_view_display.node.attendee.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.attendee.teaser.yml
@@ -13,9 +13,9 @@ bundle: attendee
 mode: teaser
 content:
   links:
-    weight: 100
     settings: {  }
     third_party_settings: {  }
+    weight: 100
     region: content
 hidden:
   field_attendee_id: true

--- a/conf/drupal/config/core.entity_view_display.node.eventbrite_event.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.eventbrite_event.default.yml
@@ -18,25 +18,25 @@ bundle: eventbrite_event
 mode: default
 content:
   body:
-    label: hidden
     type: text_default
-    weight: 103
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 103
     region: content
   eventbrite_event_id:
-    label: above
     type: string
-    weight: 101
+    label: above
     settings: {  }
     third_party_settings: {  }
+    weight: 101
     region: content
   eventbrite_event_status:
-    label: above
     type: string
-    weight: 102
+    label: above
     settings: {  }
     third_party_settings: {  }
+    weight: 102
     region: content
   links:
     weight: 100

--- a/conf/drupal/config/core.entity_view_display.node.eventbrite_event.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.eventbrite_event.teaser.yml
@@ -19,12 +19,12 @@ bundle: eventbrite_event
 mode: teaser
 content:
   body:
-    label: hidden
     type: text_summary_or_trimmed
-    weight: 101
+    label: hidden
     settings:
       trim_length: 600
     third_party_settings: {  }
+    weight: 101
     region: content
   links:
     weight: 100

--- a/conf/drupal/config/core.entity_view_display.node.job.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.job.default.yml
@@ -23,14 +23,14 @@ bundle: job
 mode: default
 content:
   field_job_description:
-    weight: 4
+    type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: text_default
+    weight: 4
     region: content
   field_job_link:
-    weight: 5
+    type: link
     label: inline
     settings:
       trim_length: 80
@@ -39,43 +39,43 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    type: link
+    weight: 5
     region: content
   field_job_location:
-    weight: 1
+    type: string
     label: inline
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 1
     region: content
   field_job_skill_level:
-    weight: 3
+    type: list_default
     label: inline
     settings: {  }
     third_party_settings: {  }
-    type: list_default
+    weight: 3
     region: content
   field_job_type:
-    weight: 2
+    type: list_default
     label: inline
     settings: {  }
     third_party_settings: {  }
-    type: list_default
+    weight: 2
     region: content
   field_sponsor_company:
-    weight: 0
+    type: entity_reference_label
     label: inline
     settings:
       link: true
     third_party_settings: {  }
-    type: entity_reference_label
+    weight: 0
     region: content
   links:
-    weight: 6
-    region: content
     settings: {  }
     third_party_settings: {  }
+    weight: 6
+    region: content
 hidden:
   field_event: true
   field_meta_tags: true

--- a/conf/drupal/config/core.entity_view_display.node.job.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.job.teaser.yml
@@ -22,8 +22,6 @@ mode: teaser
 content:
   field_job_link:
     type: link
-    weight: 5
-    region: content
     label: hidden
     settings:
       trim_length: 80
@@ -32,41 +30,43 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
+    weight: 5
+    region: content
   field_job_location:
     type: string
-    weight: 4
-    region: content
     label: inline
     settings:
       link_to_entity: false
     third_party_settings: {  }
+    weight: 4
+    region: content
   field_job_skill_level:
     type: list_default
+    label: inline
+    settings: {  }
+    third_party_settings: {  }
     weight: 3
     region: content
-    label: inline
-    settings: {  }
-    third_party_settings: {  }
   field_job_type:
     type: list_default
-    weight: 2
-    region: content
     label: inline
     settings: {  }
     third_party_settings: {  }
+    weight: 2
+    region: content
   field_sponsor_company:
     type: entity_reference_label
-    weight: 1
-    region: content
     label: hidden
     settings:
       link: true
     third_party_settings: {  }
-  links:
-    weight: 0
+    weight: 1
     region: content
+  links:
     settings: {  }
     third_party_settings: {  }
+    weight: 0
+    region: content
 hidden:
   field_event: true
   field_job_description: true

--- a/conf/drupal/config/core.entity_view_display.node.page.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.page.default.yml
@@ -19,18 +19,18 @@ mode: default
 content:
   field_page_paragraphs:
     type: entity_reference_revisions_entity_view
-    weight: 0
     label: hidden
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
+    weight: 0
     region: content
   links:
-    weight: 1
-    region: content
     settings: {  }
     third_party_settings: {  }
+    weight: 1
+    region: content
 hidden:
   field_event: true
   field_meta_tags: true

--- a/conf/drupal/config/core.entity_view_display.node.sponsor.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.sponsor.default.yml
@@ -21,40 +21,40 @@ bundle: sponsor
 mode: default
 content:
   body:
-    label: hidden
     type: text_default
-    weight: 2
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 2
     region: content
   field_image:
-    weight: 1
+    type: image
     label: hidden
     settings:
-      image_style: ''
       image_link: ''
+      image_style: ''
     third_party_settings: {  }
-    type: image
+    weight: 1
     region: content
   field_link:
     type: link
-    weight: 3
     label: hidden
     settings:
       trim_length: 80
-      target: _blank
       url_only: true
       url_plain: false
       rel: '0'
+      target: _blank
     third_party_settings: {  }
+    weight: 3
     region: content
   field_sponsor_level:
-    weight: 0
+    type: entity_reference_label
     label: hidden
     settings:
       link: false
     third_party_settings: {  }
-    type: entity_reference_label
+    weight: 0
     region: content
 hidden:
   field_event: true

--- a/conf/drupal/config/core.entity_view_display.node.sponsor.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.sponsor.teaser.yml
@@ -18,12 +18,12 @@ bundle: sponsor
 mode: teaser
 content:
   body:
-    label: hidden
     type: text_summary_or_trimmed
-    weight: 101
+    label: hidden
     settings:
       trim_length: 600
     third_party_settings: {  }
+    weight: 101
     region: content
   links:
     weight: 100

--- a/conf/drupal/config/core.entity_view_display.node.summit.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.summit.default.yml
@@ -21,23 +21,23 @@ bundle: summit
 mode: default
 content:
   body:
-    label: hidden
     type: text_default
-    weight: 1
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 1
     region: content
   field_people:
-    weight: 3
+    type: entity_reference_entity_view
     label: above
     settings:
       view_mode: compact
       link: false
     third_party_settings: {  }
-    type: entity_reference_entity_view
+    weight: 3
     region: content
   field_registration_link:
-    weight: 0
+    type: link
     label: hidden
     settings:
       trim_length: 80
@@ -46,15 +46,15 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    type: link
+    weight: 0
     region: content
   field_track:
-    weight: 2
+    type: entity_reference_label
     label: inline
     settings:
       link: false
     third_party_settings: {  }
-    type: entity_reference_label
+    weight: 2
     region: content
 hidden:
   field_accepted_confirmed: true

--- a/conf/drupal/config/core.entity_view_display.node.summit.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.summit.teaser.yml
@@ -15,17 +15,17 @@ bundle: summit
 mode: teaser
 content:
   body:
-    label: hidden
     type: text_summary_or_trimmed
-    weight: 101
+    label: hidden
     settings:
       trim_length: 600
     third_party_settings: {  }
+    weight: 101
     region: content
   links:
-    weight: 100
     settings: {  }
     third_party_settings: {  }
+    weight: 100
     region: content
 hidden:
   field_accepted_confirmed: true

--- a/conf/drupal/config/core.entity_view_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.topic.default.yml
@@ -33,78 +33,78 @@ bundle: topic
 mode: default
 content:
   body:
-    label: hidden
     type: text_default
-    weight: 3
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 3
     region: content
   content_moderation_control:
-    weight: 0
-    region: content
     settings: {  }
     third_party_settings: {  }
+    weight: 0
+    region: content
   field_captions:
-    weight: 10
+    type: text_default
     label: above
     settings: {  }
     third_party_settings: {  }
-    type: text_default
+    weight: 10
     region: content
   field_feedback_form:
-    weight: 9
+    type: webform_entity_reference_entity_view
     label: above
     settings:
       source_entity: true
     third_party_settings: {  }
-    type: webform_entity_reference_entity_view
+    weight: 9
     region: content
   field_people:
     type: entity_reference_entity_view
-    weight: 7
-    region: content
     label: above
     settings:
       view_mode: compact
       link: false
     third_party_settings: {  }
+    weight: 7
+    region: content
   field_presenter_slides:
-    weight: 5
+    type: file_default
     label: above
     settings:
       use_description_as_link_text: true
     third_party_settings: {  }
-    type: file_default
+    weight: 5
     region: content
   field_schedule_location:
-    weight: 2
+    type: entity_reference_entity_view
     label: hidden
     settings:
       view_mode: default
       link: false
     third_party_settings: {  }
-    type: entity_reference_entity_view
+    weight: 2
     region: content
   field_schedule_time:
-    weight: 1
+    type: daterange_default
     label: above
     settings:
       timezone_override: America/Chicago
       format_type: day_and_time
       separator: '-'
     third_party_settings: {  }
-    type: daterange_default
+    weight: 1
     region: content
   field_track:
-    weight: 8
+    type: entity_reference_label
     label: inline
     settings:
       link: false
     third_party_settings: {  }
-    type: entity_reference_label
+    weight: 8
     region: content
   field_transcript:
-    weight: 6
+    type: link
     label: above
     settings:
       trim_length: 80
@@ -113,18 +113,18 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    type: link
+    weight: 6
     region: content
   field_video:
-    weight: 4
+    type: video_embed_field_video
     label: hidden
     settings:
+      autoplay: false
       responsive: true
       width: 854
       height: 480
-      autoplay: false
     third_party_settings: {  }
-    type: video_embed_field_video
+    weight: 4
     region: content
 hidden:
   field_accepted_confirmed: true

--- a/conf/drupal/config/core.entity_view_display.node.topic.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.topic.teaser.yml
@@ -19,21 +19,21 @@ bundle: topic
 mode: teaser
 content:
   body:
-    label: hidden
     type: text_summary_or_trimmed
-    weight: 0
+    label: hidden
     settings:
       trim_length: 600
     third_party_settings: {  }
+    weight: 0
     region: content
   field_track:
     type: entity_reference_label
-    weight: 1
-    region: content
     label: inline
     settings:
       link: false
     third_party_settings: {  }
+    weight: 1
+    region: content
 hidden:
   content_moderation_control: true
   field_event: true

--- a/conf/drupal/config/core.entity_view_display.node.training.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.training.default.yml
@@ -23,23 +23,23 @@ bundle: training
 mode: default
 content:
   body:
-    label: hidden
     type: text_default
-    weight: 1
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 1
     region: content
   field_people:
-    weight: 4
+    type: entity_reference_entity_view
     label: above
     settings:
       view_mode: compact
       link: false
     third_party_settings: {  }
-    type: entity_reference_entity_view
+    weight: 4
     region: content
   field_registration_link:
-    weight: 0
+    type: link
     label: hidden
     settings:
       trim_length: 80
@@ -48,26 +48,26 @@ content:
       rel: '0'
       target: '0'
     third_party_settings: {  }
-    type: link
+    weight: 0
     region: content
   field_track:
-    weight: 3
+    type: entity_reference_label
     label: inline
     settings:
       link: false
     third_party_settings: {  }
-    type: entity_reference_label
+    weight: 3
     region: content
   field_video:
-    weight: 2
+    type: video_embed_field_video
     label: hidden
     settings:
+      autoplay: false
       responsive: true
       width: 854
       height: 480
-      autoplay: false
     third_party_settings: {  }
-    type: video_embed_field_video
+    weight: 2
     region: content
 hidden:
   field_accepted_confirmed: true

--- a/conf/drupal/config/core.entity_view_display.node.training.teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.node.training.teaser.yml
@@ -15,12 +15,12 @@ bundle: training
 mode: teaser
 content:
   body:
-    label: hidden
     type: text_summary_or_trimmed
-    weight: 101
+    label: hidden
     settings:
       trim_length: 600
     third_party_settings: {  }
+    weight: 101
     region: content
   links:
     weight: 100

--- a/conf/drupal/config/core.entity_view_display.node.venue.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.venue.default.yml
@@ -19,34 +19,34 @@ bundle: venue
 mode: default
 content:
   field_address:
-    weight: 1
+    type: address_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: address_default
+    weight: 1
     region: content
   field_venue_events:
-    weight: 3
+    type: entity_reference_label
     label: hidden
     settings:
       link: true
     third_party_settings: {  }
-    type: entity_reference_label
+    weight: 3
     region: content
   field_venue_paragraphs:
     type: entity_reference_revisions_entity_view
-    weight: 2
     label: hidden
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
+    weight: 2
     region: content
   links:
-    weight: 0
-    region: content
     settings: {  }
     third_party_settings: {  }
+    weight: 0
+    region: content
 hidden:
   field_event: true
   field_meta_tags: true

--- a/conf/drupal/config/core.entity_view_display.node.venue.map.yml
+++ b/conf/drupal/config/core.entity_view_display.node.venue.map.yml
@@ -17,11 +17,11 @@ bundle: venue
 mode: map
 content:
   field_address:
-    weight: 0
+    type: address_plain
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: address_plain
+    weight: 0
     region: content
 hidden:
   field_venue_events: true

--- a/conf/drupal/config/core.entity_view_display.paragraph.contact_form.default.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.contact_form.default.yml
@@ -13,11 +13,11 @@ bundle: contact_form
 mode: default
 content:
   field_contact:
-    weight: 0
+    type: contact_field_formatter
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: contact_field_formatter
+    weight: 0
     region: content
 hidden:
   created: true

--- a/conf/drupal/config/core.entity_view_display.paragraph.paragraphs_columns_even.default.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.paragraphs_columns_even.default.yml
@@ -14,12 +14,12 @@ mode: default
 content:
   field_column_content:
     type: entity_reference_revisions_entity_view
-    weight: 0
     label: above
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   created: true

--- a/conf/drupal/config/core.entity_view_display.paragraph.paragraphs_columns_uneven_2.default.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.paragraphs_columns_uneven_2.default.yml
@@ -16,19 +16,19 @@ mode: default
 content:
   field_column_content_2:
     type: entity_reference_revisions_entity_view
-    weight: 1
     label: hidden
     settings:
       view_mode: default
       link: ''
     third_party_settings: {  }
+    weight: 1
     region: content
   field_grid_style:
-    weight: 0
+    type: list_key
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: list_key
+    weight: 0
     region: content
 hidden:
   created: true

--- a/conf/drupal/config/core.entity_view_display.paragraph.paragraphs_image.default.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.paragraphs_image.default.yml
@@ -13,13 +13,13 @@ bundle: paragraphs_image
 mode: default
 content:
   field_paragraph_image:
-    weight: 0
+    type: image
     label: hidden
     settings:
-      image_style: ''
       image_link: ''
+      image_style: ''
     third_party_settings: {  }
-    type: image
+    weight: 0
     region: content
 hidden:
   created: true

--- a/conf/drupal/config/core.entity_view_display.paragraph.paragraphs_text.default.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.paragraphs_text.default.yml
@@ -13,11 +13,11 @@ bundle: paragraphs_text
 mode: default
 content:
   field_paragraph_text:
-    weight: 0
+    type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: text_default
+    weight: 0
     region: content
 hidden:
   created: true

--- a/conf/drupal/config/core.entity_view_display.paragraph.view.default.yml
+++ b/conf/drupal/config/core.entity_view_display.paragraph.view.default.yml
@@ -13,12 +13,12 @@ bundle: view
 mode: default
 content:
   field_view:
-    weight: 0
+    type: viewsreference_formatter
     label: hidden
     settings:
       render_view: true
     third_party_settings: {  }
-    type: viewsreference_formatter
+    weight: 0
     region: content
 hidden:
   created: true

--- a/conf/drupal/config/core.entity_view_display.taxonomy_term.event.branding_banner.yml
+++ b/conf/drupal/config/core.entity_view_display.taxonomy_term.event.branding_banner.yml
@@ -21,7 +21,7 @@ bundle: event
 mode: branding_banner
 content:
   field_banner_cta_anonymous:
-    weight: 2
+    type: link
     label: above
     settings:
       trim_length: 80
@@ -30,10 +30,10 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    type: link
+    weight: 2
     region: content
   field_banner_cta_authenticated:
-    weight: 3
+    type: link
     label: above
     settings:
       trim_length: 80
@@ -42,26 +42,26 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    type: link
+    weight: 3
     region: content
   field_date:
-    weight: 1
+    type: daterange_default
     label: above
     settings:
       timezone_override: ''
       format_type: long
       separator: '-'
     third_party_settings: {  }
-    type: daterange_default
+    weight: 1
     region: content
   field_image:
-    weight: 0
+    type: image
     label: above
     settings:
-      image_style: ''
       image_link: ''
+      image_style: ''
     third_party_settings: {  }
-    type: image
+    weight: 0
     region: content
 hidden:
   description: true

--- a/conf/drupal/config/core.entity_view_display.taxonomy_term.event.default.yml
+++ b/conf/drupal/config/core.entity_view_display.taxonomy_term.event.default.yml
@@ -24,14 +24,14 @@ bundle: event
 mode: default
 content:
   description:
-    label: hidden
     type: text_default
-    weight: 0
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
   field_banner_cta_anonymous:
-    weight: 4
+    type: link
     label: above
     settings:
       trim_length: 80
@@ -40,10 +40,10 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    type: link
+    weight: 4
     region: content
   field_banner_cta_authenticated:
-    weight: 5
+    type: link
     label: above
     settings:
       trim_length: 80
@@ -52,36 +52,36 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    type: link
+    weight: 5
     region: content
   field_date:
-    weight: 2
+    type: daterange_default
     label: above
     settings:
       timezone_override: ''
       format_type: long
       separator: '-'
     third_party_settings: {  }
-    type: daterange_default
+    weight: 2
     region: content
   field_date_has_time:
-    weight: 3
+    type: boolean
     label: above
     settings:
       format: default
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    type: boolean
+    weight: 3
     region: content
   field_image:
-    weight: 1
+    type: image
     label: above
     settings:
-      image_style: ''
       image_link: ''
+      image_style: ''
     third_party_settings: {  }
-    type: image
+    weight: 1
     region: content
 hidden:
   field_event_id: true

--- a/conf/drupal/config/core.entity_view_display.taxonomy_term.event.map.yml
+++ b/conf/drupal/config/core.entity_view_display.taxonomy_term.event.map.yml
@@ -22,14 +22,14 @@ bundle: event
 mode: map
 content:
   description:
-    label: hidden
     type: text_default
-    weight: 0
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
   field_banner_cta_anonymous:
-    weight: 5
+    type: link
     label: above
     settings:
       trim_length: 80
@@ -38,10 +38,10 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    type: link
+    weight: 5
     region: content
   field_banner_cta_authenticated:
-    weight: 6
+    type: link
     label: above
     settings:
       trim_length: 80
@@ -50,36 +50,36 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    type: link
+    weight: 6
     region: content
   field_date:
-    weight: 3
+    type: daterange_default
     label: above
     settings:
       timezone_override: ''
       format_type: long
       separator: '-'
     third_party_settings: {  }
-    type: daterange_default
+    weight: 3
     region: content
   field_date_has_time:
-    weight: 4
+    type: boolean
     label: above
     settings:
       format: default
       format_custom_false: ''
       format_custom_true: ''
     third_party_settings: {  }
-    type: boolean
+    weight: 4
     region: content
   field_image:
-    weight: 1
+    type: image
     label: above
     settings:
-      image_style: ''
       image_link: ''
+      image_style: ''
     third_party_settings: {  }
-    type: image
+    weight: 1
     region: content
 hidden:
   field_social_media: true

--- a/conf/drupal/config/core.entity_view_display.taxonomy_term.event.sub_event_teaser.yml
+++ b/conf/drupal/config/core.entity_view_display.taxonomy_term.event.sub_event_teaser.yml
@@ -20,39 +20,39 @@ bundle: event
 mode: sub_event_teaser
 content:
   description:
-    label: hidden
     type: text_default
-    weight: 0
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 0
     region: content
   field_date:
     type: daterange_plain
-    weight: 2
-    region: content
     label: hidden
     settings:
       timezone_override: ''
       separator: '-'
     third_party_settings: {  }
+    weight: 2
+    region: content
   field_date_has_time:
     type: boolean
-    weight: 3
-    region: content
     label: hidden
     settings:
       format: boolean
-      format_custom_true: ''
       format_custom_false: ''
+      format_custom_true: ''
     third_party_settings: {  }
+    weight: 3
+    region: content
   field_image:
-    weight: 1
+    type: image
     label: hidden
     settings:
-      image_style: sub_event_teaser_600x400
       image_link: ''
+      image_style: sub_event_teaser_600x400
     third_party_settings: {  }
-    type: image
+    weight: 1
     region: content
 hidden:
   field_banner_cta_anonymous: true

--- a/conf/drupal/config/core.entity_view_display.taxonomy_term.location.topic_page.yml
+++ b/conf/drupal/config/core.entity_view_display.taxonomy_term.location.topic_page.yml
@@ -15,22 +15,22 @@ bundle: location
 mode: topic_page
 content:
   description:
-    label: hidden
     type: text_default
-    weight: 0
-    region: content
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 0
+    region: content
   field_link:
-    weight: 1
+    type: link
     label: hidden
     settings:
       trim_length: null
-      target: _blank
       url_only: false
       url_plain: false
       rel: '0'
+      target: _blank
     third_party_settings: {  }
-    type: link
+    weight: 1
     region: content
 hidden: {  }

--- a/conf/drupal/config/core.entity_view_display.taxonomy_term.sponsor_packages.default.yml
+++ b/conf/drupal/config/core.entity_view_display.taxonomy_term.sponsor_packages.default.yml
@@ -14,14 +14,14 @@ bundle: sponsor_packages
 mode: default
 content:
   description:
-    label: hidden
     type: text_default
-    weight: 2
+    label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 2
     region: content
   field_sponsor_package_price:
-    weight: 0
+    type: number_decimal
     label: inline
     settings:
       thousand_separator: ','
@@ -29,15 +29,15 @@ content:
       scale: 2
       prefix_suffix: true
     third_party_settings: {  }
-    type: number_decimal
+    weight: 0
     region: content
   field_sponsor_package_qty_avail:
-    weight: 1
+    type: number_integer
     label: hidden
     settings:
       thousand_separator: ''
       prefix_suffix: true
     third_party_settings: {  }
-    type: number_integer
+    weight: 1
     region: content
 hidden: {  }

--- a/conf/drupal/config/core.entity_view_display.user.user.compact.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.compact.yml
@@ -34,53 +34,53 @@ mode: compact
 content:
   field_bio:
     type: text_default
-    weight: 4
-    region: content
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 4
+    region: content
   field_name:
     type: name_default
+    label: hidden
     settings:
-      list_format: default
       format: default
       markup: none
+      list_format: default
       link_target: ''
       preferred_field_reference: ''
       preferred_field_reference_separator: ', '
       alternative_field_reference: ''
       alternative_field_reference_separator: ', '
+    third_party_settings: {  }
     weight: 1
     region: content
-    label: hidden
-    third_party_settings: {  }
   field_organization:
     type: entity_reference_label
-    weight: 3
-    region: content
     label: hidden
     settings:
       link: true
     third_party_settings: {  }
+    weight: 3
+    region: content
   field_title:
     type: string
-    weight: 2
-    region: content
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
+    weight: 2
+    region: content
   masquerade:
     weight: 50
     region: content
   user_picture:
     type: image
-    weight: 0
-    settings:
-      image_style: medium
-      image_link: ''
-    third_party_settings: {  }
     label: hidden
+    settings:
+      image_link: ''
+      image_style: medium
+    third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   field_company_logo: true

--- a/conf/drupal/config/core.entity_view_display.user.user.default.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.default.yml
@@ -33,23 +33,23 @@ bundle: user
 mode: default
 content:
   field_bio:
-    weight: 7
+    type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: text_default
+    weight: 7
     region: content
   field_company_logo:
-    weight: 9
+    type: image
     label: hidden
     settings:
-      image_style: large
       image_link: ''
+      image_style: large
     third_party_settings: {  }
-    type: image
+    weight: 9
     region: content
   field_do_profile:
-    weight: 2
+    type: link
     label: inline
     settings:
       trim_length: 80
@@ -58,33 +58,33 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    type: link
+    weight: 2
     region: content
   field_name:
     type: name_default
+    label: inline
     settings:
-      list_format: default
       format: default
       markup: none
+      list_format: default
       link_target: ''
       preferred_field_reference: ''
       preferred_field_reference_separator: ', '
       alternative_field_reference: ''
       alternative_field_reference_separator: ', '
-    weight: 1
-    label: inline
     third_party_settings: {  }
+    weight: 1
     region: content
   field_organization:
-    weight: 4
+    type: entity_reference_label
     label: inline
     settings:
       link: false
     third_party_settings: {  }
-    type: entity_reference_label
+    weight: 4
     region: content
   field_site:
-    weight: 6
+    type: link
     label: above
     settings:
       trim_length: 80
@@ -93,40 +93,40 @@ content:
       rel: ''
       target: ''
     third_party_settings: {  }
-    type: link
+    weight: 6
     region: content
   field_title:
-    weight: 3
+    type: string
     label: inline
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 3
     region: content
   field_tracks:
-    weight: 8
+    type: entity_reference_label
     label: above
     settings:
       link: true
     third_party_settings: {  }
-    type: entity_reference_label
+    weight: 8
     region: content
   field_twitter:
-    weight: 5
+    type: string
     label: inline
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 5
     region: content
   user_picture:
     type: image
-    weight: 0
-    settings:
-      image_style: featured_speaker
-      image_link: ''
-    third_party_settings: {  }
     label: hidden
+    settings:
+      image_link: ''
+      image_style: featured_speaker
+    third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   field_company_url: true

--- a/conf/drupal/config/core.entity_view_display.user.user.email.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.email.yml
@@ -30,11 +30,11 @@ mode: email
 content:
   field_eventbrite_email:
     type: basic_string
-    weight: 0
-    region: content
     label: hidden
     settings: {  }
     third_party_settings: {  }
+    weight: 0
+    region: content
 hidden:
   field_bio: true
   field_company_logo: true

--- a/conf/drupal/config/core.entity_view_display.user.user.featured_speaker.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.featured_speaker.yml
@@ -34,55 +34,55 @@ mode: featured_speaker
 content:
   field_company_url:
     type: link
-    weight: 4
-    region: content
     label: hidden
     settings:
       trim_length: 80
       url_only: true
       url_plain: true
-      target: _blank
       rel: '0'
+      target: _blank
     third_party_settings: {  }
+    weight: 4
+    region: content
   field_name:
     type: name_default
+    label: hidden
     settings:
-      list_format: default
       format: default
       markup: none
+      list_format: default
       link_target: ''
       preferred_field_reference: ''
       preferred_field_reference_separator: ', '
       alternative_field_reference: ''
       alternative_field_reference_separator: ', '
-    weight: 1
-    label: hidden
     third_party_settings: {  }
+    weight: 1
     region: content
   field_organization:
-    weight: 3
+    type: entity_reference_label
     label: hidden
     settings:
       link: false
     third_party_settings: {  }
-    type: entity_reference_label
+    weight: 3
     region: content
   field_title:
-    weight: 2
+    type: string
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 2
     region: content
   user_picture:
     type: image
-    weight: 0
-    settings:
-      image_style: featured_speaker
-      image_link: content
-    third_party_settings: {  }
     label: hidden
+    settings:
+      image_link: content
+      image_style: featured_speaker
+    third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   field_bio: true

--- a/conf/drupal/config/core.entity_view_display.user.user.schedule.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.schedule.yml
@@ -32,45 +32,45 @@ bundle: user
 mode: schedule
 content:
   field_company_logo:
-    weight: 3
+    type: image
     label: hidden
     settings:
-      image_style: medium
       image_link: ''
+      image_style: medium
     third_party_settings: {  }
-    type: image
+    weight: 3
     region: content
   field_name:
     type: name_default
+    label: hidden
     settings:
-      list_format: default
       format: default
       markup: none
+      list_format: default
       link_target: ''
       preferred_field_reference: ''
       preferred_field_reference_separator: ', '
       alternative_field_reference: ''
       alternative_field_reference_separator: ', '
-    weight: 1
-    label: hidden
     third_party_settings: {  }
+    weight: 1
     region: content
   field_organization:
-    weight: 2
+    type: entity_reference_label
     label: hidden
     settings:
       link: false
     third_party_settings: {  }
-    type: entity_reference_label
+    weight: 2
     region: content
   user_picture:
     type: image
-    weight: 0
-    settings:
-      image_style: schedule_presenter
-      image_link: ''
-    third_party_settings: {  }
     label: hidden
+    settings:
+      image_link: ''
+      image_style: schedule_presenter
+    third_party_settings: {  }
+    weight: 0
     region: content
 hidden:
   field_bio: true

--- a/conf/drupal/config/core.entity_view_display.user.user.socials.yml
+++ b/conf/drupal/config/core.entity_view_display.user.user.socials.yml
@@ -31,26 +31,26 @@ mode: socials
 content:
   field_name:
     type: name_default
+    label: inline
     settings:
-      list_format: default
       format: default
       markup: none
+      list_format: default
       link_target: ''
       preferred_field_reference: ''
       preferred_field_reference_separator: ', '
       alternative_field_reference: ''
       alternative_field_reference_separator: ', '
-    weight: 0
-    label: inline
     third_party_settings: {  }
+    weight: 0
     region: content
   field_twitter:
-    weight: 1
+    type: string
     label: inline
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    type: string
+    weight: 1
     region: content
 hidden:
   field_bio: true

--- a/conf/drupal/config/core.entity_view_mode.media.media_library.yml
+++ b/conf/drupal/config/core.entity_view_mode.media.media_library.yml
@@ -2,11 +2,11 @@ uuid: 1b233843-874e-4b71-9672-2ee5aaf3a249
 langcode: en
 status: true
 dependencies:
+  module:
+    - media
   enforced:
     module:
       - media_library
-  module:
-    - media
 _core:
   default_config_hash: pkq0uj-IoqEQRBOP_ddUDV0ZJ-dKQ_fLcppsEDF2UO8
 id: media.media_library

--- a/conf/drupal/config/core.menu.static_menu_link_overrides.yml
+++ b/conf/drupal/config/core.menu.static_menu_link_overrides.yml
@@ -1,21 +1,21 @@
-definitions:
-  contact__site_page:
-    enabled: false
-    menu_name: footer
-    parent: ''
-    expanded: false
-    weight: 0
-  user__page:
-    weight: -50
-    menu_name: account
-    parent: ''
-    enabled: true
-    expanded: false
-  user__logout:
-    enabled: false
-    menu_name: account
-    parent: ''
-    expanded: false
-    weight: -49
 _core:
   default_config_hash: jdY7AU0tU-QsjmiOw3W8vwpYMb-By--_MSFgbqKUTYM
+definitions:
+  contact__site_page:
+    menu_name: footer
+    parent: ''
+    weight: 0
+    expanded: false
+    enabled: false
+  user__page:
+    menu_name: account
+    parent: ''
+    weight: -50
+    expanded: false
+    enabled: true
+  user__logout:
+    menu_name: account
+    parent: ''
+    weight: -49
+    expanded: false
+    enabled: false

--- a/conf/drupal/config/dblog.settings.yml
+++ b/conf/drupal/config/dblog.settings.yml
@@ -1,3 +1,3 @@
-row_limit: 1000
 _core:
   default_config_hash: e883aGsrt1wFrsydlYU584PZONCSfRy0DtkZ9KzHb58
+row_limit: 1000

--- a/conf/drupal/config/field.field.media.file.field_media_file.yml
+++ b/conf/drupal/config/field.field.media.file.field_media_file.yml
@@ -5,11 +5,11 @@ dependencies:
   config:
     - field.storage.media.field_media_file
     - media.type.file
+  module:
+    - file
   enforced:
     module:
       - media
-  module:
-    - file
 id: media.file.field_media_file
 field_name: field_media_file
 entity_type: media
@@ -21,10 +21,10 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
+  handler: 'default:file'
+  handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'txt rtf doc docx ppt pptx xls xlsx pdf odf odg odp ods odt fodt fods fodp fodg key numbers pages'
   max_filesize: ''
-  handler: 'default:file'
-  handler_settings: {  }
   description_field: false
 field_type: file

--- a/conf/drupal/config/field.field.media.image.field_media_image.yml
+++ b/conf/drupal/config/field.field.media.image.field_media_image.yml
@@ -5,11 +5,11 @@ dependencies:
   config:
     - field.storage.media.field_media_image
     - media.type.image
+  module:
+    - image
   enforced:
     module:
       - media
-  module:
-    - image
 id: media.image.field_media_image
 field_name: field_media_image
 entity_type: media
@@ -21,21 +21,21 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
   alt_field: true
   alt_field_required: true
   title_field: false
   title_field_required: false
-  max_resolution: ''
-  min_resolution: ''
   default_image:
     uuid: null
     alt: ''
     title: ''
     width: null
     height: null
-  file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'png gif jpg jpeg'
-  max_filesize: ''
-  handler: 'default:file'
-  handler_settings: {  }
 field_type: image

--- a/conf/drupal/config/field.field.node.article.field_article_paragraphs.yml
+++ b/conf/drupal/config/field.field.node.article.field_article_paragraphs.yml
@@ -34,22 +34,22 @@ settings:
       contact_form: contact_form
       view: view
     target_bundles_drag_drop:
-      paragraphs_text:
-        enabled: true
-        weight: -13
-      paragraphs_image:
-        enabled: true
-        weight: -12
-      paragraphs_columns_even:
-        enabled: true
-        weight: -11
-      paragraphs_columns_uneven_2:
-        enabled: true
-        weight: -10
       contact_form:
-        enabled: true
         weight: -9
-      view:
         enabled: true
+      paragraphs_columns_even:
+        weight: -11
+        enabled: true
+      paragraphs_columns_uneven_2:
+        weight: -10
+        enabled: true
+      paragraphs_image:
+        weight: -12
+        enabled: true
+      paragraphs_text:
+        weight: -13
+        enabled: true
+      view:
         weight: -8
+        enabled: true
 field_type: entity_reference_revisions

--- a/conf/drupal/config/field.field.node.attendee.field_drupal_user_account.yml
+++ b/conf/drupal/config/field.field.node.attendee.field_drupal_user_account.yml
@@ -18,11 +18,11 @@ default_value_callback: ''
 settings:
   handler: 'default:user'
   handler_settings:
-    include_anonymous: false
-    filter:
-      type: _none
     target_bundles: null
     sort:
       field: _none
     auto_create: false
+    filter:
+      type: _none
+    include_anonymous: false
 field_type: entity_reference

--- a/conf/drupal/config/field.field.node.job.field_job_link.yml
+++ b/conf/drupal/config/field.field.node.job.field_job_link.yml
@@ -18,7 +18,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  link_type: 17
   title: 1
+  link_type: 17
   title_predefined: ''
 field_type: link

--- a/conf/drupal/config/field.field.node.page.field_page_paragraphs.yml
+++ b/conf/drupal/config/field.field.node.page.field_page_paragraphs.yml
@@ -34,22 +34,22 @@ settings:
       contact_form: contact_form
       view: view
     target_bundles_drag_drop:
-      paragraphs_text:
-        enabled: true
-        weight: -9
-      paragraphs_image:
-        enabled: true
-        weight: -8
-      paragraphs_columns_even:
-        enabled: true
-        weight: -7
-      paragraphs_columns_uneven_2:
-        enabled: true
-        weight: -6
       contact_form:
-        enabled: true
         weight: 7
-      view:
         enabled: true
+      paragraphs_columns_even:
+        weight: -7
+        enabled: true
+      paragraphs_columns_uneven_2:
+        weight: -6
+        enabled: true
+      paragraphs_image:
+        weight: -8
+        enabled: true
+      paragraphs_text:
+        weight: -9
+        enabled: true
+      view:
         weight: 12
+        enabled: true
 field_type: entity_reference_revisions

--- a/conf/drupal/config/field.field.node.sponsor.field_image.yml
+++ b/conf/drupal/config/field.field.node.sponsor.field_image.yml
@@ -18,6 +18,8 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
+  handler: 'default:file'
+  handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
@@ -33,6 +35,4 @@ settings:
     title: ''
     width: null
     height: null
-  handler: 'default:file'
-  handler_settings: {  }
 field_type: image

--- a/conf/drupal/config/field.field.node.sponsor.field_link.yml
+++ b/conf/drupal/config/field.field.node.sponsor.field_link.yml
@@ -18,7 +18,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  link_type: 17
   title: 1
+  link_type: 17
   title_predefined: ''
 field_type: link

--- a/conf/drupal/config/field.field.node.summit.field_people.yml
+++ b/conf/drupal/config/field.field.node.summit.field_people.yml
@@ -18,11 +18,11 @@ default_value_callback: ''
 settings:
   handler: 'default:user'
   handler_settings:
-    include_anonymous: false
-    filter:
-      type: _none
     target_bundles: null
     sort:
       field: _none
     auto_create: false
+    filter:
+      type: _none
+    include_anonymous: false
 field_type: entity_reference

--- a/conf/drupal/config/field.field.node.summit.field_registration_link.yml
+++ b/conf/drupal/config/field.field.node.summit.field_registration_link.yml
@@ -18,7 +18,7 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
-  link_type: 17
   title: 1
+  link_type: 17
   title_predefined: ''
 field_type: link

--- a/conf/drupal/config/field.field.node.topic.field_people.yml
+++ b/conf/drupal/config/field.field.node.topic.field_people.yml
@@ -18,11 +18,11 @@ default_value_callback: ''
 settings:
   handler: 'default:user'
   handler_settings:
-    include_anonymous: false
-    filter:
-      type: _none
     target_bundles: null
     sort:
       field: _none
     auto_create: false
+    filter:
+      type: _none
+    include_anonymous: false
 field_type: entity_reference

--- a/conf/drupal/config/field.field.node.topic.field_presenter_slides.yml
+++ b/conf/drupal/config/field.field.node.topic.field_presenter_slides.yml
@@ -18,10 +18,10 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
+  handler: 'default:file'
+  handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'pdf ppt pptx'
   max_filesize: ''
   description_field: true
-  handler: 'default:file'
-  handler_settings: {  }
 field_type: file

--- a/conf/drupal/config/field.field.node.topic.field_transcript.yml
+++ b/conf/drupal/config/field.field.node.topic.field_transcript.yml
@@ -18,7 +18,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  link_type: 16
   title: 0
+  link_type: 16
   title_predefined: ''
 field_type: link

--- a/conf/drupal/config/field.field.node.training.field_people.yml
+++ b/conf/drupal/config/field.field.node.training.field_people.yml
@@ -18,11 +18,11 @@ default_value_callback: ''
 settings:
   handler: 'default:user'
   handler_settings:
-    include_anonymous: false
-    filter:
-      type: _none
     target_bundles: null
     sort:
       field: _none
     auto_create: false
+    filter:
+      type: _none
+    include_anonymous: false
 field_type: entity_reference

--- a/conf/drupal/config/field.field.node.training.field_registration_link.yml
+++ b/conf/drupal/config/field.field.node.training.field_registration_link.yml
@@ -23,7 +23,7 @@ default_value:
     options: {  }
 default_value_callback: ''
 settings:
-  link_type: 17
   title: 1
+  link_type: 17
   title_predefined: ''
 field_type: link

--- a/conf/drupal/config/field.field.node.venue.field_address.yml
+++ b/conf/drupal/config/field.field.node.venue.field_address.yml
@@ -20,6 +20,7 @@ default_value_callback: ''
 settings:
   available_countries:
     US: US
+  langcode_override: ''
   fields:
     administrativeArea: administrativeArea
     locality: locality
@@ -32,5 +33,4 @@ settings:
     givenName: '0'
     additionalName: '0'
     familyName: '0'
-  langcode_override: ''
 field_type: address

--- a/conf/drupal/config/field.field.node.venue.field_venue_paragraphs.yml
+++ b/conf/drupal/config/field.field.node.venue.field_venue_paragraphs.yml
@@ -34,22 +34,22 @@ settings:
       contact_form: contact_form
       view: view
     target_bundles_drag_drop:
-      paragraphs_text:
-        enabled: true
-        weight: -9
-      paragraphs_image:
-        enabled: true
-        weight: -8
-      paragraphs_columns_even:
-        enabled: true
-        weight: -7
-      paragraphs_columns_uneven_2:
-        enabled: true
-        weight: -6
       contact_form:
-        enabled: true
         weight: 7
-      view:
         enabled: true
+      paragraphs_columns_even:
+        weight: -7
+        enabled: true
+      paragraphs_columns_uneven_2:
+        weight: -6
+        enabled: true
+      paragraphs_image:
+        weight: -8
+        enabled: true
+      paragraphs_text:
+        weight: -9
+        enabled: true
+      view:
         weight: 12
+        enabled: true
 field_type: entity_reference_revisions

--- a/conf/drupal/config/field.field.paragraph.paragraphs_columns_even.field_column_content.yml
+++ b/conf/drupal/config/field.field.paragraph.paragraphs_columns_even.field_column_content.yml
@@ -26,13 +26,13 @@ settings:
       paragraphs_image: paragraphs_image
       paragraphs_text: paragraphs_text
     target_bundles_drag_drop:
-      paragraphs_image:
-        enabled: true
-        weight: -7
-      paragraphs_text:
-        enabled: true
-        weight: -6
       paragraphs_columns_even:
         weight: -5
         enabled: false
+      paragraphs_image:
+        weight: -7
+        enabled: true
+      paragraphs_text:
+        weight: -6
+        enabled: true
 field_type: entity_reference_revisions

--- a/conf/drupal/config/field.field.paragraph.paragraphs_columns_uneven_2.field_column_content_2.yml
+++ b/conf/drupal/config/field.field.paragraph.paragraphs_columns_uneven_2.field_column_content_2.yml
@@ -33,9 +33,9 @@ settings:
         weight: 6
         enabled: false
       paragraphs_image:
-        enabled: true
         weight: 7
-      paragraphs_text:
         enabled: true
+      paragraphs_text:
         weight: 8
+        enabled: true
 field_type: entity_reference_revisions

--- a/conf/drupal/config/field.field.paragraph.paragraphs_image.field_paragraph_image.yml
+++ b/conf/drupal/config/field.field.paragraph.paragraphs_image.field_paragraph_image.yml
@@ -18,6 +18,8 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
+  handler: 'default:file'
+  handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
@@ -33,6 +35,4 @@ settings:
     title: ''
     width: null
     height: null
-  handler: 'default:file'
-  handler_settings: {  }
 field_type: image

--- a/conf/drupal/config/field.field.taxonomy_term.event.field_banner_cta_anonymous.yml
+++ b/conf/drupal/config/field.field.taxonomy_term.event.field_banner_cta_anonymous.yml
@@ -18,7 +18,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  link_type: 17
   title: 2
+  link_type: 17
   title_predefined: ''
 field_type: link

--- a/conf/drupal/config/field.field.taxonomy_term.event.field_banner_cta_authenticated.yml
+++ b/conf/drupal/config/field.field.taxonomy_term.event.field_banner_cta_authenticated.yml
@@ -18,7 +18,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  link_type: 17
   title: 2
+  link_type: 17
   title_predefined: ''
 field_type: link

--- a/conf/drupal/config/field.field.taxonomy_term.event.field_image.yml
+++ b/conf/drupal/config/field.field.taxonomy_term.event.field_image.yml
@@ -18,6 +18,8 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
+  handler: 'default:file'
+  handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: ''
@@ -33,6 +35,4 @@ settings:
     title: ''
     width: null
     height: null
-  handler: 'default:file'
-  handler_settings: {  }
 field_type: image

--- a/conf/drupal/config/field.field.taxonomy_term.event.field_social_media.yml
+++ b/conf/drupal/config/field.field.taxonomy_term.event.field_social_media.yml
@@ -18,7 +18,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  link_type: 16
   title: 5
+  link_type: 16
   title_predefined: "facebook|Facebook\r\ntwitter|Twitter\r\ngoogle-plus|Google+\r\nyoutube|Youtube"
 field_type: link

--- a/conf/drupal/config/field.field.taxonomy_term.location.field_link.yml
+++ b/conf/drupal/config/field.field.taxonomy_term.location.field_link.yml
@@ -18,7 +18,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  link_type: 16
   title: 5
+  link_type: 16
   title_predefined: 'Go to [term:name]'
 field_type: link

--- a/conf/drupal/config/field.field.user.user.field_company_logo.yml
+++ b/conf/drupal/config/field.field.user.user.field_company_logo.yml
@@ -18,6 +18,8 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
+  handler: 'default:file'
+  handler_settings: {  }
   file_directory: '[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: '5 MB'
@@ -33,6 +35,4 @@ settings:
     title: ''
     width: null
     height: null
-  handler: 'default:file'
-  handler_settings: {  }
 field_type: image

--- a/conf/drupal/config/field.field.user.user.field_company_url.yml
+++ b/conf/drupal/config/field.field.user.user.field_company_url.yml
@@ -18,7 +18,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  link_type: 16
   title: 0
+  link_type: 16
   title_predefined: ''
 field_type: link

--- a/conf/drupal/config/field.field.user.user.field_do_profile.yml
+++ b/conf/drupal/config/field.field.user.user.field_do_profile.yml
@@ -18,7 +18,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  link_type: 16
   title: 1
+  link_type: 16
   title_predefined: ''
 field_type: link

--- a/conf/drupal/config/field.field.user.user.field_mailing_list.yml
+++ b/conf/drupal/config/field.field.user.user.field_mailing_list.yml
@@ -18,18 +18,18 @@ translatable: false
 default_value:
   -
     value:
-      subscribe: 0
+      subscribe: false
     subscribe: null
     interest_groups: null
 default_value_callback: ''
 settings:
   subscribe_checkbox_label: Subscribe
-  show_interest_groups: 0
-  interest_groups_hidden: 0
+  show_interest_groups: false
+  interest_groups_hidden: false
   interest_groups_label: 'Interest Groups'
   merge_fields:
     EMAIL: mail
     FNAME: field_name
     LNAME: ''
-  unsubscribe_on_delete: 0
+  unsubscribe_on_delete: false
 field_type: mailchimp_lists_subscription

--- a/conf/drupal/config/field.field.user.user.field_name.yml
+++ b/conf/drupal/config/field.field.user.user.field_name.yml
@@ -25,52 +25,20 @@ default_value:
     credentials: null
 default_value_callback: ''
 settings:
-  size:
-    title: 6
-    given: 20
-    middle: 20
-    family: 20
-    generational: 5
-    credentials: 35
-  title_display:
-    title: description
-    given: description
-    middle: description
-    family: description
-    generational: description
-    credentials: description
-  field_type:
-    title: select
-    given: text
-    middle: text
-    family: text
-    generational: select
-    credentials: text
-  component_layout: default
-  show_component_required_marker: false
-  credentials_inline: false
-  override_format: short_full
   components:
-    given: true
-    family: true
     title: false
+    given: true
     middle: false
+    family: true
     generational: false
     credentials: false
   minimum_components:
-    given: true
-    family: true
     title: false
+    given: true
     middle: false
+    family: true
     generational: false
     credentials: false
-  labels:
-    title: Title
-    given: First
-    middle: 'Middle name(s)'
-    family: Last
-    generational: Generational
-    credentials: Credentials
   max_length:
     title: 31
     given: 63
@@ -78,6 +46,14 @@ settings:
     family: 63
     generational: 15
     credentials: 255
+  labels:
+    title: Title
+    given: First
+    middle: 'Middle name(s)'
+    family: Last
+    generational: Generational
+    credentials: Credentials
+  allow_family_or_given: false
   autocomplete_source:
     title:
       title: title
@@ -94,7 +70,6 @@ settings:
     family: ' -'
     generational: ' '
     credentials: ', '
-  allow_family_or_given: false
   title_options:
     - '-- --'
     - Mr.
@@ -121,6 +96,31 @@ settings:
     title: false
     generational: false
   widget_layout: stacked
+  component_layout: default
+  show_component_required_marker: false
+  credentials_inline: false
+  override_format: short_full
+  field_type:
+    title: select
+    given: text
+    middle: text
+    family: text
+    generational: select
+    credentials: text
+  size:
+    title: 6
+    given: 20
+    middle: 20
+    family: 20
+    generational: 5
+    credentials: 35
+  title_display:
+    title: description
+    given: description
+    middle: description
+    family: description
+    generational: description
+    credentials: description
   preferred_field_reference: ''
   preferred_field_reference_separator: ', '
   alternative_field_reference: ''

--- a/conf/drupal/config/field.field.user.user.field_site.yml
+++ b/conf/drupal/config/field.field.user.user.field_site.yml
@@ -18,7 +18,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  link_type: 16
   title: 0
+  link_type: 16
   title_predefined: ''
 field_type: link

--- a/conf/drupal/config/field.field.user.user.user_picture.yml
+++ b/conf/drupal/config/field.field.user.user.user_picture.yml
@@ -20,6 +20,8 @@ translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
+  handler: 'default:file'
+  handler_settings: {  }
   file_directory: 'pictures/[date:custom:Y]-[date:custom:m]'
   file_extensions: 'png gif jpg jpeg'
   max_filesize: '512 KB'
@@ -35,6 +37,4 @@ settings:
     title: ''
     width: null
     height: null
-  handler: 'default:file'
-  handler_settings: {  }
 field_type: image

--- a/conf/drupal/config/field.settings.yml
+++ b/conf/drupal/config/field.settings.yml
@@ -1,3 +1,3 @@
-purge_batch_size: 50
 _core:
   default_config_hash: nJk0TAQBzlNo52ehiHI7bIEPLGi0BYqZvPdEn7Chfu0
+purge_batch_size: 50

--- a/conf/drupal/config/field.storage.media.field_media_file.yml
+++ b/conf/drupal/config/field.storage.media.field_media_file.yml
@@ -2,21 +2,21 @@ uuid: a68970d5-fb00-4aa2-ba2f-cb817b2c1ee9
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - media
   module:
     - file
     - media
+  enforced:
+    module:
+      - media
 id: media.field_media_file
 field_name: field_media_file
 entity_type: media
 type: file
 settings:
-  uri_scheme: public
   target_type: file
   display_field: false
   display_default: false
+  uri_scheme: public
 module: file
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.media.field_media_image.yml
+++ b/conf/drupal/config/field.storage.media.field_media_image.yml
@@ -2,28 +2,28 @@ uuid: abbf5a9b-b3d3-48c7-86d3-77ec8d4b09a3
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - media
   module:
     - file
     - image
     - media
+  enforced:
+    module:
+      - media
 id: media.field_media_image
 field_name: field_media_image
 entity_type: media
 type: image
 settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
   default_image:
     uuid: null
     alt: ''
     title: ''
     width: null
     height: null
-  target_type: file
-  display_field: false
-  display_default: false
-  uri_scheme: public
 module: image
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.media.field_media_oembed_video.yml
+++ b/conf/drupal/config/field.storage.media.field_media_oembed_video.yml
@@ -10,8 +10,8 @@ entity_type: media
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.node.eventbrite_event_id.yml
+++ b/conf/drupal/config/field.storage.node.eventbrite_event_id.yml
@@ -12,8 +12,8 @@ entity_type: node
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.node.eventbrite_event_status.yml
+++ b/conf/drupal/config/field.storage.node.eventbrite_event_status.yml
@@ -12,8 +12,8 @@ entity_type: node
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.node.field_attendee_id.yml
+++ b/conf/drupal/config/field.storage.node.field_attendee_id.yml
@@ -14,8 +14,8 @@ entity_type: node
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.node.field_first_name.yml
+++ b/conf/drupal/config/field.storage.node.field_first_name.yml
@@ -14,8 +14,8 @@ entity_type: node
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.node.field_image.yml
+++ b/conf/drupal/config/field.storage.node.field_image.yml
@@ -13,6 +13,9 @@ field_name: field_image
 entity_type: node
 type: image
 settings:
+  target_type: file
+  display_field: false
+  display_default: false
   uri_scheme: public
   default_image:
     uuid: null
@@ -20,9 +23,6 @@ settings:
     title: ''
     width: null
     height: null
-  target_type: file
-  display_field: false
-  display_default: false
 module: image
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.node.field_job_location.yml
+++ b/conf/drupal/config/field.storage.node.field_job_location.yml
@@ -10,8 +10,8 @@ entity_type: node
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.node.field_job_title.yml
+++ b/conf/drupal/config/field.storage.node.field_job_title.yml
@@ -14,8 +14,8 @@ entity_type: node
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.node.field_last_name.yml
+++ b/conf/drupal/config/field.storage.node.field_last_name.yml
@@ -14,8 +14,8 @@ entity_type: node
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.node.field_name.yml
+++ b/conf/drupal/config/field.storage.node.field_name.yml
@@ -14,8 +14,8 @@ entity_type: node
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.node.field_organization.yml
+++ b/conf/drupal/config/field.storage.node.field_organization.yml
@@ -14,8 +14,8 @@ entity_type: node
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.node.field_presenter_slides.yml
+++ b/conf/drupal/config/field.storage.node.field_presenter_slides.yml
@@ -14,10 +14,10 @@ field_name: field_presenter_slides
 entity_type: node
 type: file
 settings:
+  target_type: file
   display_field: true
   display_default: true
   uri_scheme: public
-  target_type: file
 module: file
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.node.field_ticket_state.yml
+++ b/conf/drupal/config/field.storage.node.field_ticket_state.yml
@@ -14,8 +14,8 @@ entity_type: node
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.node.field_ticket_type.yml
+++ b/conf/drupal/config/field.storage.node.field_ticket_type.yml
@@ -14,8 +14,8 @@ entity_type: node
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.paragraph.field_paragraph_image.yml
+++ b/conf/drupal/config/field.storage.paragraph.field_paragraph_image.yml
@@ -11,6 +11,9 @@ field_name: field_paragraph_image
 entity_type: paragraph
 type: image
 settings:
+  target_type: file
+  display_field: false
+  display_default: false
   uri_scheme: public
   default_image:
     uuid: ''
@@ -18,9 +21,6 @@ settings:
     title: ''
     width: null
     height: null
-  target_type: file
-  display_field: false
-  display_default: false
 module: image
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.taxonomy_term.field_event_id.yml
+++ b/conf/drupal/config/field.storage.taxonomy_term.field_event_id.yml
@@ -14,8 +14,8 @@ entity_type: taxonomy_term
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.taxonomy_term.field_event_status.yml
+++ b/conf/drupal/config/field.storage.taxonomy_term.field_event_status.yml
@@ -14,8 +14,8 @@ entity_type: taxonomy_term
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.taxonomy_term.field_image.yml
+++ b/conf/drupal/config/field.storage.taxonomy_term.field_image.yml
@@ -11,6 +11,9 @@ field_name: field_image
 entity_type: taxonomy_term
 type: image
 settings:
+  target_type: file
+  display_field: false
+  display_default: false
   uri_scheme: public
   default_image:
     uuid: ''
@@ -18,9 +21,6 @@ settings:
     title: ''
     width: null
     height: null
-  target_type: file
-  display_field: false
-  display_default: false
 module: image
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.taxonomy_term.field_tito_slug.yml
+++ b/conf/drupal/config/field.storage.taxonomy_term.field_tito_slug.yml
@@ -14,8 +14,8 @@ entity_type: taxonomy_term
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.user.field_company_logo.yml
+++ b/conf/drupal/config/field.storage.user.field_company_logo.yml
@@ -15,6 +15,9 @@ field_name: field_company_logo
 entity_type: user
 type: image
 settings:
+  target_type: file
+  display_field: false
+  display_default: false
   uri_scheme: public
   default_image:
     uuid: ''
@@ -22,9 +25,6 @@ settings:
     title: ''
     width: null
     height: null
-  target_type: file
-  display_field: false
-  display_default: false
 module: image
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.user.field_mailing_list.yml
+++ b/conf/drupal/config/field.storage.user.field_mailing_list.yml
@@ -11,8 +11,8 @@ entity_type: user
 type: mailchimp_lists_subscription
 settings:
   mc_list_id: 12c897b018
-  double_opt_in: 0
-  send_welcome: 0
+  double_opt_in: false
+  send_welcome: false
 module: mailchimp_lists
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.user.field_title.yml
+++ b/conf/drupal/config/field.storage.user.field_title.yml
@@ -10,8 +10,8 @@ entity_type: user
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.user.field_twitter.yml
+++ b/conf/drupal/config/field.storage.user.field_twitter.yml
@@ -10,8 +10,8 @@ entity_type: user
 type: string
 settings:
   max_length: 255
-  is_ascii: false
   case_sensitive: false
+  is_ascii: false
 module: core
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field.storage.user.user_picture.yml
+++ b/conf/drupal/config/field.storage.user.user_picture.yml
@@ -17,6 +17,9 @@ field_name: user_picture
 entity_type: user
 type: image
 settings:
+  target_type: file
+  display_field: false
+  display_default: false
   uri_scheme: public
   default_image:
     uuid: null
@@ -24,9 +27,6 @@ settings:
     title: ''
     width: null
     height: null
-  target_type: file
-  display_field: false
-  display_default: false
 module: image
 locked: false
 cardinality: 1

--- a/conf/drupal/config/field_ui.settings.yml
+++ b/conf/drupal/config/field_ui.settings.yml
@@ -1,3 +1,3 @@
-field_prefix: field_
 _core:
   default_config_hash: Q1nMi90W6YQxKzZAgJQw7Ag9U4JrsEUwkomF0lhvbIM
+field_prefix: field_

--- a/conf/drupal/config/file.settings.yml
+++ b/conf/drupal/config/file.settings.yml
@@ -1,8 +1,8 @@
+_core:
+  default_config_hash: 8LI-1XgwLt9hYRns_7c81S632d6JhdqXKs4vDheaG6E
 description:
   type: textfield
   length: 128
 icon:
   directory: core/modules/file/icons
-_core:
-  default_config_hash: 8LI-1XgwLt9hYRns_7c81S632d6JhdqXKs4vDheaG6E
 make_unused_managed_files_temporary: false

--- a/conf/drupal/config/filter.settings.yml
+++ b/conf/drupal/config/filter.settings.yml
@@ -1,4 +1,4 @@
-fallback_format: plain_text
-always_show_fallback_choice: false
 _core:
   default_config_hash: FiPjM3WdB__ruFA7B6TLwni_UcZbmek5G4b2dxQItxA
+fallback_format: plain_text
+always_show_fallback_choice: false

--- a/conf/drupal/config/google_analytics.settings.yml
+++ b/conf/drupal/config/google_analytics.settings.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: SMk3vOyh4KT6rXnqkDcNQ51YGpJzRV5hyig5SSIfU6U
 account: UA-60086119-2
 premium: false
 domain_mode: 0
@@ -33,5 +35,3 @@ codesnippet:
 translation_set: false
 cache: false
 debug: false
-_core:
-  default_config_hash: SMk3vOyh4KT6rXnqkDcNQ51YGpJzRV5hyig5SSIfU6U

--- a/conf/drupal/config/honeypot.settings.yml
+++ b/conf/drupal/config/honeypot.settings.yml
@@ -1,10 +1,12 @@
+_core:
+  default_config_hash: 9bVDfWSa_In6VzTXmy04jJ_3ZQobihKjO9isuuUCPaw
+protect_all_forms: false
 unprotected_forms:
   - user_login_form
   - search_form
   - search_block_form
   - views_exposed_form
   - honeypot_settings_form
-protect_all_forms: false
 log: true
 element_name: url
 time_limit: 10
@@ -24,5 +26,3 @@ form_settings:
   node_training_form: true
   node_venue_form: false
   comment_comment_form: true
-_core:
-  default_config_hash: 9bVDfWSa_In6VzTXmy04jJ_3ZQobihKjO9isuuUCPaw

--- a/conf/drupal/config/image.settings.yml
+++ b/conf/drupal/config/image.settings.yml
@@ -1,5 +1,5 @@
+_core:
+  default_config_hash: k-yDFHbqNfpe-Srg4sdCSqaosCl2D8uwyEY5esF8gEw
 preview_image: core/modules/image/sample.png
 allow_insecure_derivatives: false
 suppress_itok_output: false
-_core:
-  default_config_hash: k-yDFHbqNfpe-Srg4sdCSqaosCl2D8uwyEY5esF8gEw

--- a/conf/drupal/config/libraries.settings.yml
+++ b/conf/drupal/config/libraries.settings.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: KKB0aS0aX7OeHfUItthQDDpvK0UAyriE-8Bn5okgPps
 definition:
   local:
     path: 'public://library-definitions'
@@ -6,5 +8,3 @@ definition:
     urls:
       - 'http://cgit.drupalcode.org/libraries_registry/plain/registry/8'
 global_locators: {  }
-_core:
-  default_config_hash: KKB0aS0aX7OeHfUItthQDDpvK0UAyriE-8Bn5okgPps

--- a/conf/drupal/config/mailchimp.settings.yml
+++ b/conf/drupal/config/mailchimp.settings.yml
@@ -1,10 +1,10 @@
+_core:
+  default_config_hash: x8k6uOqmSHPqpp71jYGxHF3_SAs3U-Pha3YCntQIhPU
+api_timeout: 10
 cron: false
 batch_limit: 100
 api_classname: Mailchimp\Mailchimp
 test_mode: false
-_core:
-  default_config_hash: x8k6uOqmSHPqpp71jYGxHF3_SAs3U-Pha3YCntQIhPU
 enable_connected: true
 connected_id: 3c32683d2b85c4b
 connected_paths: '<front>'
-api_timeout: 10

--- a/conf/drupal/config/media.settings.yml
+++ b/conf/drupal/config/media.settings.yml
@@ -1,6 +1,6 @@
+_core:
+  default_config_hash: PlWtVQXY5oKYZqCMPXh6SPamXagn5BoZqgAI8EY9WsY
 icon_base_uri: 'public://media-icons/generic'
 iframe_domain: ''
 oembed_providers_url: 'https://oembed.com/providers.json'
 standalone_url: true
-_core:
-  default_config_hash: PlWtVQXY5oKYZqCMPXh6SPamXagn5BoZqgAI8EY9WsY

--- a/conf/drupal/config/media.type.remote_video.yml
+++ b/conf/drupal/config/media.type.remote_video.yml
@@ -9,10 +9,10 @@ source: 'oembed:video'
 queue_thumbnail_downloads: false
 new_revision: false
 source_configuration:
+  source_field: field_media_oembed_video
   thumbnails_directory: 'public://oembed_thumbnails'
   providers:
     - YouTube
     - Vimeo
-  source_field: field_media_oembed_video
 field_map:
   title: name

--- a/conf/drupal/config/menu_ui.settings.yml
+++ b/conf/drupal/config/menu_ui.settings.yml
@@ -1,3 +1,3 @@
-override_parent_selector: false
 _core:
   default_config_hash: SqMarzIjxC3F8dZo9FEOxfqDKD_sdW1tbcFTV1BA2zU
+override_parent_selector: false

--- a/conf/drupal/config/name.settings.yml
+++ b/conf/drupal/config/name.settings.yml
@@ -1,8 +1,8 @@
+_core:
+  default_config_hash: JCsvMkZ6JYCJ99YViyi8ie9Pf46l5eDF3rX01kl4g2A
 component_required_marker: '*'
-default_format: ((((t+ig)+im)+if)+is)+jc
 sep1: ' '
 sep2: ', '
 sep3: ''
 user_preferred: field_name
-_core:
-  default_config_hash: JCsvMkZ6JYCJ99YViyi8ie9Pf46l5eDF3rX01kl4g2A
+default_format: ((((t+ig)+im)+if)+is)+jc

--- a/conf/drupal/config/node.settings.yml
+++ b/conf/drupal/config/node.settings.yml
@@ -1,3 +1,3 @@
-use_admin_theme: true
 _core:
   default_config_hash: 2OMXCScXUOLSYID9-phjO4q36nnnaMWNUlDxEqZzG1U
+use_admin_theme: true

--- a/conf/drupal/config/node.type.page.yml
+++ b/conf/drupal/config/node.type.page.yml
@@ -18,13 +18,13 @@ third_party_settings:
     fields_display_mode: vertical_tab
     publish_enable: false
     publish_past_date: error
+    publish_past_date_created: false
     publish_required: false
     publish_revision: false
     publish_touch: false
     unpublish_enable: false
     unpublish_required: false
     unpublish_revision: false
-    publish_past_date_created: false
 _core:
   default_config_hash: zhtPXoRcC6REiepM0k16zw__FDW5YOXDR6U2WlldTrs
 name: 'Basic page'

--- a/conf/drupal/config/node.type.topic.yml
+++ b/conf/drupal/config/node.type.topic.yml
@@ -14,13 +14,13 @@ third_party_settings:
     fields_display_mode: vertical_tab
     publish_enable: false
     publish_past_date: error
+    publish_past_date_created: false
     publish_required: false
     publish_revision: false
     publish_touch: false
     unpublish_enable: false
     unpublish_required: false
     unpublish_revision: false
-    publish_past_date_created: false
 name: 'Topic Proposal'
 type: topic
 description: 'Use <em>topic</em> for individual session, keynote, BoF, etc.'

--- a/conf/drupal/config/pathauto.pattern.basic_pages.yml
+++ b/conf/drupal/config/pathauto.pattern.basic_pages.yml
@@ -11,12 +11,12 @@ pattern: '[node:field_event:entity:url:path]/[node:title]'
 selection_criteria:
   fe413bb3-aae4-44fe-87c3-36e63c5130e7:
     id: node_type
-    bundles:
-      page: page
     negate: false
+    uuid: fe413bb3-aae4-44fe-87c3-36e63c5130e7
     context_mapping:
       node: node
-    uuid: fe413bb3-aae4-44fe-87c3-36e63c5130e7
+    bundles:
+      page: page
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/conf/drupal/config/pathauto.pattern.content.yml
+++ b/conf/drupal/config/pathauto.pattern.content.yml
@@ -11,6 +11,10 @@ pattern: '[node:field_event:entity:url:path]/[node:content-type]/[node:title]'
 selection_criteria:
   967e3bfc-632f-4c3d-b18f-91886599bc38:
     id: node_type
+    negate: false
+    uuid: 967e3bfc-632f-4c3d-b18f-91886599bc38
+    context_mapping:
+      node: node
     bundles:
       article: article
       sponsor: sponsor
@@ -18,10 +22,6 @@ selection_criteria:
       topic: topic
       training: training
       venue: venue
-    negate: false
-    context_mapping:
-      node: node
-    uuid: 967e3bfc-632f-4c3d-b18f-91886599bc38
 selection_logic: and
 weight: -7
 relationships: {  }

--- a/conf/drupal/config/pathauto.pattern.events.yml
+++ b/conf/drupal/config/pathauto.pattern.events.yml
@@ -12,12 +12,12 @@ pattern: '[term:root]/[term:name]'
 selection_criteria:
   b927e73e-693b-4e83-9948-308047e4014e:
     id: 'entity_bundle:taxonomy_term'
-    bundles:
-      event: event
     negate: false
+    uuid: b927e73e-693b-4e83-9948-308047e4014e
     context_mapping:
       taxonomy_term: taxonomy_term
-    uuid: b927e73e-693b-4e83-9948-308047e4014e
+    bundles:
+      event: event
 selection_logic: and
 weight: -6
 relationships: {  }

--- a/conf/drupal/config/pathauto.pattern.jobs.yml
+++ b/conf/drupal/config/pathauto.pattern.jobs.yml
@@ -11,12 +11,12 @@ pattern: '/jobs/[node:field_sponsor_company]/[node:title]'
 selection_criteria:
   1743f797-5c39-4618-8a3b-09c10dea8b21:
     id: node_type
-    bundles:
-      job: job
     negate: false
+    uuid: 1743f797-5c39-4618-8a3b-09c10dea8b21
     context_mapping:
       node: node
-    uuid: 1743f797-5c39-4618-8a3b-09c10dea8b21
+    bundles:
+      job: job
 selection_logic: and
 weight: -10
 relationships: {  }

--- a/conf/drupal/config/pathauto.pattern.sponsor_packages.yml
+++ b/conf/drupal/config/pathauto.pattern.sponsor_packages.yml
@@ -12,12 +12,12 @@ pattern: '/sponsor/package/[term:name]'
 selection_criteria:
   e2625ac6-345e-491d-a480-1c0c4d09722a:
     id: 'entity_bundle:taxonomy_term'
-    bundles:
-      sponsor_packages: sponsor_packages
     negate: false
+    uuid: e2625ac6-345e-491d-a480-1c0c4d09722a
     context_mapping:
       taxonomy_term: taxonomy_term
-    uuid: e2625ac6-345e-491d-a480-1c0c4d09722a
+    bundles:
+      sponsor_packages: sponsor_packages
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/conf/drupal/config/pathauto.settings.yml
+++ b/conf/drupal/config/pathauto.settings.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: GcMSgi6uAfG5R_FGEsWUVCvRPkNIzPUH2bNVcx6H0JA
 enabled_entity_types:
   - user
 punctuation:
@@ -11,8 +13,6 @@ reduce_ascii: false
 case: true
 ignore_words: 'a, an, as, at, before, but, by, for, from, is, in, into, like, of, off, on, onto, per, since, than, the, this, that, to, up, via, with'
 update_action: 2
-_core:
-  default_config_hash: GcMSgi6uAfG5R_FGEsWUVCvRPkNIzPUH2bNVcx6H0JA
 safe_tokens:
   - alias
   - alias

--- a/conf/drupal/config/r4032login.settings.yml
+++ b/conf/drupal/config/r4032login.settings.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: 0f9QAstx6Dyy5Z49L0a6pO8MlIl1SNBalUWB9lGnzj8
 display_denied_message: true
 access_denied_message: 'Access denied. You must log in to view this page.'
 access_denied_message_type: error
@@ -5,5 +7,3 @@ redirect_authenticated_users_to: ''
 user_login_path: /user/login
 default_redirect_code: 302
 match_noredirect_pages: ''
-_core:
-  default_config_hash: 0f9QAstx6Dyy5Z49L0a6pO8MlIl1SNBalUWB9lGnzj8

--- a/conf/drupal/config/recaptcha.settings.yml
+++ b/conf/drupal/config/recaptcha.settings.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: eKR4FfUD7Cp3bXamsCz6GAxh0PCLIZNMa65y2kChIh0
 verify_hostname: false
 use_globally: true
 widget:
@@ -6,5 +8,3 @@ widget:
   size: ''
   tabindex: 0
   noscript: true
-_core:
-  default_config_hash: eKR4FfUD7Cp3bXamsCz6GAxh0PCLIZNMa65y2kChIh0

--- a/conf/drupal/config/redirect.settings.yml
+++ b/conf/drupal/config/redirect.settings.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: FEwQLW1wXW7fiJdG1B2bxW1c_-k6w-r-3V3bSsW6PqM
 auto_redirect: true
 default_status_code: 301
 passthrough_querystring: true
@@ -5,5 +7,3 @@ warning: false
 ignore_admin_path: false
 access_check: false
 route_normalizer_enabled: true
-_core:
-  default_config_hash: FEwQLW1wXW7fiJdG1B2bxW1c_-k6w-r-3V3bSsW6PqM

--- a/conf/drupal/config/scheduler.settings.yml
+++ b/conf/drupal/config/scheduler.settings.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: JOzWPTQNpL0mkZGbvh0o7T1wKYyGfC3DHHiwhjw2YhU
 allow_date_only: true
 date_format: 'Y-m-d H:i:s'
 date_letters: djmnFMyY
@@ -9,6 +11,7 @@ default_publish_past_date: error
 default_publish_required: false
 default_publish_revision: false
 default_publish_touch: false
+default_show_message_after_update: true
 default_time: '00:00:00'
 default_unpublish_enable: false
 default_unpublish_required: false
@@ -17,6 +20,3 @@ lightweight_cron_access_key: 8b703e5a96f3fd600bcc
 log: true
 time_letters: hHgGisaA
 time_only_format: 'H:i:s'
-_core:
-  default_config_hash: JOzWPTQNpL0mkZGbvh0o7T1wKYyGfC3DHHiwhjw2YhU
-default_show_message_after_update: true

--- a/conf/drupal/config/search.settings.yml
+++ b/conf/drupal/config/search.settings.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: hvVxL1G-ZCxaq32IZws0YsfuhvaDiQE_np-0g35KjUk
 and_or_limit: 7
 default_page: node_search
 index:
@@ -18,5 +20,3 @@ index:
     em: 3
     a: 10
 logging: false
-_core:
-  default_config_hash: hvVxL1G-ZCxaq32IZws0YsfuhvaDiQE_np-0g35KjUk

--- a/conf/drupal/config/simple_sitemap.custom_links.default.yml
+++ b/conf/drupal/config/simple_sitemap.custom_links.default.yml
@@ -1,7 +1,7 @@
+_core:
+  default_config_hash: 25hWeYa4sasuJtHqKKcEN_nYiuEC1lMPYHsn5dawJEw
 links:
   -
     path: /
     priority: '1.0'
     changefreq: daily
-_core:
-  default_config_hash: 25hWeYa4sasuJtHqKKcEN_nYiuEC1lMPYHsn5dawJEw

--- a/conf/drupal/config/simple_sitemap.settings.yml
+++ b/conf/drupal/config/simple_sitemap.settings.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: LWI5gcV7qtIl5h1xg7AWMtepAzBAvTaw_TOmsQbw9Tk
 max_links: 2000
 cron_generate: true
 cron_generate_interval: 0
@@ -13,5 +15,3 @@ enabled_entity_types:
   - node
   - taxonomy_term
   - menu_link_content
-_core:
-  default_config_hash: LWI5gcV7qtIl5h1xg7AWMtepAzBAvTaw_TOmsQbw9Tk

--- a/conf/drupal/config/simple_sitemap.variants.default_hreflang.yml
+++ b/conf/drupal/config/simple_sitemap.variants.default_hreflang.yml
@@ -1,6 +1,6 @@
+_core:
+  default_config_hash: nQAXscP-SDpsmqHlQ6u0iBvcuJPrAikb09c3cP2_n0k
 variants:
   default:
     label: Default
     weight: 0
-_core:
-  default_config_hash: nQAXscP-SDpsmqHlQ6u0iBvcuJPrAikb09c3cP2_n0k

--- a/conf/drupal/config/system.action.redirect_delete_action.yml
+++ b/conf/drupal/config/system.action.redirect_delete_action.yml
@@ -2,11 +2,11 @@ uuid: 99d42652-1cf8-4083-91a8-d32352081d8d
 langcode: en
 status: true
 dependencies:
+  module:
+    - redirect
   enforced:
     module:
       - redirect
-  module:
-    - redirect
 _core:
   default_config_hash: QmBeFeWHnYLbMWN48tWZZJmZIHZw0XEWUfxLYZFXhzQ
 id: redirect_delete_action

--- a/conf/drupal/config/system.authorize.yml
+++ b/conf/drupal/config/system.authorize.yml
@@ -1,3 +1,0 @@
-filetransfer_default: null
-_core:
-  default_config_hash: z63ds8M4zPrylEgFRkRcOlfcsXWwfITzjD4cj1kRdfg

--- a/conf/drupal/config/system.cron.yml
+++ b/conf/drupal/config/system.cron.yml
@@ -1,5 +1,5 @@
+_core:
+  default_config_hash: 05U0n1_8zHYzxEFSWjyHCWuJyhdez2a6Z_aTIXin04E
 threshold:
   requirements_warning: 172800
   requirements_error: 1209600
-_core:
-  default_config_hash: 05U0n1_8zHYzxEFSWjyHCWuJyhdez2a6Z_aTIXin04E

--- a/conf/drupal/config/system.date.yml
+++ b/conf/drupal/config/system.date.yml
@@ -1,11 +1,11 @@
+_core:
+  default_config_hash: V9UurX2GPT05NWKG9f2GWQqFG2TRG8vczidwjpy7Woo
+first_day: 0
 country:
   default: ''
-first_day: 0
 timezone:
   default: America/Chicago
   user:
     configurable: true
-    warn: false
     default: 0
-_core:
-  default_config_hash: V9UurX2GPT05NWKG9f2GWQqFG2TRG8vczidwjpy7Woo
+    warn: false

--- a/conf/drupal/config/system.diff.yml
+++ b/conf/drupal/config/system.diff.yml
@@ -1,5 +1,5 @@
+_core:
+  default_config_hash: 1WanmaEhxW_vM8_5Ktsdntj8MaO9UBHXg0lN603PsWM
 context:
   lines_leading: 2
   lines_trailing: 2
-_core:
-  default_config_hash: 1WanmaEhxW_vM8_5Ktsdntj8MaO9UBHXg0lN603PsWM

--- a/conf/drupal/config/system.file.yml
+++ b/conf/drupal/config/system.file.yml
@@ -1,6 +1,6 @@
+_core:
+  default_config_hash: t48gCU9DzYfjb3bAOIqHLzhL0ChBlXh6_5B5Pyo9t8g
 allow_insecure_uploads: false
 default_scheme: public
 path: {  }
 temporary_maximum_age: 21600
-_core:
-  default_config_hash: t48gCU9DzYfjb3bAOIqHLzhL0ChBlXh6_5B5Pyo9t8g

--- a/conf/drupal/config/system.image.gd.yml
+++ b/conf/drupal/config/system.image.gd.yml
@@ -1,3 +1,3 @@
-jpeg_quality: 75
 _core:
   default_config_hash: eNXaHfkJJUThHeF0nvkoXyPLRrKYGxgHRjORvT4F5rQ
+jpeg_quality: 75

--- a/conf/drupal/config/system.image.yml
+++ b/conf/drupal/config/system.image.yml
@@ -1,3 +1,3 @@
-toolkit: gd
 _core:
   default_config_hash: durWHaKeBaq4d9Wpi4RqwADj1OufDepcnJuhVLmKN24
+toolkit: gd

--- a/conf/drupal/config/system.logging.yml
+++ b/conf/drupal/config/system.logging.yml
@@ -1,3 +1,3 @@
-error_level: hide
 _core:
   default_config_hash: u3-njszl92FaxjrCMiq0yDcjAfcdx72w1zT1O9dx6aA
+error_level: hide

--- a/conf/drupal/config/system.mail.yml
+++ b/conf/drupal/config/system.mail.yml
@@ -1,5 +1,5 @@
+_core:
+  default_config_hash: rYgt7uhPafP2ngaN_ZUPFuyI4KdE0zU868zLNSlzKoE
 interface:
   default: php_mail
   webform: webform_php_mail
-_core:
-  default_config_hash: rYgt7uhPafP2ngaN_ZUPFuyI4KdE0zU868zLNSlzKoE

--- a/conf/drupal/config/system.maintenance.yml
+++ b/conf/drupal/config/system.maintenance.yml
@@ -1,4 +1,4 @@
-message: '@site is currently under maintenance. We should be back shortly. Thank you for your patience.'
-langcode: en
 _core:
   default_config_hash: Z5MXifrF77GEAgx0GQ6iWT8wStjFuY8BD9OruofWTJ8
+langcode: en
+message: '@site is currently under maintenance. We should be back shortly. Thank you for your patience.'

--- a/conf/drupal/config/system.performance.yml
+++ b/conf/drupal/config/system.performance.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: b2cssrj-lOmATIbdehfCqfCFgVR0qCdxxWhwqa2KBVQ
 cache:
   page:
     max_age: 0
@@ -13,5 +15,3 @@ js:
   preprocess: true
   gzip: true
 stale_file_threshold: 2592000
-_core:
-  default_config_hash: b2cssrj-lOmATIbdehfCqfCFgVR0qCdxxWhwqa2KBVQ

--- a/conf/drupal/config/system.rss.yml
+++ b/conf/drupal/config/system.rss.yml
@@ -1,8 +1,4 @@
-channel:
-  description: ''
-items:
-  limit: 10
-  view_mode: rss
-langcode: en
 _core:
   default_config_hash: TlH7NNk46phfxu1mSUfwg1C0YqaGsUCeD4l9JQnQlDU
+items:
+  view_mode: rss

--- a/conf/drupal/config/system.site.yml
+++ b/conf/drupal/config/system.site.yml
@@ -1,3 +1,6 @@
+_core:
+  default_config_hash: yXadRE77Va-G6dxhd2kPYapAvbnSvTF6hO4oXiOEynI
+langcode: en
 uuid: 4e8b0d7f-53e9-45f1-9a7c-7188d45194bd
 name: MidCamp
 mail: info@midcamp.org
@@ -8,8 +11,5 @@ page:
   front: /taxonomy/term/234
 admin_compact_mode: false
 weight_select_max: 100
-langcode: en
 default_langcode: en
-_core:
-  default_config_hash: yXadRE77Va-G6dxhd2kPYapAvbnSvTF6hO4oXiOEynI
 mail_notification: ''

--- a/conf/drupal/config/system.theme.global.yml
+++ b/conf/drupal/config/system.theme.global.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: 9rAU4Pku7eMBQxauQqAgjzlcicFZ2As6zEa6zvTlCB8
 favicon:
   mimetype: image/vnd.microsoft.icon
   path: ''
@@ -12,5 +14,3 @@ logo:
   path: ''
   url: ''
   use_default: true
-_core:
-  default_config_hash: 9rAU4Pku7eMBQxauQqAgjzlcicFZ2As6zEa6zvTlCB8

--- a/conf/drupal/config/system.theme.yml
+++ b/conf/drupal/config/system.theme.yml
@@ -1,4 +1,4 @@
-admin: seven
-default: hatter
 _core:
   default_config_hash: fOjer9hADYYnbCJVZMFZIIM1azTFWyg84ZkFDHfAbUg
+admin: seven
+default: hatter

--- a/conf/drupal/config/taxonomy.settings.yml
+++ b/conf/drupal/config/taxonomy.settings.yml
@@ -1,5 +1,5 @@
+_core:
+  default_config_hash: zKpaWT6cJc1tVQQaTqatGELaCqU_oyRym6zTl27Yias
 maintain_index_table: true
 override_selector: false
 terms_per_page_admin: 100
-_core:
-  default_config_hash: zKpaWT6cJc1tVQQaTqatGELaCqU_oyRym6zTl27Yias

--- a/conf/drupal/config/text.settings.yml
+++ b/conf/drupal/config/text.settings.yml
@@ -1,3 +1,3 @@
-default_summary_length: 600
 _core:
   default_config_hash: Bkewb77RBOK3_aXMPsp8p87gbc03NvmC5gBLzPl7hVA
+default_summary_length: 600

--- a/conf/drupal/config/tour.tour.honeypot.yml
+++ b/conf/drupal/config/tour.tour.honeypot.yml
@@ -19,49 +19,44 @@ tips:
     label: Honeypot
     weight: -10
     body: "Congratulations on installing Honeypot on your site! With just a few clicks, you can have your site well-protected against automated spam bots.\r\n\r\nClick Next to be guided through this configuration page."
-    location: top
+    position: top-start
   protect-all-forms:
     id: protect-all-forms
     plugin: text
     label: 'Protect all forms'
     weight: -9
-    attributes:
-      data-id: edit-protect-all-forms
     body: "Protecting all the forms is the easiest way to quickly cut down on spam on your site, but doing this disables Drupal's caching for every page where a form is displayed.\r\n\r\nNote: If you have the honeypot time limit enabled, this option may cause issues with Drupal Commerce product forms or similarly-sparse forms that are able to be completed in a very short time."
-    location: bottom
+    selector: '#edit-protect-all-forms'
+    position: bottom-start
   log-blocked-form-submissions:
     id: log-blocked-form-submissions
     plugin: text
     label: 'Log blocked form submissions'
     weight: -8
-    attributes:
-      data-id: edit-log
     body: 'Check this box to log every form submission using watchdog. If you have Database Logging enabled, you can view these log entries in the Recent log messages page under Reports.'
-    location: bottom
+    selector: '#edit-log'
+    position: bottom-start
   honeypot-element-name:
     id: honeypot-element-name
     plugin: text
     label: 'Honeypot Element Name'
     weight: -7
-    attributes:
-      data-id: edit-element-name
     body: 'Spam bots typically fill out any field they believe will help get links back to their site, so tempting them with a field named something like ''url'', ''homepage'', or ''link'' makes it hard for them to resist filling in the field—and easy to catch them in the trap and reject their submissions!'
-    location: top
+    selector: '#edit-element-name'
+    position: top-start
   honeypot-time-limit:
     id: honeypot-time-limit
     plugin: text
     label: 'Honeypot Time Limit'
     weight: -6
-    attributes:
-      data-id: edit-time-limit
     body: 'If you enter a positive value, Honeypot will require that all protected forms take at least that many seconds long to fill out. Most forms take at least 5-10 seconds to complete (if you''re a human), so setting this to a value < 5 will help protect against spam bots. Set to 0 to disable.'
-    location: top
+    selector: '#edit-time-limit'
+    position: top-start
   honeypot-form-specific-settings:
     id: honeypot-form-specific-settings
     plugin: text
     label: 'Honeypot form-specific settings'
     weight: -5
-    attributes:
-      data-id: edit-form-settings
     body: 'If you would like to choose particular forms to be protected by Honeypot, check the forms you wish to protect in this section. Most common types of forms are available for protection.'
-    location: top
+    selector: '#edit-form-settings'
+    position: top-start

--- a/conf/drupal/config/tour.tour.views-ui.yml
+++ b/conf/drupal/config/tour.tour.views-ui.yml
@@ -19,79 +19,70 @@ tips:
     id: views-main
     plugin: text
     label: 'Manage view settings'
-    body: 'View or edit the configuration.'
     weight: 1
+    body: 'View or edit the configuration.'
   views-ui-displays:
     id: views-ui-displays
     plugin: text
     label: 'Displays in this view'
-    body: 'A display is a way of outputting the results, e.g., as a page or a block. A view can contain multiple displays, which are listed here. The active display is highlighted.'
     weight: 2
-    attributes:
-      data-id: views-display-top
+    body: 'A display is a way of outputting the results, e.g., as a page or a block. A view can contain multiple displays, which are listed here. The active display is highlighted.'
+    selector: '#views-display-top'
   views-ui-view-admin:
     id: views-ui-view-admin
     plugin: text
     label: 'View administration'
-    body: 'Perform administrative tasks, including adding a description and creating a clone. Click the drop-down button to view the available options.'
     weight: 3
-    location: left
-    attributes:
-      data-id: views-display-extra-actions
+    body: 'Perform administrative tasks, including adding a description and creating a clone. Click the drop-down button to view the available options.'
+    selector: '#views-display-extra-actions'
+    position: left-start
   views-ui-format:
     id: views-ui-format
     plugin: text
     label: 'Output format'
-    body: 'Choose how to output results. E.g., choose <em>Content</em> to output each item completely, using your configured display settings. Or choose <em>Fields</em>, which allows you to output only specific fields for each result. Additional formats can be added by installing modules to <em>extend</em> Drupal''s base functionality.'
     weight: 4
-    attributes:
-      data-class: views-ui-display-tab-bucket.format
+    body: 'Choose how to output results. E.g., choose <em>Content</em> to output each item completely, using your configured display settings. Or choose <em>Fields</em>, which allows you to output only specific fields for each result. Additional formats can be added by installing modules to <em>extend</em> Drupal''s base functionality.'
+    selector: .views-ui-display-tab-bucket.format
   views-ui-fields:
     id: views-ui-fields
     plugin: text
     label: Fields
-    body: 'If this view uses fields, they are listed here. You can click on a field to configure it.'
     weight: 5
-    attributes:
-      data-class: views-ui-display-tab-bucket.field
+    body: 'If this view uses fields, they are listed here. You can click on a field to configure it.'
+    selector: .views-ui-display-tab-bucket.field
   views-ui-filter:
     id: views-ui-filter
     plugin: text
     label: 'Filter your view'
-    body: 'Add filters to limit the results in the output. E.g., to only show content that is <em>published</em>, you would add a filter for <em>Published</em> and select <em>Yes</em>.'
     weight: 6
-    attributes:
-      data-class: views-ui-display-tab-bucket.filter
+    body: 'Add filters to limit the results in the output. E.g., to only show content that is <em>published</em>, you would add a filter for <em>Published</em> and select <em>Yes</em>.'
+    selector: .views-ui-display-tab-bucket.filter
   views-ui-filter-operations:
     id: views-ui-filter-operations
     plugin: text
     label: 'Filter actions'
-    body: 'Add, rearrange or remove filters.'
     weight: 7
-    attributes:
-      data-class: 'views-ui-display-tab-bucket.filter .dropbutton-widget'
+    body: 'Add, rearrange or remove filters.'
+    selector: '.views-ui-display-tab-bucket.filter .dropbutton-widget'
   views-ui-sorts:
     id: views-ui-sorts
     plugin: text
     label: 'Sort Criteria'
-    body: 'Control the order in which the results are output. Click on an active sort rule to configure it.'
     weight: 8
-    attributes:
-      data-class: views-ui-display-tab-bucket.sort
+    body: 'Control the order in which the results are output. Click on an active sort rule to configure it.'
+    selector: .views-ui-display-tab-bucket.sort
   views-ui-sorts-operations:
     id: views-ui-sorts-operations
     plugin: text
     label: 'Sort actions'
-    body: 'Add, rearrange or remove sorting rules.'
     weight: 9
-    attributes:
-      data-class: 'views-ui-display-tab-bucket.sort .dropbutton-widget'
+    body: 'Add, rearrange or remove sorting rules.'
+    selector: '.views-ui-display-tab-bucket.sort .dropbutton-widget'
   views-ui-preview:
     id: views-ui-preview
     plugin: text
     label: Preview
-    body: 'Show a preview of the view output.'
     weight: 10
-    location: left
-    attributes:
-      data-id: preview-submit
+    body: 'Show a preview of the view output.'
+    selector: '#preview-submit'
+    position: left-start

--- a/conf/drupal/config/update.settings.yml
+++ b/conf/drupal/config/update.settings.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: 2QzULf0zovJQx3J06Y9rufzzfi-CY2CTTlEfJJh2Qyw
 check:
   disabled_extensions: false
   interval_days: 1
@@ -5,5 +7,3 @@ fetch:
   url: ''
   max_attempts: 2
   timeout: 30
-_core:
-  default_config_hash: 2QzULf0zovJQx3J06Y9rufzzfi-CY2CTTlEfJJh2Qyw

--- a/conf/drupal/config/upgrade_status.settings.yml
+++ b/conf/drupal/config/upgrade_status.settings.yml
@@ -1,3 +1,3 @@
-paths_per_scan: 30
 _core:
   default_config_hash: BqkUHiXXGvu2L7NR_nblxtP6f03MdD16XSMWwVM0QEc
+paths_per_scan: 30

--- a/conf/drupal/config/user.flood.yml
+++ b/conf/drupal/config/user.flood.yml
@@ -1,7 +1,7 @@
+_core:
+  default_config_hash: UYfMzeP1S8jKm9PSvxf7nQNe8DsNS-3bc2WSNNXBQWs
 uid_only: false
 ip_limit: 50
 ip_window: 3600
 user_limit: 5
 user_window: 21600
-_core:
-  default_config_hash: UYfMzeP1S8jKm9PSvxf7nQNe8DsNS-3bc2WSNNXBQWs

--- a/conf/drupal/config/user.mail.yml
+++ b/conf/drupal/config/user.mail.yml
@@ -1,30 +1,30 @@
-cancel_confirm:
-  body: "[user:display-name],\r\n\r\nA request to cancel your account has been made at [site:name].\r\n\r\nYou may now cancel your account on [site:url-brief] by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:cancel-url]\r\n\r\nNOTE: The cancellation of your account is not reversible.\r\n\r\nThis link expires in one day and nothing will happen if it is not used.\r\n\r\n--  [site:name] team"
-  subject: 'Account cancellation request for [user:display-name] at [site:name]'
-password_reset:
-  body: "[user:display-name],\r\n\r\nA request to reset the password for your account has been made at [site:name].\r\n\r\nYou may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password. It expires after one day and nothing will happen if it's not used.\r\n\r\n--  [site:name] team"
-  subject: 'Replacement login information for [user:display-name] at [site:name]'
-register_admin_created:
-  body: "[user:display-name],\r\n\r\nA site administrator at [site:name] has created an account for you. You may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\r\n\r\nusername: [user:name]\r\npassword: Your password\r\n\r\n--  [site:name] team"
-  subject: 'An administrator created an account for you at [site:name]'
-register_no_approval_required:
-  body: "[user:display-name],\r\n\r\nThank you for registering at [site:name]. You may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\r\n\r\nusername: [user:name]\r\npassword: Your password\r\n\r\n--  [site:name] team"
-  subject: 'Account details for [user:display-name] at [site:name]'
-register_pending_approval:
-  body: "[user:display-name],\r\n\r\nThank you for registering at [site:name]. Your application for an account is currently pending approval. Once it has been approved, you will receive another email containing information about how to log in, set your password, and other details.\r\n\r\n\r\n--  [site:name] team"
-  subject: 'Account details for [user:display-name] at [site:name] (pending admin approval)'
-register_pending_approval_admin:
-  body: "[user:display-name] has applied for an account.\r\n\r\n[user:edit-url]"
-  subject: 'Account details for [user:display-name] at [site:name] (pending admin approval)'
-status_activated:
-  body: "[user:display-name],\r\n\r\nYour account at [site:name] has been activated.\r\n\r\nYou may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\r\n\r\nusername: [user:account-name]\r\npassword: Your password\r\n\r\n--  [site:name] team"
-  subject: 'Account details for [user:display-name] at [site:name] (approved)'
-status_blocked:
-  body: "[user:display-name],\r\n\r\nYour account on [site:name] has been blocked.\r\n\r\n--  [site:name] team"
-  subject: 'Account details for [user:display-name] at [site:name] (blocked)'
-status_canceled:
-  body: "[user:display-name],\r\n\r\nYour account on [site:name] has been canceled.\r\n\r\n--  [site:name] team"
-  subject: 'Account details for [user:display-name] at [site:name] (canceled)'
-langcode: en
 _core:
   default_config_hash: m4J3ROov32OEquRYGLbx3SpdDGuqx9l_zJtNvihqdCg
+langcode: en
+cancel_confirm:
+  subject: 'Account cancellation request for [user:display-name] at [site:name]'
+  body: "[user:display-name],\r\n\r\nA request to cancel your account has been made at [site:name].\r\n\r\nYou may now cancel your account on [site:url-brief] by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:cancel-url]\r\n\r\nNOTE: The cancellation of your account is not reversible.\r\n\r\nThis link expires in one day and nothing will happen if it is not used.\r\n\r\n--  [site:name] team"
+password_reset:
+  subject: 'Replacement login information for [user:display-name] at [site:name]'
+  body: "[user:display-name],\r\n\r\nA request to reset the password for your account has been made at [site:name].\r\n\r\nYou may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password. It expires after one day and nothing will happen if it's not used.\r\n\r\n--  [site:name] team"
+register_admin_created:
+  subject: 'An administrator created an account for you at [site:name]'
+  body: "[user:display-name],\r\n\r\nA site administrator at [site:name] has created an account for you. You may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\r\n\r\nusername: [user:name]\r\npassword: Your password\r\n\r\n--  [site:name] team"
+register_no_approval_required:
+  subject: 'Account details for [user:display-name] at [site:name]'
+  body: "[user:display-name],\r\n\r\nThank you for registering at [site:name]. You may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\r\n\r\nusername: [user:name]\r\npassword: Your password\r\n\r\n--  [site:name] team"
+register_pending_approval:
+  subject: 'Account details for [user:display-name] at [site:name] (pending admin approval)'
+  body: "[user:display-name],\r\n\r\nThank you for registering at [site:name]. Your application for an account is currently pending approval. Once it has been approved, you will receive another email containing information about how to log in, set your password, and other details.\r\n\r\n\r\n--  [site:name] team"
+register_pending_approval_admin:
+  subject: 'Account details for [user:display-name] at [site:name] (pending admin approval)'
+  body: "[user:display-name] has applied for an account.\r\n\r\n[user:edit-url]"
+status_activated:
+  subject: 'Account details for [user:display-name] at [site:name] (approved)'
+  body: "[user:display-name],\r\n\r\nYour account at [site:name] has been activated.\r\n\r\nYou may now log in by clicking this link or copying and pasting it into your browser:\r\n\r\n[user:one-time-login-url]\r\n\r\nThis link can only be used once to log in and will lead you to a page where you can set your password.\r\n\r\nAfter setting your password, you will be able to log in at [site:login-url] in the future using:\r\n\r\nusername: [user:account-name]\r\npassword: Your password\r\n\r\n--  [site:name] team"
+status_blocked:
+  subject: 'Account details for [user:display-name] at [site:name] (blocked)'
+  body: "[user:display-name],\r\n\r\nYour account on [site:name] has been blocked.\r\n\r\n--  [site:name] team"
+status_canceled:
+  subject: 'Account details for [user:display-name] at [site:name] (canceled)'
+  body: "[user:display-name],\r\n\r\nYour account on [site:name] has been canceled.\r\n\r\n--  [site:name] team"

--- a/conf/drupal/config/user.role.anonymous.yml
+++ b/conf/drupal/config/user.role.anonymous.yml
@@ -1,7 +1,17 @@
 uuid: cca12b62-9ecd-4386-be4b-e194282a35aa
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - filter.format.restricted_html
+  module:
+    - comment
+    - contact
+    - field_permissions
+    - filter
+    - media
+    - search
+    - system
 _core:
   default_config_hash: j5zLMOdJBqC0bMvSdth5UebkprJB8g_2FXHqhfpJzow
 id: anonymous

--- a/conf/drupal/config/user.role.authenticated.yml
+++ b/conf/drupal/config/user.role.authenticated.yml
@@ -1,7 +1,21 @@
 uuid: 13219806-f24b-4e5e-b746-5b3c09094513
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - filter.format.basic_html
+    - filter.format.restricted_html
+    - node.type.topic
+  module:
+    - comment
+    - contact
+    - field_permissions
+    - filter
+    - media
+    - node
+    - search
+    - shortcut
+    - system
 _core:
   default_config_hash: dJ0L2DNSj5q6XVZAGsuVDpJTh5UeYkIPwKrUOOpr8YI
 id: authenticated
@@ -19,10 +33,6 @@ permissions:
   - 'post comments'
   - 'search content'
   - 'skip comment approval'
-  - 'use session_proposal transition create_new_draft'
-  - 'use session_proposal transition submitted_proposal'
-  - 'use session_review transition create_new_draft'
-  - 'use session_review transition submit_for_review'
   - 'use text format basic_html'
   - 'use text format basic_html'
   - 'use text format restricted_html'
@@ -33,7 +43,6 @@ permissions:
   - 'view field_schedule_time'
   - 'view field_transcript'
   - 'view field_video'
-  - 'view latest version'
   - 'view media'
   - 'view own field_accepted_confirmed'
   - 'view own field_feedback_form'

--- a/conf/drupal/config/user.role.content_editor.yml
+++ b/conf/drupal/config/user.role.content_editor.yml
@@ -1,7 +1,38 @@
 uuid: fb322d03-a0ea-4030-80e3-5a20f94fbb4a
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - filter.format.full_html
+    - filter.format.mailchimp_campaign
+    - node.type.article
+    - node.type.job
+    - node.type.page
+    - node.type.sponsor
+    - node.type.summit
+    - node.type.topic
+    - node.type.training
+    - node.type.venue
+    - taxonomy.vocabulary.event
+    - taxonomy.vocabulary.sponsor_packages
+    - taxonomy.vocabulary.tags
+    - taxonomy.vocabulary.topic_type
+  module:
+    - block_content
+    - comment
+    - contact
+    - field_permissions
+    - field_ui
+    - file
+    - filter
+    - node
+    - paragraphs
+    - path
+    - quickedit
+    - system
+    - taxonomy
+    - toolbar
+    - tour
 id: content_editor
 label: 'Content Editor'
 weight: -7
@@ -94,8 +125,6 @@ permissions:
   - 'edit terms in sponsor_packages'
   - 'edit terms in tags'
   - 'edit terms in topic_type'
-  - 'masquerade as authenticated'
-  - 'masquerade as speaker'
   - 'revert all revisions'
   - 'revert article revisions'
   - 'revert job revisions'
@@ -106,20 +135,11 @@ permissions:
   - 'revert training revisions'
   - 'revert venue revisions'
   - 'skip comment approval'
-  - 'use editorial transition archive'
-  - 'use editorial transition archived_published'
-  - 'use editorial transition create_new_draft'
-  - 'use editorial transition publish'
-  - 'use session_proposal transition publish'
-  - 'use session_proposal transition submitted_proposal'
-  - 'use session_review transition accept_session'
   - 'use text format full_html'
   - 'use text format mailchimp_campaign'
   - 'view all revisions'
-  - 'view any unpublished content'
   - 'view article revisions'
   - 'view job revisions'
-  - 'view latest version'
   - 'view own field_captions'
   - 'view page revisions'
   - 'view sponsor revisions'

--- a/conf/drupal/config/user.role.organizer.yml
+++ b/conf/drupal/config/user.role.organizer.yml
@@ -1,7 +1,9 @@
 uuid: d79f367c-c1f4-424c-8588-fff1754f9ff1
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - field_permissions
 id: organizer
 label: Organizer
 weight: 4
@@ -13,9 +15,5 @@ permissions:
   - 'edit field_transcript'
   - 'edit own field_captions'
   - 'edit own field_transcript'
-  - 'use session_proposal transition publish'
-  - 'use session_proposal transition submitted_proposal'
-  - 'view any unpublished content'
-  - 'view latest version'
   - 'view own field_captions'
   - 'view own field_transcript'

--- a/conf/drupal/config/user.role.speaker.yml
+++ b/conf/drupal/config/user.role.speaker.yml
@@ -1,7 +1,12 @@
 uuid: 01bdd8f2-e08b-4ff9-bd23-c8ac6b5e38d9
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - node.type.topic
+  module:
+    - field_permissions
+    - node
 id: speaker
 label: Speaker
 weight: -8
@@ -9,4 +14,3 @@ is_admin: null
 permissions:
   - 'edit own field_video'
   - 'edit own topic content'
-  - 'use session_proposal transition submitted_proposal'

--- a/conf/drupal/config/user.role.sponsor.yml
+++ b/conf/drupal/config/user.role.sponsor.yml
@@ -1,7 +1,12 @@
 uuid: 1c8fdf4f-072b-4764-a8f9-7e0721519ff3
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - node.type.job
+    - node.type.sponsor
+  module:
+    - node
 id: sponsor
 label: Sponsor
 weight: 3

--- a/conf/drupal/config/user.settings.yml
+++ b/conf/drupal/config/user.settings.yml
@@ -1,3 +1,6 @@
+_core:
+  default_config_hash: r4kwhOM0IWXVMUZDz744Yc16EOh37ZhYbA8kGOhSmLk
+langcode: en
 anonymous: Anonymous
 verify_mail: true
 notify:
@@ -13,6 +16,3 @@ register: admin_only
 cancel_method: user_cancel_block_unpublish
 password_reset_timeout: 86400
 password_strength: true
-langcode: en
-_core:
-  default_config_hash: r4kwhOM0IWXVMUZDz744Yc16EOh37ZhYbA8kGOhSmLk

--- a/conf/drupal/config/views.settings.yml
+++ b/conf/drupal/config/views.settings.yml
@@ -1,3 +1,5 @@
+_core:
+  default_config_hash: RaRd9EIcwA4u3qCSRLL8EnCicbda1kV__ASmVbyehvQ
 display_extenders: {  }
 skip_cache: false
 sql_signature: false
@@ -5,7 +7,7 @@ ui:
   show:
     additional_queries: false
     advanced_column: false
-    master_display: false
+    default_display: false
     performance_statistics: false
     preview_information: true
     sql_query:
@@ -44,5 +46,3 @@ field_rewrite_elements:
   ins: INS
   q: Q
   s: S
-_core:
-  default_config_hash: RaRd9EIcwA4u3qCSRLL8EnCicbda1kV__ASmVbyehvQ

--- a/conf/drupal/config/views.view.archive.yml
+++ b/conf/drupal/config/views.view.archive.yml
@@ -23,22 +23,26 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      query:
-        type: views_query
-        options:
-          query_comment: ''
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_tags: {  }
       title: 'Monthly archive'
-      access:
-        type: perm
+      fields: {  }
+      pager:
+        type: mini
         options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
+          offset: 0
+          items_per_page: 10
+          total_pages: 0
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
       exposed_form:
         type: basic
         options:
@@ -49,74 +53,65 @@ display:
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
-      pager:
-        type: mini
+      access:
+        type: perm
         options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: 0
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
       sorts:
         created:
           id: created
           table: node_field_data
           field: created
-          order: DESC
-          plugin_id: date
           relationship: none
           group_type: group
           admin_label: ''
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
           entity_type: node
           entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
       arguments:
         created_year_month:
           id: created_year_month
           table: node_field_data
           field: created_year_month
+          entity_type: node
+          plugin_id: date_year_month
           default_action: summary
           exception:
             title_enable: true
           title_enable: true
           title: '{{ arguments.created_year_month }}'
           default_argument_type: fixed
-          summary:
-            sort_order: desc
-            format: default_summary
           summary_options:
             override: true
             items_per_page: 30
+          summary:
+            sort_order: desc
+            format: default_summary
           specify_validation: true
-          plugin_id: date_year_month
-          entity_type: node
       filters:
         status:
           id: status
           table: node_field_data
           field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
           value: '1'
           group: 0
           expose:
             operator: '0'
             operator_limit_selection: false
             operator_list: {  }
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
         langcode:
           id: langcode
           table: node_field_data
@@ -124,6 +119,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
           operator: in
           value:
             '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
@@ -135,6 +133,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -142,8 +142,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -156,9 +154,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: language
-          entity_type: node
-          entity_field: langcode
       style:
         type: default
         options:
@@ -170,20 +165,26 @@ display:
         type: 'entity:node'
         options:
           view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header: {  }
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      fields: {  }
       display_extenders: {  }
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_interface'
         - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
-      max-age: -1
       tags: {  }
   block_1:
     id: block_1
@@ -191,38 +192,38 @@ display:
     display_plugin: block
     position: 1
     display_options:
-      query:
-        type: views_query
-        options: {  }
-      defaults:
-        arguments: false
       arguments:
         created_year_month:
           id: created_year_month
           table: node_field_data
           field: created_year_month
+          entity_type: node
+          plugin_id: date_year_month
           default_action: summary
           exception:
             title_enable: true
           title_enable: true
           title: '{{ arguments.created_year_month }}'
           default_argument_type: fixed
-          summary:
-            format: default_summary
           summary_options:
             items_per_page: 30
+          summary:
+            format: default_summary
           specify_validation: true
-          plugin_id: date_year_month
-          entity_type: node
+      query:
+        type: views_query
+        options: {  }
+      defaults:
+        arguments: false
       display_extenders: {  }
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_interface'
         - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
-      max-age: -1
       tags: {  }
   page_1:
     id: page_1
@@ -233,14 +234,14 @@ display:
       query:
         type: views_query
         options: {  }
-      path: archive
       display_extenders: {  }
+      path: archive
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_interface'
         - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
-      max-age: -1
       tags: {  }

--- a/conf/drupal/config/views.view.attendees.yml
+++ b/conf/drupal/config/views.view.attendees.yml
@@ -20,71 +20,12 @@ base_table: eventbrite_events_attendee
 base_field: id
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: none
-        options: {  }
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 15
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 5
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: 'speaker-item l-3up'
-          default_row_class: true
-      row:
-        type: fields
-        options:
-          default_field_elements: true
-          inline:
-            field_title: field_title
-            field_organization: field_organization
-          separator: ''
-          hide_empty: false
+      title: Attendees
       fields:
         user_picture:
           id: user_picture
@@ -93,6 +34,7 @@ display:
           relationship: assoc_drupal_user
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -137,8 +79,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: ''
             image_link: ''
+            image_style: ''
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -149,7 +91,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         name:
           id: name
           table: eventbrite_events_attendee
@@ -157,6 +98,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: name
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -212,9 +156,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: null
-          entity_field: name
-          plugin_id: field
         job_title:
           id: job_title
           table: eventbrite_events_attendee
@@ -222,6 +163,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: eventbrite_events_attendee
+          entity_field: job_title
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -277,9 +221,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: eventbrite_events_attendee
-          entity_field: job_title
-          plugin_id: field
         field_title:
           id: field_title
           table: user__field_title
@@ -287,6 +228,7 @@ display:
           relationship: assoc_drupal_user
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -342,7 +284,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         company:
           id: company
           table: eventbrite_events_attendee
@@ -350,6 +291,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: eventbrite_events_attendee
+          entity_field: company
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -405,9 +349,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: eventbrite_events_attendee
-          entity_field: company
-          plugin_id: field
         field_organization:
           id: field_organization
           table: user__field_organization
@@ -415,6 +356,7 @@ display:
           relationship: assoc_drupal_user
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -470,7 +412,46 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 15
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 5
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
       filters:
         attendee_status:
           id: attendee_status
@@ -479,6 +460,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: eventbrite_events_attendee
+          entity_field: attendee_status
+          plugin_id: string
           operator: not_starts
           value: 'Not Attending'
           group: 1
@@ -489,6 +473,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -496,8 +482,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -510,9 +494,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: eventbrite_events_attendee
-          entity_field: attendee_status
-          plugin_id: string
         ticket_class_name_1:
           id: ticket_class_name_1
           table: eventbrite_events_attendee
@@ -520,6 +501,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: eventbrite_events_attendee
+          entity_field: ticket_class_name
+          plugin_id: string
           operator: '='
           value: 'MidCamp 2019 Regular Admission (March 21-22)'
           group: 2
@@ -530,6 +514,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -537,8 +523,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -551,9 +535,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: eventbrite_events_attendee
-          entity_field: ticket_class_name
-          plugin_id: string
         ticket_class_name:
           id: ticket_class_name
           table: eventbrite_events_attendee
@@ -561,6 +542,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: eventbrite_events_attendee
+          entity_field: ticket_class_name
+          plugin_id: string
           operator: '='
           value: 'MidCamp 2019 Individual Sponsorship (March 21-22)'
           group: 2
@@ -571,6 +555,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -578,8 +564,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -592,14 +576,34 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: eventbrite_events_attendee
-          entity_field: ticket_class_name
-          plugin_id: string
-      sorts: {  }
-      title: Attendees
-      header: {  }
-      footer: {  }
-      empty: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: OR
+          2: OR
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: 'speaker-item l-3up'
+          default_row_class: true
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline:
+            field_title: field_title
+            field_organization: field_organization
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         assoc_drupal_user:
           id: assoc_drupal_user
@@ -608,19 +612,15 @@ display:
           relationship: none
           group_type: group
           admin_label: User
-          required: false
           entity_type: eventbrite_events_attendee
           entity_field: assoc_drupal_user
           plugin_id: standard
-      arguments: {  }
-      display_extenders: {  }
-      group_by: false
-      filter_groups:
-        operator: AND
-        groups:
-          1: OR
-          2: OR
+          required: false
       css_class: cols-3
+      group_by: false
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -632,9 +632,9 @@ display:
         - 'config:field.storage.user.field_title'
         - 'config:field.storage.user.user_picture'
   block_1:
-    display_plugin: block
     id: block_1
     display_title: Block
+    display_plugin: block
     position: 1
     display_options:
       display_extenders: {  }
@@ -649,13 +649,12 @@ display:
         - 'config:field.storage.user.field_title'
         - 'config:field.storage.user.user_picture'
   block_2:
-    display_plugin: block
     id: block_2
     display_title: '2019 Individual Sponsors Block'
+    display_plugin: block
     position: 4
     display_options:
-      display_extenders: {  }
-      display_description: ''
+      title: 'Individual Sponsors'
       filters:
         attendee_status:
           id: attendee_status
@@ -664,6 +663,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: eventbrite_events_attendee
+          entity_field: attendee_status
+          plugin_id: string
           operator: not_starts
           value: 'Not Attending'
           group: 1
@@ -674,6 +676,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -681,8 +685,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -695,9 +697,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: eventbrite_events_attendee
-          entity_field: attendee_status
-          plugin_id: string
         ticket_class_name:
           id: ticket_class_name
           table: eventbrite_events_attendee
@@ -705,6 +704,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: eventbrite_events_attendee
+          entity_field: ticket_class_name
+          plugin_id: string
           operator: '='
           value: 'MidCamp 2019 Individual Sponsorship (March 21-22)'
           group: 2
@@ -715,6 +717,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -722,8 +726,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -736,21 +738,19 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: eventbrite_events_attendee
-          entity_field: ticket_class_name
-          plugin_id: string
-      defaults:
-        filters: false
-        filter_groups: false
-        title: false
-        css_class: false
       filter_groups:
         operator: AND
         groups:
           1: OR
           2: OR
-      title: 'Individual Sponsors'
+      defaults:
+        title: false
+        css_class: false
+        filters: false
+        filter_groups: false
       css_class: 'sponsor-group cols-3'
+      display_description: ''
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -762,23 +762,23 @@ display:
         - 'config:field.storage.user.field_title'
         - 'config:field.storage.user.user_picture'
   page_1:
-    display_plugin: page
     id: page_1
     display_title: '2019 Attendees'
+    display_plugin: page
     position: 2
     display_options:
+      display_description: ''
       display_extenders: {  }
       path: 2019/attendees
       menu:
         type: normal
         title: Attendees
         description: ''
-        expanded: false
-        parent: 'menu_link_content:db3c8044-0b1c-4432-b89f-8a2b03de0754'
         weight: -44
-        context: '0'
+        expanded: false
         menu_name: midcamp-2019-navigation
-      display_description: ''
+        parent: 'menu_link_content:db3c8044-0b1c-4432-b89f-8a2b03de0754'
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:
@@ -790,13 +790,12 @@ display:
         - 'config:field.storage.user.field_title'
         - 'config:field.storage.user.user_picture'
   page_2:
-    display_plugin: page
     id: page_2
     display_title: '2019 Individual Sponsors'
+    display_plugin: page
     position: 3
     display_options:
-      display_extenders: {  }
-      display_description: ''
+      title: 'Individual Sponsors'
       filters:
         attendee_status:
           id: attendee_status
@@ -805,6 +804,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: eventbrite_events_attendee
+          entity_field: attendee_status
+          plugin_id: string
           operator: not_starts
           value: 'Not Attending'
           group: 1
@@ -815,6 +817,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -822,8 +826,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -836,9 +838,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: eventbrite_events_attendee
-          entity_field: attendee_status
-          plugin_id: string
         ticket_class_name:
           id: ticket_class_name
           table: eventbrite_events_attendee
@@ -846,6 +845,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: eventbrite_events_attendee
+          entity_field: ticket_class_name
+          plugin_id: string
           operator: '='
           value: 'MidCamp 2019 Individual Sponsorship (March 21-22)'
           group: 2
@@ -856,6 +858,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -863,8 +867,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -877,20 +879,18 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: eventbrite_events_attendee
-          entity_field: ticket_class_name
-          plugin_id: string
-      defaults:
-        filters: false
-        filter_groups: false
-        title: false
       filter_groups:
         operator: AND
         groups:
           1: OR
           2: OR
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+      display_description: ''
+      display_extenders: {  }
       path: 2019/individual-sponsors
-      title: 'Individual Sponsors'
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.attendees_2020.yml
+++ b/conf/drupal/config/views.view.attendees_2020.yml
@@ -27,70 +27,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 15
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 5
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: 'speaker-item l-3up'
-          default_row_class: true
-      row:
-        type: fields
-        options:
-          default_field_elements: true
-          inline: {  }
-          separator: ''
-          hide_empty: false
+      title: 'MidCamp 2020 Attendees'
       fields:
         user_picture:
           id: user_picture
@@ -99,6 +41,7 @@ display:
           relationship: field_drupal_user_account
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -143,8 +86,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: ''
             image_link: ''
+            image_style: ''
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -155,7 +98,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -163,6 +105,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -218,9 +163,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         field_job_title:
           id: field_job_title
           table: node__field_job_title
@@ -228,6 +170,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -283,7 +226,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_title:
           id: field_title
           table: user__field_title
@@ -291,6 +233,7 @@ display:
           relationship: field_drupal_user_account
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -346,7 +289,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_organization:
           id: field_organization
           table: node__field_organization
@@ -354,6 +296,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -409,7 +352,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_organization_1:
           id: field_organization_1
           table: user__field_organization
@@ -417,6 +359,7 @@ display:
           relationship: field_drupal_user_account
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -472,30 +415,70 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 15
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 5
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            attendee: attendee
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            attendee: attendee
           group: 1
           expose:
             operator_limit_selection: false
@@ -507,6 +490,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             - 143
@@ -518,6 +502,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -525,8 +511,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -540,12 +524,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: textfield
-          limit: true
           vid: event
+          type: textfield
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_ticket_type_value:
           id: field_ticket_type_value
           table: node__field_ticket_type
@@ -553,6 +536,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: string
           operator: '='
           value: 'The Worm'
           group: 2
@@ -563,6 +547,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -570,8 +556,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -584,7 +568,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: string
         field_ticket_type_value_1:
           id: field_ticket_type_value_1
           table: node__field_ticket_type
@@ -592,6 +575,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: string
           operator: '='
           value: Alice
           group: 2
@@ -602,6 +586,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -609,8 +595,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -623,7 +607,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: string
         field_ticket_type_value_2:
           id: field_ticket_type_value_2
           table: node__field_ticket_type
@@ -631,6 +614,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: string
           operator: '='
           value: 'The Rabbit'
           group: 2
@@ -641,6 +625,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -648,8 +634,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -662,7 +646,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: string
         field_ticket_type_value_3:
           id: field_ticket_type_value_3
           table: node__field_ticket_type
@@ -670,6 +653,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: string
           operator: '='
           value: Student
           group: 2
@@ -680,6 +664,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -687,8 +673,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -701,7 +685,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: string
         field_ticket_type_value_4:
           id: field_ticket_type_value_4
           table: node__field_ticket_type
@@ -709,6 +692,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: string
           operator: '='
           value: Sponsored
           group: 2
@@ -719,6 +703,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -726,8 +712,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -740,7 +724,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: string
         field_first_name_value:
           id: field_first_name_value
           table: node__field_first_name
@@ -748,6 +731,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: string
           operator: 'not empty'
           value: ''
           group: 1
@@ -758,6 +742,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -765,8 +751,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -779,12 +763,32 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: string
-      sorts: {  }
-      title: 'MidCamp 2020 Attendees'
-      header: {  }
-      footer: {  }
-      empty: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: 'speaker-item l-3up'
+          default_row_class: true
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         field_drupal_user_account:
           id: field_drupal_user_account
@@ -793,15 +797,11 @@ display:
           relationship: none
           group_type: group
           admin_label: User
-          required: false
           plugin_id: standard
-      arguments: {  }
+          required: false
+      header: {  }
+      footer: {  }
       display_extenders: {  }
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
-          2: OR
     cache_metadata:
       max-age: -1
       contexts:
@@ -818,42 +818,39 @@ display:
         - 'config:field.storage.user.field_title'
         - 'config:field.storage.user.user_picture'
   block_1:
-    display_plugin: block
     id: block_1
     display_title: 'Individual Sponsor Block'
+    display_plugin: block
     position: 2
     display_options:
-      display_extenders: {  }
       title: 'Individual Sponsors'
-      defaults:
-        title: false
-        filters: false
-        filter_groups: false
-        pager: false
-        css_class: false
+      pager:
+        type: none
+        options:
+          offset: 0
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            attendee: attendee
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            attendee: attendee
           group: 1
           expose:
             operator_limit_selection: false
@@ -865,6 +862,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             - 143
@@ -876,6 +874,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -883,8 +883,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -898,12 +896,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: textfield
-          limit: true
           vid: event
+          type: textfield
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_first_name_value:
           id: field_first_name_value
           table: node__field_first_name
@@ -911,6 +908,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: string
           operator: 'not empty'
           value: ''
           group: 1
@@ -921,6 +919,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -928,8 +928,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -942,7 +940,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: string
         field_ticket_type_value:
           id: field_ticket_type_value
           table: node__field_ticket_type
@@ -950,6 +947,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: string
           operator: '='
           value: 'Individual Sponsor (add-on)'
           group: 1
@@ -960,6 +958,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -967,8 +967,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -981,18 +979,20 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: string
       filter_groups:
         operator: AND
         groups:
           1: AND
-      block_description: 'MidCamp 2020 Individual Sponsors'
-      pager:
-        type: none
-        options:
-          offset: 0
+      defaults:
+        title: false
+        css_class: false
+        pager: false
+        filters: false
+        filter_groups: false
       css_class: ''
       display_description: ''
+      display_extenders: {  }
+      block_description: 'MidCamp 2020 Individual Sponsors'
     cache_metadata:
       max-age: -1
       contexts:
@@ -1008,24 +1008,24 @@ display:
         - 'config:field.storage.user.field_title'
         - 'config:field.storage.user.user_picture'
   page_1:
-    display_plugin: page
     id: page_1
     display_title: 'Attendee Page'
+    display_plugin: page
     position: 1
     display_options:
+      display_description: ''
       display_extenders: {  }
       path: 2020/attendees
       menu:
         type: normal
         title: Attendees
         description: ''
-        expanded: false
-        parent: 'menu_link_content:8a08e9a9-1692-43db-8f38-b20ee4b9c7f0'
         weight: 0
-        context: '0'
-        menu_name: midcamp-2020-navigation
         enabled: false
-      display_description: ''
+        expanded: false
+        menu_name: midcamp-2020-navigation
+        parent: 'menu_link_content:8a08e9a9-1692-43db-8f38-b20ee4b9c7f0'
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.block_content.yml
+++ b/conf/drupal/config/views.view.block_content.yml
@@ -16,103 +16,12 @@ base_table: block_content_field_data
 base_field: id
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'administer blocks'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            info: info
-            type: type
-            changed: changed
-            operations: operations
-          info:
-            info:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            type:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            changed:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            operations:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: changed
-          empty_table: true
-      row:
-        type: fields
+      title: 'Custom block library'
       fields:
         info:
           id: info
@@ -121,6 +30,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: info
+          plugin_id: field
           label: 'Block description'
           exclude: false
           alter:
@@ -176,9 +88,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: null
-          entity_field: info
-          plugin_id: field
         type:
           id: type
           table: block_content_field_data
@@ -186,6 +95,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: block_content
+          entity_field: type
+          plugin_id: field
           label: 'Block type'
           exclude: false
           alter:
@@ -241,9 +153,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: block_content
-          entity_field: type
-          plugin_id: field
         changed:
           id: changed
           table: block_content_field_data
@@ -251,6 +160,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: block_content
+          entity_field: changed
+          plugin_id: field
           label: Updated
           exclude: false
           alter:
@@ -292,14 +204,11 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          entity_type: block_content
-          entity_field: changed
           type: timestamp
           settings:
             date_format: short
             custom_date_format: ''
             timezone: ''
-          plugin_id: field
         operations:
           id: operations
           table: block_content
@@ -307,6 +216,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: block_content
+          plugin_id: entity_operations
           label: Operations
           exclude: false
           alter:
@@ -349,8 +260,66 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: true
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer blocks'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'There are no custom blocks available. '
+          tokenize: false
+        block_content_listing_empty:
+          id: block_content_listing_empty
+          table: block_content
+          field: block_content_listing_empty
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: block_content
-          plugin_id: entity_operations
+          plugin_id: block_content_listing_empty
+          label: ''
+          empty: true
+      sorts: {  }
+      arguments: {  }
       filters:
         info:
           id: info
@@ -359,6 +328,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: block_content
+          entity_field: info
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -369,6 +341,8 @@ display:
             description: ''
             use_operator: false
             operator: info_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: info
             required: false
             remember: false
@@ -378,8 +352,6 @@ display:
               anonymous: '0'
               administrator: '0'
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -392,9 +364,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: block_content
-          entity_field: info
-          plugin_id: string
         type:
           id: type
           table: block_content_field_data
@@ -402,6 +371,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: block_content
+          entity_field: type
+          plugin_id: bundle
           operator: in
           value: {  }
           group: 1
@@ -412,6 +384,8 @@ display:
             description: ''
             use_operator: false
             operator: type_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: type
             required: false
             remember: false
@@ -421,8 +395,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -435,52 +407,80 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: block_content
-          entity_field: type
-          plugin_id: bundle
-      sorts: {  }
-      title: 'Custom block library'
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            info: info
+            type: type
+            changed: changed
+            operations: operations
+          default: changed
+          info:
+            info:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: true
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header: {  }
       footer: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'There are no custom blocks available. '
-          plugin_id: text_custom
-        block_content_listing_empty:
-          admin_label: ''
-          empty: true
-          field: block_content_listing_empty
-          group_type: group
-          id: block_content_listing_empty
-          label: ''
-          relationship: none
-          table: block_content
-          plugin_id: block_content_listing_empty
-          entity_type: block_content
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - user.permissions
-      max-age: -1
       tags: {  }
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
       display_extenders: {  }
@@ -489,16 +489,16 @@ display:
         type: tab
         title: 'Custom block library'
         description: ''
-        parent: block.admin_display
         weight: 0
-        context: '0'
         menu_name: admin
+        parent: block.admin_display
+        context: '0'
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - user.permissions
-      max-age: -1
       tags: {  }

--- a/conf/drupal/config/views.view.comment.yml
+++ b/conf/drupal/config/views.view.comment.yml
@@ -14,120 +14,12 @@ base_table: comment_field_data
 base_field: cid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'administer comments'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: '‹ previous'
-            next: 'next ›'
-            first: '« first'
-            last: 'last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: true
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            comment_bulk_form: comment_bulk_form
-            subject: subject
-            uid: uid
-            entity_id: entity_id
-            changed: changed
-            operations: operations
-          info:
-            comment_bulk_form:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            subject:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            uid:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            entity_id:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            changed:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-low
-            operations:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: changed
-          empty_table: true
-      row:
-        type: fields
+      title: Comments
       fields:
         comment_bulk_form:
           id: comment_bulk_form
@@ -136,6 +28,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          plugin_id: comment_bulk_form
           label: ''
           exclude: false
           alter:
@@ -182,8 +76,6 @@ display:
           selected_actions:
             - comment_delete_action
             - comment_unpublish_action
-          plugin_id: comment_bulk_form
-          entity_type: comment
         subject:
           id: subject
           table: comment_field_data
@@ -191,6 +83,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          entity_field: subject
+          plugin_id: field
           label: Subject
           exclude: false
           alter:
@@ -246,9 +141,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: comment
-          entity_field: subject
-          plugin_id: field
         uid:
           id: uid
           table: comment_field_data
@@ -256,6 +148,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          entity_field: uid
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -311,9 +206,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: comment
-          entity_field: uid
-          plugin_id: field
         name:
           id: name
           table: comment_field_data
@@ -321,6 +213,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          entity_field: name
+          plugin_id: field
           label: Author
           exclude: false
           alter:
@@ -375,9 +270,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: comment
-          entity_field: name
-          plugin_id: field
         entity_id:
           id: entity_id
           table: comment_field_data
@@ -385,6 +277,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          entity_field: entity_id
+          plugin_id: commented_entity
           label: 'Posted in'
           exclude: false
           alter:
@@ -440,9 +335,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: comment
-          entity_field: entity_id
-          plugin_id: commented_entity
         changed:
           id: changed
           table: comment_field_data
@@ -450,6 +342,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          entity_field: changed
+          plugin_id: field
           label: Updated
           exclude: false
           alter:
@@ -507,9 +402,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: comment
-          entity_field: changed
-          plugin_id: field
         operations:
           id: operations
           table: comment
@@ -517,6 +409,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          plugin_id: entity_operations
           label: Operations
           exclude: false
           alter:
@@ -559,8 +453,6 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: true
-          entity_type: comment
-          plugin_id: entity_operations
         name_1:
           id: name_1
           table: users_field_data
@@ -568,6 +460,9 @@ display:
           relationship: uid
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -623,9 +518,74 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: user
-          entity_field: name
-          plugin_id: field
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'next ›'
+            previous: '‹ previous'
+            first: '« first'
+            last: 'last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer comments'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No comments available.'
+          tokenize: false
+      sorts:
+        changed:
+          id: changed
+          table: comment_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: comment
+          entity_field: changed
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: changed
+          exposed: false
+          granularity: second
+      arguments: {  }
       filters:
         status:
           id: status
@@ -634,6 +594,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -644,14 +607,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -664,9 +627,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: comment
-          entity_field: status
-          plugin_id: boolean
         subject:
           id: subject
           table: comment_field_data
@@ -674,6 +634,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          entity_field: subject
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -684,6 +647,8 @@ display:
             description: ''
             use_operator: false
             operator: subject_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: subject
             required: false
             remember: false
@@ -693,8 +658,6 @@ display:
               anonymous: '0'
               administrator: '0'
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -707,9 +670,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: comment
-          entity_field: subject
-          plugin_id: string
         combine:
           id: combine
           table: views
@@ -717,6 +677,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: combine
           operator: contains
           value: ''
           group: 1
@@ -727,6 +688,8 @@ display:
             description: ''
             use_operator: false
             operator: combine_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: author_name
             required: false
             remember: false
@@ -736,8 +699,6 @@ display:
               anonymous: '0'
               administrator: '0'
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -753,7 +714,6 @@ display:
           fields:
             name: name
             name_1: name_1
-          plugin_id: combine
         langcode:
           id: langcode
           table: comment_field_data
@@ -761,6 +721,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          entity_field: langcode
+          plugin_id: language
           operator: in
           value: {  }
           group: 1
@@ -771,6 +734,8 @@ display:
             description: ''
             use_operator: false
             operator: langcode_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: langcode
             required: false
             remember: false
@@ -780,8 +745,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -794,50 +757,81 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: comment
-          entity_field: langcode
-          plugin_id: language
-      sorts:
-        changed:
-          id: changed
-          table: comment_field_data
-          field: changed
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-          entity_type: comment
-          entity_field: changed
-          plugin_id: date
-      title: Comments
-      header: {  }
-      footer: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'No comments available.'
-          plugin_id: text_custom
-      arguments: {  }
-      display_extenders: {  }
-      use_more: false
-      use_more_always: true
-      use_more_text: more
-      use_ajax: false
-      hide_attachment_summary: false
-      show_admin_links: true
-      group_by: false
-      css_class: ''
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            comment_bulk_form: comment_bulk_form
+            subject: subject
+            uid: uid
+            entity_id: entity_id
+            changed: changed
+            operations: operations
+          default: changed
+          info:
+            comment_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            subject:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            entity_id:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            operations:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: true
+          summary: ''
+          empty_table: true
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         uid:
           id: uid
@@ -846,245 +840,66 @@ display:
           relationship: none
           group_type: group
           admin_label: author
-          required: false
           entity_type: comment
           entity_field: uid
           plugin_id: standard
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
+          required: false
+      css_class: ''
+      use_ajax: false
+      group_by: false
+      show_admin_links: true
+      use_more: false
+      use_more_always: true
+      use_more_text: more
+      header: {  }
+      footer: {  }
+      hide_attachment_summary: false
+      display_extenders: {  }
     cache_metadata:
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - user.permissions
-      cacheable: false
-      max-age: 0
       tags: {  }
+      cacheable: false
   page_published:
-    display_plugin: page
     id: page_published
     display_title: 'Published comments'
+    display_plugin: page
     position: 1
     display_options:
+      display_description: 'The approved comments listing.'
+      display_comment: ''
+      exposed_block: false
+      display_extenders: {  }
       path: admin/content/comment
       menu:
         type: tab
         title: Comments
         description: 'Comments published'
-        parent: ''
         weight: 0
-        context: '0'
         menu_name: admin
-      display_description: 'The approved comments listing.'
-      display_extenders: {  }
-      exposed_block: false
-      display_comment: ''
+        parent: ''
+        context: '0'
     cache_metadata:
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - user.permissions
-      cacheable: false
-      max-age: 0
       tags: {  }
+      cacheable: false
   page_unapproved:
-    display_plugin: page
     id: page_unapproved
     display_title: 'Unapproved comments'
+    display_plugin: page
     position: 2
     display_options:
-      path: admin/content/comment/approval
-      menu:
-        type: tab
-        title: 'Unapproved comments'
-        description: 'Comments unapproved'
-        parent: ''
-        weight: 1
-        context: '0'
-        menu_name: admin
-      display_description: 'The unapproved comments listing.'
-      filters:
-        status:
-          id: status
-          table: comment_field_data
-          field: status
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: '0'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: comment
-          entity_field: status
-          plugin_id: boolean
-        subject:
-          id: subject
-          table: comment_field_data
-          field: subject
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: subject_op
-            label: Subject
-            description: ''
-            use_operator: false
-            operator: subject_op
-            identifier: subject
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: comment
-          entity_field: subject
-          plugin_id: string
-        combine:
-          id: combine
-          table: views
-          field: combine
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: combine_op
-            label: 'Author Name'
-            description: ''
-            use_operator: false
-            operator: combine_op
-            identifier: author_name
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          fields:
-            name: name
-            name_1: name_1
-          plugin_id: combine
-        langcode:
-          id: langcode
-          table: comment_field_data
-          field: langcode
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: in
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: langcode_op
-            label: Language
-            description: ''
-            use_operator: false
-            operator: langcode_op
-            identifier: langcode
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: comment
-          entity_field: langcode
-          plugin_id: language
-      defaults:
-        filters: false
-        filter_groups: false
-        fields: false
-      display_extenders: {  }
       fields:
         comment_bulk_form:
           id: comment_bulk_form
@@ -1093,6 +908,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          plugin_id: comment_bulk_form
           label: ''
           exclude: false
           alter:
@@ -1139,8 +956,6 @@ display:
           selected_actions:
             - comment_delete_action
             - comment_publish_action
-          plugin_id: comment_bulk_form
-          entity_type: comment
         subject:
           id: subject
           table: comment_field_data
@@ -1148,6 +963,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          entity_field: subject
+          plugin_id: field
           label: Subject
           exclude: false
           alter:
@@ -1203,9 +1021,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: comment
-          entity_field: subject
-          plugin_id: field
         uid:
           id: uid
           table: comment_field_data
@@ -1213,6 +1028,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          entity_field: uid
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -1268,9 +1086,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: comment
-          entity_field: uid
-          plugin_id: field
         name:
           id: name
           table: comment_field_data
@@ -1278,6 +1093,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          entity_field: name
+          plugin_id: field
           label: Author
           exclude: false
           alter:
@@ -1332,9 +1150,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: comment
-          entity_field: name
-          plugin_id: field
         entity_id:
           id: entity_id
           table: comment_field_data
@@ -1342,6 +1157,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          entity_field: entity_id
+          plugin_id: commented_entity
           label: 'Posted in'
           exclude: false
           alter:
@@ -1397,9 +1215,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: comment
-          entity_field: entity_id
-          plugin_id: commented_entity
         changed:
           id: changed
           table: comment_field_data
@@ -1407,6 +1222,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          entity_field: changed
+          plugin_id: field
           label: Updated
           exclude: false
           alter:
@@ -1464,9 +1282,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: comment
-          entity_field: changed
-          plugin_id: field
         operations:
           id: operations
           table: comment
@@ -1474,6 +1289,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: comment
+          plugin_id: entity_operations
           label: Operations
           exclude: false
           alter:
@@ -1516,8 +1333,6 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: true
-          entity_type: comment
-          plugin_id: entity_operations
         name_1:
           id: name_1
           table: users_field_data
@@ -1525,6 +1340,9 @@ display:
           relationship: uid
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -1580,20 +1398,203 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: user
-          entity_field: name
-          plugin_id: field
+      filters:
+        status:
+          id: status
+          table: comment_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: comment
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: '0'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        subject:
+          id: subject
+          table: comment_field_data
+          field: subject
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: comment
+          entity_field: subject
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: subject_op
+            label: Subject
+            description: ''
+            use_operator: false
+            operator: subject_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: subject
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        combine:
+          id: combine
+          table: views
+          field: combine
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: combine
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: combine_op
+            label: 'Author Name'
+            description: ''
+            use_operator: false
+            operator: combine_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: author_name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          fields:
+            name: name
+            name_1: name_1
+        langcode:
+          id: langcode
+          table: comment_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: comment
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: langcode_op
+            label: Language
+            description: ''
+            use_operator: false
+            operator: langcode_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        fields: false
+        filters: false
+        filter_groups: false
+      display_description: 'The unapproved comments listing.'
+      display_extenders: {  }
+      path: admin/content/comment/approval
+      menu:
+        type: tab
+        title: 'Unapproved comments'
+        description: 'Comments unapproved'
+        weight: 1
+        menu_name: admin
+        parent: ''
+        context: '0'
     cache_metadata:
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - user.permissions
-      cacheable: false
-      max-age: 0
       tags: {  }
+      cacheable: false

--- a/conf/drupal/config/views.view.comments_recent.yml
+++ b/conf/drupal/config/views.view.comments_recent.yml
@@ -17,63 +17,23 @@ base_table: comment_field_data
 base_field: cid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access comments'
-      cache:
-        type: tag
-      query:
-        type: views_query
-      exposed_form:
-        type: basic
-      pager:
-        type: some
-        options:
-          items_per_page: 10
-          offset: 0
-      style:
-        type: html_list
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          type: ul
-          wrapper_class: item-list
-          class: ''
-      row:
-        type: fields
-        options:
-          default_field_elements: true
-          inline:
-            subject: subject
-            changed: changed
-          separator: ' '
-          hide_empty: false
-      relationships:
-        node:
-          field: node
-          id: node
-          table: comment_field_data
-          required: true
-          plugin_id: standard
+      title: 'Recent comments'
       fields:
         subject:
           id: subject
           table: comment_field_data
           field: subject
           relationship: none
-          type: string
-          settings:
-            link_to_entity: true
-          plugin_id: field
           group_type: group
           admin_label: ''
+          entity_type: comment
+          entity_field: subject
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -115,16 +75,19 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          entity_type: comment
-          entity_field: subject
+          type: string
+          settings:
+            link_to_entity: true
         changed:
           id: changed
           table: comment_field_data
           field: changed
           relationship: none
-          plugin_id: field
           group_type: group
           admin_label: ''
+          entity_type: comment
+          entity_field: changed
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -171,64 +134,19 @@ display:
             future_format: '@interval hence'
             past_format: '@interval ago'
             granularity: 2
-          entity_type: comment
-          entity_field: changed
-      filters:
-        status:
-          value: '1'
-          table: comment_field_data
-          field: status
-          id: status
-          plugin_id: boolean
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-          entity_type: comment
-          entity_field: status
-        status_node:
-          value: '1'
-          table: node_field_data
-          field: status
-          relationship: node
-          id: status_node
-          plugin_id: boolean
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-          entity_type: node
-          entity_field: status
-      sorts:
-        created:
-          id: created
-          table: comment_field_data
-          field: created
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: date
-          entity_type: comment
-          entity_field: created
-        cid:
-          id: cid
-          table: comment_field_data
-          field: cid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          plugin_id: field
-          entity_type: comment
-          entity_field: cid
-      title: 'Recent comments'
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 10
+      exposed_form:
+        type: basic
+      access:
+        type: perm
+        options:
+          perm: 'access comments'
+      cache:
+        type: tag
       empty:
         area_text_custom:
           id: area_text_custom
@@ -237,34 +155,119 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text_custom
           label: ''
           empty: true
           content: 'No comments available.'
           tokenize: false
-          plugin_id: text_custom
+      sorts:
+        created:
+          id: created
+          table: comment_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: comment
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+        cid:
+          id: cid
+          table: comment_field_data
+          field: cid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: comment
+          entity_field: cid
+          plugin_id: field
+          order: DESC
+          exposed: false
+          expose:
+            field_identifier: cid
+      filters:
+        status:
+          id: status
+          table: comment_field_data
+          field: status
+          entity_type: comment
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        status_node:
+          id: status_node
+          table: node_field_data
+          field: status
+          relationship: node
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+      style:
+        type: html_list
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          type: ul
+          wrapper_class: item-list
+          class: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline:
+            subject: subject
+            changed: changed
+          separator: ' '
+          hide_empty: false
+      query:
+        type: views_query
+      relationships:
+        node:
+          id: node
+          table: comment_field_data
+          field: node
+          plugin_id: standard
+          required: true
       display_extenders: {  }
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - user.permissions
-      max-age: -1
       tags: {  }
   block_1:
-    display_plugin: block
     id: block_1
     display_title: Block
+    display_plugin: block
     position: 1
     display_options:
+      display_extenders: {  }
       block_description: 'Recent comments'
       block_category: 'Lists (Views)'
       allow:
         items_per_page: true
-      display_extenders: {  }
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - user.permissions
-      max-age: -1
       tags: {  }

--- a/conf/drupal/config/views.view.content.yml
+++ b/conf/drupal/config/views.view.content.yml
@@ -20,128 +20,19 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
+    id: default
+    display_title: Master
+    display_plugin: default
+    position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content overview'
-      cache:
-        type: tag
-      query:
-        type: views_query
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Filter
-          reset_button: true
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: true
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            node_bulk_form: node_bulk_form
-            title: title
-            field_event: field_event
-            type: type
-            name: name
-            status: status
-            changed: changed
-            operations: operations
-          info:
-            node_bulk_form:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            title:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            field_event:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            type:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            name:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-low
-            status:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            changed:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-low
-            operations:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: changed
-          empty_table: true
-      row:
-        type: fields
+      title: Content
       fields:
         node_bulk_form:
           id: node_bulk_form
           table: node
           field: node_bulk_form
+          entity_type: node
+          plugin_id: node_bulk_form
           label: ''
           exclude: false
           alter:
@@ -152,12 +43,13 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: node_bulk_form
-          entity_type: node
         title:
           id: title
           table: node_field_data
           field: title
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: Title
           exclude: false
           alter:
@@ -168,12 +60,9 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          entity_type: node
-          entity_field: title
           type: string
           settings:
             link_to_entity: true
-          plugin_id: field
         field_event:
           id: field_event
           table: node__field_event
@@ -181,6 +70,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Event
           exclude: false
           alter:
@@ -236,7 +126,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         type:
           id: type
           table: node_field_data
@@ -244,6 +133,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: field
           label: 'Content type'
           exclude: false
           alter:
@@ -299,14 +191,14 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: type
-          plugin_id: field
         name:
           id: name
           table: users_field_data
           field: name
           relationship: uid
+          entity_type: user
+          entity_field: name
+          plugin_id: field
           label: Author
           exclude: false
           alter:
@@ -317,14 +209,14 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: field
           type: user_name
-          entity_type: user
-          entity_field: name
         status:
           id: status
           table: node_field_data
           field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: field
           label: Status
           exclude: false
           alter:
@@ -338,15 +230,15 @@ display:
           type: boolean
           settings:
             format: custom
-            format_custom_true: Published
             format_custom_false: Unpublished
-          plugin_id: field
-          entity_type: node
-          entity_field: status
+            format_custom_true: Published
         changed:
           id: changed
           table: node_field_data
           field: changed
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
           label: Updated
           exclude: false
           alter:
@@ -362,9 +254,6 @@ display:
             date_format: short
             custom_date_format: ''
             timezone: ''
-          plugin_id: field
-          entity_type: node
-          entity_field: changed
         operations:
           id: operations
           table: node
@@ -372,6 +261,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: entity_operations
           label: Operations
           exclude: false
           alter:
@@ -414,17 +304,63 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: true
-          plugin_id: entity_operations
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content overview'
+      cache:
+        type: tag
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          plugin_id: text_custom
+          empty: true
+          content: 'No content available.'
+      sorts: {  }
+      arguments: {  }
       filters:
         status_extra:
           id: status_extra
           table: node_field_data
           field: status_extra
+          entity_type: node
+          plugin_id: node_status
           operator: '='
           value: false
-          plugin_id: node_status
           group: 1
-          entity_type: node
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -435,6 +371,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -445,14 +384,14 @@ display:
             description: ''
             use_operator: false
             operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: status
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: true
           group_info:
             label: 'Published status'
@@ -473,9 +412,6 @@ display:
                 title: Unpublished
                 operator: '='
                 value: '0'
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
         type:
           id: type
           table: node_field_data
@@ -483,6 +419,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
           operator: in
           value: {  }
           group: 1
@@ -493,6 +432,8 @@ display:
             description: ''
             use_operator: false
             operator: type_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: type
             required: false
             remember: false
@@ -502,8 +443,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -516,9 +455,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: bundle
-          entity_type: node
-          entity_field: type
         title:
           id: title
           table: node_field_data
@@ -526,6 +462,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -536,6 +475,8 @@ display:
             description: ''
             use_operator: false
             operator: title_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: title
             required: false
             remember: false
@@ -545,8 +486,6 @@ display:
               anonymous: '0'
               administrator: '0'
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -559,9 +498,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: string
-          entity_type: node
-          entity_field: title
         langcode:
           id: langcode
           table: node_field_data
@@ -569,6 +505,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
           operator: in
           value: {  }
           group: 1
@@ -579,6 +518,8 @@ display:
             description: ''
             use_operator: false
             operator: langcode_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: langcode
             required: false
             remember: false
@@ -588,8 +529,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -602,9 +541,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: language
-          entity_type: node
-          entity_field: langcode
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -612,6 +548,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value: {  }
           group: 1
@@ -622,6 +559,8 @@ display:
             description: ''
             use_operator: false
             operator: field_event_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_event_target_id
             required: false
             remember: false
@@ -635,8 +574,6 @@ display:
               sponsor: '0'
               organizer: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -650,42 +587,106 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      sorts: {  }
-      title: Content
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          empty: true
-          content: 'No content available.'
-          plugin_id: text_custom
-      arguments: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            node_bulk_form: node_bulk_form
+            title: title
+            field_event: field_event
+            type: type
+            name: name
+            status: status
+            changed: changed
+            operations: operations
+          default: changed
+          info:
+            node_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_event:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            operations:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: true
+          summary: ''
+          empty_table: true
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
       relationships:
         uid:
           id: uid
           table: node_field_data
           field: uid
           admin_label: author
-          required: true
           plugin_id: standard
+          required: true
       show_admin_links: false
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
       display_extenders: {  }
-    display_plugin: default
-    display_title: Master
-    id: default
-    position: 0
     cache_metadata:
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -694,31 +695,31 @@ display:
         - user
         - 'user.node_grants:view'
         - user.permissions
-      max-age: 0
       tags:
         - 'config:field.storage.node.field_event'
   page_1:
+    id: page_1
+    display_title: Page
+    display_plugin: page
+    position: 1
     display_options:
+      display_extenders: {  }
       path: admin/content/node
       menu:
         type: 'default tab'
         title: Content
         description: ''
-        menu_name: admin
         weight: -10
+        menu_name: admin
         context: ''
       tab_options:
         type: normal
         title: Content
         description: 'Find and manage content'
-        menu_name: admin
         weight: -10
-      display_extenders: {  }
-    display_plugin: page
-    display_title: Page
-    id: page_1
-    position: 1
+        menu_name: admin
     cache_metadata:
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -727,6 +728,5 @@ display:
         - user
         - 'user.node_grants:view'
         - user.permissions
-      max-age: 0
       tags:
         - 'config:field.storage.node.field_event'

--- a/conf/drupal/config/views.view.content_recent.yml
+++ b/conf/drupal/config/views.view.content_recent.yml
@@ -16,75 +16,34 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: some
-        options:
-          items_per_page: 10
-          offset: 0
-      style:
-        type: html_list
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          type: ul
-          wrapper_class: item-list
-          class: ''
-      row:
-        type: fields
+      title: 'Recent content'
       fields:
         title:
           id: title
           table: node_field_data
           field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          relationship: none
-          group_type: group
-          admin_label: ''
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -94,11 +53,12 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           type: string
           settings:
             link_to_entity: true
-          plugin_id: field
         changed:
           id: changed
           table: node_field_data
@@ -106,6 +66,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -160,9 +123,58 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 10
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No content available.'
+          tokenize: false
+      sorts:
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: changed
-          plugin_id: field
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: changed
+          exposed: false
+          granularity: second
+      arguments: {  }
       filters:
         status_extra:
           id: status_extra
@@ -171,6 +183,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: node_status
           operator: '='
           value: false
           group: 1
@@ -181,14 +195,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -201,8 +215,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          plugin_id: node_status
         langcode:
           id: langcode
           table: node_field_data
@@ -210,6 +222,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
           operator: in
           value:
             '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
@@ -221,6 +236,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -228,8 +245,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -242,40 +257,25 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: langcode
-          plugin_id: language
-      sorts:
-        changed:
-          id: changed
-          table: node_field_data
-          field: changed
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-          entity_type: node
-          entity_field: changed
-          plugin_id: date
-      title: 'Recent content'
-      header: {  }
-      footer: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'No content available.'
-          plugin_id: text_custom
+      style:
+        type: html_list
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          type: ul
+          wrapper_class: item-list
+          class: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         uid:
           id: uid
@@ -284,39 +284,40 @@ display:
           relationship: none
           group_type: group
           admin_label: author
-          required: true
           entity_type: node
           entity_field: uid
           plugin_id: standard
-      arguments: {  }
-      display_extenders: {  }
+          required: true
       use_more: false
       use_more_always: false
       use_more_text: More
-      link_url: ''
       link_display: '0'
+      link_url: ''
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - user
         - 'user.node_grants:view'
         - user.permissions
-      max-age: -1
       tags: {  }
   block_1:
-    display_plugin: block
     id: block_1
     display_title: Block
+    display_plugin: block
     position: 1
     display_options:
       display_extenders: {  }
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - user
         - 'user.node_grants:view'
         - user.permissions
-      max-age: -1
       tags: {  }

--- a/conf/drupal/config/views.view.drupal_planet.yml
+++ b/conf/drupal/config/views.view.drupal_planet.yml
@@ -17,68 +17,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          uses_fields: false
-      row:
-        type: fields
-        options:
-          inline: {  }
-          separator: ''
-          hide_empty: false
-          default_field_elements: true
+      title: 'MidCamp - Midwest Drupal Camp News'
       fields:
         title:
           id: title
@@ -87,6 +31,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -142,9 +89,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         path:
           id: path
           table: node
@@ -152,6 +96,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: entity_link
           label: ''
           exclude: false
           alter:
@@ -193,10 +139,8 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          absolute: false
-          entity_type: node
-          plugin_id: entity_link
           output_url_as_text: true
+          absolute: false
         uid:
           id: uid
           table: node_field_data
@@ -204,6 +148,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: uid
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -258,9 +205,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: uid
-          plugin_id: field
         created:
           id: created
           table: node_field_data
@@ -268,6 +212,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -325,9 +272,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: created
-          plugin_id: field
         rendered_entity:
           id: rendered_entity
           table: node
@@ -335,6 +279,8 @@ display:
           relationship: none
           group_type: group
           admin_label: 'Content: Body (Rendered Entity)'
+          entity_type: node
+          plugin_id: rendered_entity
           label: ''
           exclude: false
           alter:
@@ -377,22 +323,74 @@ display:
           empty_zero: false
           hide_alter_empty: true
           view_mode: rss
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
-          plugin_id: rendered_entity
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments: {  }
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
@@ -400,6 +398,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
           operator: in
           value:
             article: article
@@ -411,6 +412,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -418,8 +421,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -432,9 +433,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
         field_planet_value:
           id: field_planet_value
           table: node__field_planet
@@ -442,6 +440,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -452,14 +451,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -472,30 +471,32 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
-      sorts:
-        created:
-          id: created
-          table: node_field_data
-          field: created
-          order: DESC
-          entity_type: node
-          entity_field: created
-          plugin_id: date
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header: {  }
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
-      title: 'MidCamp - Midwest Drupal Camp News'
     cache_metadata:
       max-age: -1
       contexts:
@@ -522,12 +523,11 @@ display:
         - 'config:core.entity_view_display.node.venue.map'
         - 'config:core.entity_view_display.node.venue.teaser'
   feed_1:
-    display_plugin: feed
     id: feed_1
     display_title: Feed
+    display_plugin: feed
     position: 1
     display_options:
-      display_extenders: {  }
       row:
         type: rss_fields
         options:
@@ -539,6 +539,7 @@ display:
           guid_field_options:
             guid_field: path
             guid_field_is_permalink: true
+      display_extenders: {  }
       path: midcamp-news.xml
       sitename_title: false
     cache_metadata:

--- a/conf/drupal/config/views.view.event_news.yml
+++ b/conf/drupal/config/views.view.event_news.yml
@@ -18,54 +18,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: some
-        options:
-          items_per_page: 3
-          offset: 0
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: 'l-3up news-teaser'
-          default_row_class: false
-      row:
-        type: fields
-        options:
-          default_field_elements: false
-          inline: {  }
-          separator: ''
-          hide_empty: true
+      title: 'Latest News'
       fields:
         created:
           id: created
@@ -74,6 +32,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -131,9 +92,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: created
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -141,6 +99,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -196,7 +155,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_article_summary:
           id: field_article_summary
           table: node__field_article_summary
@@ -204,6 +162,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -258,67 +217,46 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
-      filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          value:
-            article: article
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-          expose:
-            operator_limit_selection: false
-            operator_list: {  }
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 3
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
       sorts:
         created:
           id: created
           table: node_field_data
           field: created
-          order: DESC
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: created
           plugin_id: date
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exposed: false
+          order: DESC
           expose:
             label: ''
+            field_identifier: created
+          exposed: false
           granularity: second
-      title: 'Latest News'
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: '<h2 class="banner-title">Latest News</h2>'
-            format: full_html
-          plugin_id: text
-      footer: {  }
-      empty: {  }
-      relationships: {  }
       arguments:
         term_node_tid_depth:
           id: term_node_tid_depth
@@ -327,6 +265,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: taxonomy_index_tid_depth
           default_action: default
           exception:
             value: all
@@ -337,16 +277,16 @@ display:
           default_argument_type: taxonomy_tid
           default_argument_options:
             term_page: '1'
-            anyall: ','
             node: false
             limit: false
             vids: {  }
+            anyall: ','
           default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -356,13 +296,74 @@ display:
             type: none
             fail: 'not found'
           validate_options: {  }
-          depth: 1
           break_phrase: false
+          depth: 1
           use_taxonomy_term_path: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
           entity_type: node
-          plugin_id: taxonomy_index_tid_depth
-      display_extenders: {  }
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            article: article
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: 'l-3up news-teaser'
+          default_row_class: false
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: true
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       show_admin_links: false
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: '<h2 class="banner-title">Latest News</h2>'
+            format: full_html
+          tokenize: false
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -374,13 +375,13 @@ display:
       tags:
         - 'config:field.storage.node.field_article_summary'
   block_1:
-    display_plugin: block
     id: block_1
     display_title: 'Event News Block'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
       display_description: ''
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.event_sponsors.yml
+++ b/conf/drupal/config/views.view.event_sponsors.yml
@@ -31,54 +31,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: some
-        options:
-          items_per_page: 0
-          offset: 0
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: l-3up
-          default_row_class: false
-      row:
-        type: fields
-        options:
-          default_field_elements: false
-          inline: {  }
-          separator: ''
-          hide_empty: true
+      title: 'Thank You to our Contrib Sponsors'
       fields:
         nid:
           id: nid
@@ -87,6 +45,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -143,9 +104,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: nid
-          plugin_id: field
         field_image:
           id: field_image
           table: node__field_image
@@ -153,6 +111,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -197,8 +156,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: ''
             image_link: ''
+            image_style: ''
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -209,30 +168,119 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'This sponsor level used to be much more...&ldquo;muchier.&rdquo; It has lost its muchness. <a href="/become-a-sponsor">Help stop this madness!</a>'
+            format: basic_html
+          tokenize: false
+      sorts:
+        random:
+          id: random
+          table: views
+          field: random
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: random
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: random
+          exposed: false
+      arguments:
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: taxonomy_tid
+          default_argument_options:
+            term_page: '1'
+            node: true
+            limit: false
+            vids: {  }
+            anyall: ','
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            sponsor: sponsor
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            sponsor: sponsor
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -243,6 +291,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             11: 11
@@ -254,6 +303,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -261,8 +312,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -276,26 +325,33 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: sponsor_packages
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      sorts:
-        random:
-          id: random
-          table: views
-          field: random
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: random
-      title: 'Thank You to our Contrib Sponsors'
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: l-3up
+          default_row_class: false
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: true
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header: {  }
       footer:
         area_text_custom:
@@ -305,65 +361,10 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          empty: false
-          tokenize: false
-          content: "<div class=\"l-1up button--center-container\">\r\n      <a href=\"/become-a-sponsor\" class=\"cta-link\">Become a Sponsor<span class=\"cta-arrow\"></span></a>\r\n      <a href=\"/sponsors\" class=\"cta-link\">See all Sponsors<span class=\"cta-arrow\"></span></a>\r\n    </div>"
           plugin_id: text_custom
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
+          empty: false
+          content: "<div class=\"l-1up button--center-container\">\r\n      <a href=\"/become-a-sponsor\" class=\"cta-link\">Become a Sponsor<span class=\"cta-arrow\"></span></a>\r\n      <a href=\"/sponsors\" class=\"cta-link\">See all Sponsors<span class=\"cta-arrow\"></span></a>\r\n    </div>"
           tokenize: false
-          content:
-            value: 'This sponsor level used to be much more...&ldquo;muchier.&rdquo; It has lost its muchness. <a href="/become-a-sponsor">Help stop this madness!</a>'
-            format: basic_html
-          plugin_id: text
-      relationships: {  }
-      arguments:
-        field_event_target_id:
-          id: field_event_target_id
-          table: node__field_event
-          field: field_event_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: taxonomy_tid
-          default_argument_options:
-            term_page: '1'
-            node: true
-            anyall: ','
-            limit: false
-            vids: {  }
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: false
-          not: false
-          plugin_id: numeric
       display_extenders: {  }
     cache_metadata:
       max-age: 0
@@ -377,36 +378,35 @@ display:
       tags:
         - 'config:field.storage.node.field_image'
   block_1:
-    display_plugin: block
     id: block_1
     display_title: 'Core Sponsors footer block'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: ''
+      title: 'Thank You to our Core Sponsors'
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            sponsor: sponsor
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            sponsor: sponsor
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -417,6 +417,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             8: 8
@@ -428,6 +429,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -435,8 +438,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -450,23 +451,15 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: sponsor_packages
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      defaults:
-        filters: false
-        filter_groups: false
-        title: false
-        style: false
-        row: false
       filter_groups:
         operator: AND
         groups:
           1: AND
-      title: 'Thank You to our Core Sponsors'
       style:
         type: default
         options:
@@ -480,6 +473,14 @@ display:
           inline: {  }
           separator: ''
           hide_empty: true
+      defaults:
+        title: false
+        style: false
+        row: false
+        filters: false
+        filter_groups: false
+      display_description: ''
+      display_extenders: {  }
     cache_metadata:
       max-age: 0
       contexts:
@@ -492,46 +493,35 @@ display:
       tags:
         - 'config:field.storage.node.field_image'
   block_10:
-    display_plugin: block
     id: block_10
     display_title: 'Community Sponsors block'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      footer: {  }
-      defaults:
-        footer: false
-        filters: false
-        filter_groups: false
-        title: false
-        style: false
-        row: false
-        css_class: false
-      block_description: 'Sponsor page Community'
+      title: 'Community Sponsors'
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            sponsor: sponsor
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            sponsor: sponsor
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -542,6 +532,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             173: 173
@@ -553,6 +544,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -560,8 +553,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -575,17 +566,15 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: sponsor_packages
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
-      title: 'Community Sponsors'
       style:
         type: default
         options:
@@ -599,7 +588,19 @@ display:
           inline: {  }
           separator: ''
           hide_empty: true
+      defaults:
+        title: false
+        css_class: false
+        style: false
+        row: false
+        filters: false
+        filter_groups: false
+        footer: false
       css_class: sponsor-group
+      display_description: ''
+      footer: {  }
+      display_extenders: {  }
+      block_description: 'Sponsor page Community'
     cache_metadata:
       max-age: 0
       contexts:
@@ -612,46 +613,35 @@ display:
       tags:
         - 'config:field.storage.node.field_image'
   block_11:
-    display_plugin: block
     id: block_11
     display_title: 'Special Recognition Sponsors block'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      footer: {  }
-      defaults:
-        footer: false
-        filters: false
-        filter_groups: false
-        title: false
-        style: false
-        row: false
-        css_class: false
-      block_description: 'Sponsor page Special Recognition'
+      title: 'Special Recognition Sponsors'
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            sponsor: sponsor
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            sponsor: sponsor
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -662,6 +652,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             174: 174
@@ -673,6 +664,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -680,8 +673,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -695,17 +686,15 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: sponsor_packages
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
-      title: 'Special Recognition Sponsors'
       style:
         type: default
         options:
@@ -719,7 +708,19 @@ display:
           inline: {  }
           separator: ''
           hide_empty: true
+      defaults:
+        title: false
+        css_class: false
+        style: false
+        row: false
+        filters: false
+        filter_groups: false
+        footer: false
       css_class: sponsor-group
+      display_description: ''
+      footer: {  }
+      display_extenders: {  }
+      block_description: 'Sponsor page Special Recognition'
     cache_metadata:
       max-age: 0
       contexts:
@@ -732,46 +733,35 @@ display:
       tags:
         - 'config:field.storage.node.field_image'
   block_2:
-    display_plugin: block
     id: block_2
     display_title: 'Contrib Sponsors block'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      footer: {  }
-      defaults:
-        footer: false
-        filters: false
-        filter_groups: false
-        title: false
-        style: false
-        row: false
-        css_class: false
-      block_description: 'Sponsor page Contrib'
+      title: 'Contrib Sponsors'
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            sponsor: sponsor
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            sponsor: sponsor
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -782,6 +772,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             9: 9
@@ -793,6 +784,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -800,8 +793,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -815,17 +806,15 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: sponsor_packages
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
-      title: 'Contrib Sponsors'
       style:
         type: default
         options:
@@ -839,7 +828,19 @@ display:
           inline: {  }
           separator: ''
           hide_empty: true
+      defaults:
+        title: false
+        css_class: false
+        style: false
+        row: false
+        filters: false
+        filter_groups: false
+        footer: false
       css_class: sponsor-group
+      display_description: ''
+      footer: {  }
+      display_extenders: {  }
+      block_description: 'Sponsor page Contrib'
     cache_metadata:
       max-age: 0
       contexts:
@@ -852,46 +853,35 @@ display:
       tags:
         - 'config:field.storage.node.field_image'
   block_3:
-    display_plugin: block
     id: block_3
     display_title: 'Supporting Sponsors block'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      footer: {  }
-      defaults:
-        footer: false
-        filters: false
-        filter_groups: false
-        title: false
-        style: false
-        row: false
-        css_class: false
-      block_description: 'Sponsor page Supporting'
+      title: 'Supporting Sponsors'
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            sponsor: sponsor
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            sponsor: sponsor
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -902,6 +892,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             10: 10
@@ -913,6 +904,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -920,8 +913,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -935,17 +926,15 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: sponsor_packages
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
-      title: 'Supporting Sponsors'
       style:
         type: default
         options:
@@ -959,7 +948,19 @@ display:
           inline: {  }
           separator: ''
           hide_empty: true
+      defaults:
+        title: false
+        css_class: false
+        style: false
+        row: false
+        filters: false
+        filter_groups: false
+        footer: false
       css_class: sponsor-group
+      display_description: ''
+      footer: {  }
+      display_extenders: {  }
+      block_description: 'Sponsor page Supporting'
     cache_metadata:
       max-age: 0
       contexts:
@@ -972,46 +973,35 @@ display:
       tags:
         - 'config:field.storage.node.field_image'
   block_4:
-    display_plugin: block
     id: block_4
     display_title: 'Core Sponsors block'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      footer: {  }
-      defaults:
-        footer: false
-        filters: false
-        filter_groups: false
-        title: false
-        style: false
-        row: false
-        css_class: false
-      block_description: 'Sponsor page Core'
+      title: 'Core Sponsors'
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            sponsor: sponsor
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            sponsor: sponsor
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -1022,6 +1012,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             8: 8
@@ -1033,6 +1024,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -1040,8 +1033,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1055,17 +1046,15 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: sponsor_packages
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
-      title: 'Core Sponsors'
       style:
         type: default
         options:
@@ -1079,7 +1068,19 @@ display:
           inline: {  }
           separator: ''
           hide_empty: true
+      defaults:
+        title: false
+        css_class: false
+        style: false
+        row: false
+        filters: false
+        filter_groups: false
+        footer: false
       css_class: sponsor-group
+      display_description: ''
+      footer: {  }
+      display_extenders: {  }
+      block_description: 'Sponsor page Core'
     cache_metadata:
       max-age: 0
       contexts:
@@ -1092,60 +1093,35 @@ display:
       tags:
         - 'config:field.storage.node.field_image'
   block_5:
-    display_plugin: block
     id: block_5
     display_title: 'Party Sponsors block'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      footer: {  }
-      defaults:
-        footer: false
-        title: false
-        style: false
-        row: false
-        filters: false
-        filter_groups: false
-        css_class: false
-      block_description: 'Sponsor page Party'
       title: 'Party Sponsors'
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: l-3up
-          default_row_class: false
-      row:
-        type: fields
-        options:
-          default_field_elements: false
-          inline: {  }
-          separator: ''
-          hide_empty: true
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            sponsor: sponsor
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            sponsor: sponsor
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -1156,6 +1132,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             13: 13
@@ -1167,6 +1144,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -1174,8 +1153,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1189,17 +1166,41 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: sponsor_packages
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: l-3up
+          default_row_class: false
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: true
+      defaults:
+        title: false
+        css_class: false
+        style: false
+        row: false
+        filters: false
+        filter_groups: false
+        footer: false
       css_class: sponsor-group
+      display_description: ''
+      footer: {  }
+      display_extenders: {  }
+      block_description: 'Sponsor page Party'
     cache_metadata:
       max-age: 0
       contexts:
@@ -1212,46 +1213,35 @@ display:
       tags:
         - 'config:field.storage.node.field_image'
   block_6:
-    display_plugin: block
     id: block_6
     display_title: 'InKind Sponsors block'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      footer: {  }
-      defaults:
-        footer: false
-        filters: false
-        filter_groups: false
-        title: false
-        style: false
-        row: false
-        css_class: false
-      block_description: 'Sponsor page InKind'
+      title: 'In-Kind Sponsors'
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            sponsor: sponsor
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            sponsor: sponsor
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -1262,6 +1252,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             7: 7
@@ -1273,6 +1264,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -1280,8 +1273,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1295,17 +1286,15 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: sponsor_packages
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
-      title: 'In-Kind Sponsors'
       style:
         type: default
         options:
@@ -1319,7 +1308,19 @@ display:
           inline: {  }
           separator: ''
           hide_empty: true
+      defaults:
+        title: false
+        css_class: false
+        style: false
+        row: false
+        filters: false
+        filter_groups: false
+        footer: false
       css_class: 'sponsor-group clearfix'
+      display_description: ''
+      footer: {  }
+      display_extenders: {  }
+      block_description: 'Sponsor page InKind'
     cache_metadata:
       max-age: 0
       contexts:
@@ -1332,24 +1333,88 @@ display:
       tags:
         - 'config:field.storage.node.field_image'
   block_7:
-    display_plugin: block
     id: block_7
     display_title: 'Summit Sponsors block'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      footer: {  }
-      defaults:
-        footer: false
-        title: false
-        style: false
-        row: false
-        filters: false
-        filter_groups: false
-        css_class: false
-      block_description: 'Sponsor page Training'
       title: 'Summit Sponsors'
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            sponsor: sponsor
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+        field_sponsor_level_target_id:
+          id: field_sponsor_level_target_id
+          table: node__field_sponsor_level
+          field: field_sponsor_level_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value:
+            11: 11
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: sponsor_packages
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: default
         options:
@@ -1363,83 +1428,19 @@ display:
           inline: {  }
           separator: ''
           hide_empty: true
-      filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          value:
-            sponsor: sponsor
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-          expose:
-            operator_limit_selection: false
-            operator_list: {  }
-        field_sponsor_level_target_id:
-          id: field_sponsor_level_target_id
-          table: node__field_sponsor_level
-          field: field_sponsor_level_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: or
-          value:
-            11: 11
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          type: select
-          limit: true
-          vid: sponsor_packages
-          hierarchy: false
-          error_message: true
-          plugin_id: taxonomy_index_tid
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
+      defaults:
+        title: false
+        css_class: false
+        style: false
+        row: false
+        filters: false
+        filter_groups: false
+        footer: false
       css_class: sponsor-group
+      display_description: ''
+      footer: {  }
+      display_extenders: {  }
+      block_description: 'Sponsor page Training'
     cache_metadata:
       max-age: 0
       contexts:
@@ -1452,46 +1453,35 @@ display:
       tags:
         - 'config:field.storage.node.field_image'
   block_8:
-    display_plugin: block
     id: block_8
     display_title: 'Sprint Sponsors block'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      footer: {  }
-      defaults:
-        footer: false
-        filters: false
-        filter_groups: false
-        title: false
-        style: false
-        row: false
-        css_class: false
-      block_description: 'Sponsor page Sprints'
+      title: 'Contribution Day Sponsors'
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            sponsor: sponsor
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            sponsor: sponsor
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -1502,6 +1492,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             12: 12
@@ -1513,6 +1504,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -1520,8 +1513,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1535,17 +1526,15 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: sponsor_packages
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
-      title: 'Contribution Day Sponsors'
       style:
         type: default
         options:
@@ -1559,7 +1548,19 @@ display:
           inline: {  }
           separator: ''
           hide_empty: true
+      defaults:
+        title: false
+        css_class: false
+        style: false
+        row: false
+        filters: false
+        filter_groups: false
+        footer: false
       css_class: sponsor-group
+      display_description: ''
+      footer: {  }
+      display_extenders: {  }
+      block_description: 'Sponsor page Sprints'
     cache_metadata:
       max-age: 0
       contexts:
@@ -1572,46 +1573,35 @@ display:
       tags:
         - 'config:field.storage.node.field_image'
   block_9:
-    display_plugin: block
     id: block_9
     display_title: 'Contribution Day Sponsors block'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      footer: {  }
-      defaults:
-        footer: false
-        filters: false
-        filter_groups: false
-        title: false
-        style: false
-        row: false
-        css_class: false
-      block_description: 'Sponsor page Contribution Day'
+      title: 'Contribution Day Sponsors'
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            sponsor: sponsor
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            sponsor: sponsor
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -1622,6 +1612,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             172: 172
@@ -1633,6 +1624,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -1640,8 +1633,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1655,17 +1646,15 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: sponsor_packages
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
-      title: 'Contribution Day Sponsors'
       style:
         type: default
         options:
@@ -1679,7 +1668,19 @@ display:
           inline: {  }
           separator: ''
           hide_empty: true
+      defaults:
+        title: false
+        css_class: false
+        style: false
+        row: false
+        filters: false
+        filter_groups: false
+        footer: false
       css_class: sponsor-group
+      display_description: ''
+      footer: {  }
+      display_extenders: {  }
+      block_description: 'Sponsor page Contribution Day'
     cache_metadata:
       max-age: 0
       contexts:

--- a/conf/drupal/config/views.view.event_sub_events.yml
+++ b/conf/drupal/config/views.view.event_sub_events.yml
@@ -20,79 +20,34 @@ base_table: taxonomy_term_field_data
 base_field: tid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: some
-        options:
-          items_per_page: 5
-          offset: 0
-      style:
-        type: default
-        options:
-          row_class: ''
-          default_row_class: false
-          uses_fields: false
-      row:
-        type: 'entity:taxonomy_term'
-        options:
-          relationship: none
-          view_mode: sub_event_teaser
+      title: 'Events at a Glance'
       fields:
         name:
           id: name
           table: taxonomy_term_field_data
           field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: taxonomy_term
           entity_field: name
+          plugin_id: term_name
           label: ''
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          type: string
-          settings:
-            link_to_entity: true
-          plugin_id: term_name
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -102,8 +57,13 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -122,6 +82,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -179,20 +140,29 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
-      filters:
-        vid:
-          id: vid
-          table: taxonomy_term_field_data
-          field: vid
-          value:
-            event: event
-          entity_type: taxonomy_term
-          entity_field: vid
-          plugin_id: bundle
-          expose:
-            operator_limit_selection: false
-            operator_list: {  }
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 5
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
       sorts:
         field_date_value:
           id: field_date_value
@@ -201,17 +171,13 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           order: ASC
-          exposed: false
           expose:
             label: ''
+            field_identifier: field_date_value
+          exposed: false
           granularity: second
-          plugin_id: datetime
-      title: 'Events at a Glance'
-      header: {  }
-      footer: {  }
-      empty: {  }
-      relationships: {  }
       arguments:
         parent:
           id: parent
@@ -220,6 +186,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy
           default_action: default
           exception:
             value: all
@@ -230,16 +197,16 @@ display:
           default_argument_type: taxonomy_tid
           default_argument_options:
             term_page: '1'
-            anyall: ','
             node: false
             limit: false
             vids: {  }
+            anyall: ','
           default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -251,12 +218,46 @@ display:
           validate_options:
             bundles:
               event: event
+            access: false
             operation: view
             multiple: 0
-            access: false
           break_phrase: false
           not: false
-          plugin_id: taxonomy
+      filters:
+        vid:
+          id: vid
+          table: taxonomy_term_field_data
+          field: vid
+          entity_type: taxonomy_term
+          entity_field: vid
+          plugin_id: bundle
+          value:
+            event: event
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+      style:
+        type: default
+        options:
+          row_class: ''
+          default_row_class: false
+          uses_fields: false
+      row:
+        type: 'entity:taxonomy_term'
+        options:
+          relationship: none
+          view_mode: sub_event_teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -268,13 +269,13 @@ display:
       tags:
         - 'config:field.storage.taxonomy_term.field_date'
   block_1:
-    display_plugin: block
     id: block_1
     display_title: 'Sub-events Block'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
       display_description: ''
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.event_venue.yml
+++ b/conf/drupal/config/views.view.event_venue.yml
@@ -20,59 +20,21 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: some
-        options:
-          items_per_page: 1
-          offset: 0
-      style:
-        type: default
-      row:
-        type: 'entity:node'
-        options:
-          relationship: none
-          view_mode: map
+      title: Venue
       fields:
         title:
           id: title
           table: node_field_data
           field: title
-          settings:
-            link_to_entity: true
-          plugin_id: field
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -116,6 +78,8 @@ display:
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -133,6 +97,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -187,54 +152,46 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
-      filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          value:
-            venue: venue
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-          expose:
-            operator_limit_selection: false
-            operator_list: {  }
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 1
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
       sorts:
         created:
           id: created
           table: node_field_data
           field: created
-          order: DESC
-          entity_type: node
-          entity_field: created
-          plugin_id: date
           relationship: none
           group_type: group
           admin_label: ''
-          exposed: false
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: DESC
           expose:
             label: ''
+            field_identifier: created
+          exposed: false
           granularity: second
-      title: Venue
-      header: {  }
-      footer: {  }
-      empty: {  }
-      relationships: {  }
       arguments:
         term_node_tid_depth:
           id: term_node_tid_depth
@@ -243,6 +200,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: taxonomy_index_tid_depth
           default_action: default
           exception:
             value: all
@@ -254,15 +213,15 @@ display:
           default_argument_options:
             term_page: '1'
             node: true
-            anyall: ','
             limit: false
             vids: {  }
+            anyall: ','
           default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -272,13 +231,55 @@ display:
             type: none
             fail: 'not found'
           validate_options: {  }
-          depth: 0
           break_phrase: false
+          depth: 0
           use_taxonomy_term_path: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
           entity_type: node
-          plugin_id: taxonomy_index_tid_depth
-      display_extenders: {  }
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            venue: venue
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+      style:
+        type: default
+      row:
+        type: 'entity:node'
+        options:
+          relationship: none
+          view_mode: map
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       css_class: container
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -290,13 +291,13 @@ display:
       tags:
         - 'config:field.storage.node.field_address'
   block_1:
-    display_plugin: block
     id: block_1
     display_title: 'Event Venue Block'
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
       display_description: ''
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.files.yml
+++ b/conf/drupal/config/views.view.files.yml
@@ -16,26 +16,456 @@ base_table: file_managed
 base_field: fid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
+      title: Files
+      fields:
+        fid:
+          id: fid
+          table: file_managed
+          field: fid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: fid
+          plugin_id: field
+          label: Fid
+          exclude: true
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+        filename:
+          id: filename
+          table: file_managed
+          field: filename
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: filename
+          plugin_id: field
+          label: Name
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: file_link
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        filemime:
+          id: filemime
+          table: file_managed
+          field: filemime
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: filemime
+          plugin_id: field
+          label: 'MIME type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: file_filemime
+        filesize:
+          id: filesize
+          table: file_managed
+          field: filesize
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: filesize
+          plugin_id: field
+          label: Size
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: file_size
+        status:
+          id: status
+          table: file_managed
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: status
+          plugin_id: field
+          label: Status
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: boolean
+          settings:
+            format: custom
+            format_custom_false: Temporary
+            format_custom_true: Permanent
+        created:
+          id: created
+          table: file_managed
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: created
+          plugin_id: field
+          label: 'Upload date'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+        changed:
+          id: changed
+          table: file_managed
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: changed
+          plugin_id: field
+          label: 'Changed date'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+        count:
+          id: count
+          table: file_usage
+          field: count
+          relationship: fid
+          group_type: sum
+          admin_label: ''
+          plugin_id: numeric
+          label: 'Used in'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: true
+            path: 'admin/content/files/usage/{{ fid }}'
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ','
+          format_plural: true
+          format_plural_string: !!binary MSBwbGFjZQNAY291bnQgcGxhY2Vz
+          prefix: ''
+          suffix: ''
+      pager:
+        type: mini
         options:
-          perm: 'access files overview'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
+          offset: 0
+          items_per_page: 50
+          total_pages: 0
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
       exposed_form:
         type: basic
         options:
@@ -46,35 +476,159 @@ display:
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
-      pager:
-        type: mini
+      access:
+        type: perm
         options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: 0
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
+          perm: 'access files overview'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          plugin_id: text_custom
+          empty: true
+          content: 'No files available.'
+      sorts: {  }
+      arguments: {  }
+      filters:
+        filename:
+          id: filename
+          table: file_managed
+          field: filename
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: filename
+          plugin_id: string
+          operator: word
+          value: ''
+          group: 1
+          exposed: true
           expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
+            operator_id: filemime_op
+            label: Filename
+            description: ''
+            use_operator: false
+            operator: filename_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: filename
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        filemime:
+          id: filemime
+          table: file_managed
+          field: filemime
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: filemime
+          plugin_id: string
+          operator: word
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: filemime_op
+            label: 'MIME type'
+            description: ''
+            use_operator: false
+            operator: filemime_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: filemime
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status:
+          id: status
+          table: file_managed
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: file
+          entity_field: status
+          plugin_id: file_status
+          operator: in
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: status_op
+            label: Status
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       style:
         type: table
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
           columns:
             fid: fid
             filename: filename
@@ -84,6 +638,7 @@ display:
             created: created
             changed: changed
             count: count
+          default: changed
           info:
             fid:
               sortable: false
@@ -141,578 +696,22 @@ display:
               separator: ''
               empty_column: false
               responsive: priority-medium
-          default: changed
+          override: true
+          sticky: false
+          summary: ''
           empty_table: true
+          caption: ''
+          description: ''
       row:
         type: fields
-      fields:
-        fid:
-          id: fid
-          table: file_managed
-          field: fid
-          alter:
-            alter_text: false
-            make_link: false
-            absolute: false
-            trim: false
-            word_boundary: false
-            ellipsis: false
-            strip_tags: false
-            html: false
-          hide_empty: false
-          empty_zero: false
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: Fid
-          exclude: true
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_alter_empty: true
-          plugin_id: field
-          entity_type: file
-          entity_field: fid
-        filename:
-          id: filename
-          table: file_managed
-          field: filename
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: Name
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: false
-            ellipsis: false
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: file_link
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          plugin_id: field
-          entity_type: file
-          entity_field: filename
-        filemime:
-          id: filemime
-          table: file_managed
-          field: filemime
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: 'MIME type'
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          type: file_filemime
-          plugin_id: field
-          entity_type: file
-          entity_field: filemime
-        filesize:
-          id: filesize
-          table: file_managed
-          field: filesize
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: Size
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          type: file_size
-          plugin_id: field
-          entity_type: file
-          entity_field: filesize
-        status:
-          id: status
-          table: file_managed
-          field: status
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: Status
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          type: boolean
-          settings:
-            format: custom
-            format_custom_false: Temporary
-            format_custom_true: Permanent
-          plugin_id: field
-          entity_type: file
-          entity_field: status
-        created:
-          id: created
-          table: file_managed
-          field: created
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: 'Upload date'
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          type: timestamp
-          settings:
-            date_format: medium
-            custom_date_format: ''
-            timezone: ''
-          plugin_id: field
-          entity_type: file
-          entity_field: created
-        changed:
-          id: changed
-          table: file_managed
-          field: changed
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: 'Changed date'
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          type: timestamp
-          settings:
-            date_format: medium
-            custom_date_format: ''
-            timezone: ''
-          plugin_id: field
-          entity_type: file
-          entity_field: changed
-        count:
-          id: count
-          table: file_usage
-          field: count
-          relationship: fid
-          group_type: sum
-          admin_label: ''
-          label: 'Used in'
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: true
-            path: 'admin/content/files/usage/{{ fid }}'
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          set_precision: false
-          precision: 0
-          decimal: .
-          separator: ','
-          format_plural: true
-          format_plural_string: !!binary MSBwbGFjZQNAY291bnQgcGxhY2Vz
-          prefix: ''
-          suffix: ''
-          plugin_id: numeric
-      filters:
-        filename:
-          id: filename
-          table: file_managed
-          field: filename
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: word
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: filemime_op
-            label: Filename
-            description: ''
-            use_operator: false
-            operator: filename_op
-            identifier: filename
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: string
-          entity_type: file
-          entity_field: filename
-        filemime:
-          id: filemime
-          table: file_managed
-          field: filemime
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: word
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: filemime_op
-            label: 'MIME type'
-            description: ''
-            use_operator: false
-            operator: filemime_op
-            identifier: filemime
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: string
-          entity_type: file
-          entity_field: filemime
-        status:
-          id: status
-          table: file_managed
-          field: status
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: in
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: status_op
-            label: Status
-            description: ''
-            use_operator: false
-            operator: status_op
-            identifier: status
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: file_status
-          entity_type: file
-          entity_field: status
-      sorts: {  }
-      title: Files
-      header: {  }
-      footer: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          empty: true
-          content: 'No files available.'
-          plugin_id: text_custom
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         fid:
           id: fid
@@ -722,34 +721,26 @@ display:
           group_type: group
           admin_label: 'File usage'
           required: true
-      arguments: {  }
       group_by: true
       show_admin_links: true
+      header: {  }
+      footer: {  }
       display_extenders: {  }
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - user.permissions
-      max-age: -1
       tags: {  }
   page_1:
-    display_plugin: page
     id: page_1
     display_title: 'Files overview'
+    display_plugin: page
     position: 1
     display_options:
-      path: admin/content/files
-      menu:
-        type: tab
-        title: Files
-        description: ''
-        menu_name: admin
-        weight: 0
-        context: ''
-      display_description: ''
       defaults:
         pager: true
         relationships: false
@@ -762,59 +753,32 @@ display:
           group_type: group
           admin_label: 'File usage'
           required: false
+      display_description: ''
       display_extenders: {  }
+      path: admin/content/files
+      menu:
+        type: tab
+        title: Files
+        description: ''
+        weight: 0
+        menu_name: admin
+        context: ''
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - user.permissions
-      max-age: -1
       tags: {  }
   page_2:
-    display_plugin: page
     id: page_2
     display_title: 'File usage'
+    display_plugin: page
     position: 2
     display_options:
-      display_description: ''
-      path: admin/content/files/usage/%
-      empty: {  }
-      defaults:
-        empty: false
-        pager: false
-        filters: false
-        filter_groups: false
-        fields: false
-        group_by: false
-        title: false
-        arguments: false
-        style: false
-        row: false
-        relationships: false
-      pager:
-        type: mini
-        options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: 0
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-      filters: {  }
-      filter_groups:
-        operator: AND
-        groups: {  }
+      title: 'File usage'
       fields:
         entity_label:
           id: entity_label
@@ -823,6 +787,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: entity_label
           label: Entity
           exclude: false
           alter:
@@ -865,7 +830,6 @@ display:
           empty_zero: false
           hide_alter_empty: true
           link_to_entity: true
-          plugin_id: entity_label
         type:
           id: type
           table: file_usage
@@ -873,6 +837,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: standard
           label: 'Entity type'
           exclude: false
           alter:
@@ -914,7 +879,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: standard
         module:
           id: module
           table: file_usage
@@ -922,6 +886,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: standard
           label: 'Registering module'
           exclude: false
           alter:
@@ -963,7 +928,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: standard
         count:
           id: count
           table: file_usage
@@ -971,6 +935,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: numeric
           label: 'Use count'
           exclude: false
           alter:
@@ -1020,9 +985,25 @@ display:
           format_plural_string: !!binary MQNAY291bnQ=
           prefix: ''
           suffix: ''
-          plugin_id: numeric
-      group_by: false
-      title: 'File usage'
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: 0
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      empty: {  }
       arguments:
         fid:
           id: fid
@@ -1031,6 +1012,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: file
+          entity_field: fid
+          plugin_id: file_fid
           default_action: 'not found'
           exception:
             value: all
@@ -1045,8 +1029,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -1058,25 +1042,22 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
-          plugin_id: file_fid
-          entity_type: file
-          entity_field: fid
+      filters: {  }
+      filter_groups:
+        operator: AND
+        groups: {  }
       style:
         type: table
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
           columns:
             entity_label: entity_label
             type: type
             module: module
             count: count
+          default: entity_label
           info:
             entity_label:
               sortable: true
@@ -1106,11 +1087,27 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-          default: entity_label
+          override: true
+          sticky: false
+          summary: ''
           empty_table: true
+          caption: ''
+          description: ''
       row:
         type: fields
         options: {  }
+      defaults:
+        empty: false
+        title: false
+        pager: false
+        group_by: false
+        style: false
+        row: false
+        relationships: false
+        fields: false
+        arguments: false
+        filters: false
+        filter_groups: false
       relationships:
         fid:
           id: fid
@@ -1120,12 +1117,15 @@ display:
           group_type: group
           admin_label: 'File usage'
           required: true
+      group_by: false
+      display_description: ''
       display_extenders: {  }
+      path: admin/content/files/usage/%
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_interface'
         - url
         - url.query_args
         - user.permissions
-      max-age: -1
       tags: {  }

--- a/conf/drupal/config/views.view.frontpage.yml
+++ b/conf/drupal/config/views.view.frontpage.yml
@@ -19,49 +19,34 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
+    id: default
+    display_title: Master
+    display_plugin: default
+    position: 0
     display_options:
-      access:
-        type: perm
+      title: ''
+      fields: {  }
+      pager:
+        type: full
         options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      empty:
-        area_text_custom:
-          admin_label: ''
-          content: 'No front page content has been created yet.'
-          empty: true
-          field: area_text_custom
-          group_type: group
-          id: area_text_custom
-          label: ''
-          relationship: none
-          table: views
-          tokenize: false
-          plugin_id: text_custom
-        node_listing_empty:
-          admin_label: ''
-          empty: true
-          field: node_listing_empty
-          group_type: group
-          id: node_listing_empty
-          label: ''
-          relationship: none
-          table: node
-          plugin_id: node_listing_empty
-          entity_type: node
-        title:
-          id: title
-          table: views
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          empty: true
-          title: 'Welcome to [site:name]'
-          plugin_id: title
+          offset: 0
+          items_per_page: 10
+          total_pages: 0
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
       exposed_form:
         type: basic
         options:
@@ -72,60 +57,135 @@ display:
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          label: ''
+          empty: true
+          content: 'No front page content has been created yet.'
+          tokenize: false
+        node_listing_empty:
+          id: node_listing_empty
+          table: node
+          field: node_listing_empty
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: node_listing_empty
+          label: ''
+          empty: true
+        title:
+          id: title
+          table: views
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: title
+          label: ''
+          empty: true
+          title: 'Welcome to [site:name]'
+      sorts:
+        sticky:
+          id: sticky
+          table: node_field_data
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: sticky
+          plugin_id: boolean
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: sticky
+          exposed: false
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments: {  }
       filters:
         promote:
-          admin_label: ''
-          expose:
-            description: ''
-            identifier: ''
-            label: ''
-            multiple: false
-            operator: ''
-            operator_id: ''
-            remember: false
-            remember_roles:
-              authenticated: authenticated
-            required: false
-            use_operator: false
-            operator_limit_selection: false
-            operator_list: {  }
-          exposed: false
-          field: promote
-          group: 1
-          group_info:
-            default_group: All
-            default_group_multiple: {  }
-            description: ''
-            group_items: {  }
-            identifier: ''
-            label: ''
-            multiple: false
-            optional: true
-            remember: false
-            widget: select
-          group_type: group
           id: promote
-          is_grouped: false
-          operator: '='
-          relationship: none
           table: node_field_data
-          value: '1'
-          plugin_id: boolean
+          field: promote
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: promote
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          field: status
-          group: 1
-          id: status
-          table: node_field_data
-          value: '1'
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
         langcode:
           id: langcode
           table: node_field_data
@@ -133,6 +193,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
           operator: in
           value:
             '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
@@ -144,6 +207,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -151,8 +216,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -165,72 +228,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: language
-          entity_type: node
-          entity_field: langcode
-      pager:
-        type: full
-        options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: 0
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
-          quantity: 9
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      row:
-        type: 'entity:node'
-        options:
-          view_mode: teaser
-      sorts:
-        sticky:
-          admin_label: ''
-          expose:
-            label: ''
-          exposed: false
-          field: sticky
-          group_type: group
-          id: sticky
-          order: DESC
-          relationship: none
-          table: node_field_data
-          plugin_id: boolean
-          entity_type: node
-          entity_field: sticky
-        created:
-          field: created
-          id: created
-          order: DESC
-          table: node_field_data
-          plugin_id: date
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-          entity_type: node
-          entity_field: created
       style:
         type: default
         options:
@@ -238,73 +235,78 @@ display:
           row_class: ''
           default_row_class: true
           uses_fields: false
-      title: ''
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header: {  }
       footer: {  }
-      relationships: {  }
-      fields: {  }
-      arguments: {  }
       display_extenders: {  }
-    display_plugin: default
-    display_title: Master
-    id: default
-    position: 0
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_interface'
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
-      max-age: -1
       tags: {  }
   feed_1:
-    display_plugin: feed
     id: feed_1
     display_title: Feed
+    display_plugin: feed
     position: 2
     display_options:
-      sitename_title: true
-      path: rss.xml
-      displays:
-        page_1: page_1
-        default: ''
       pager:
         type: some
         options:
-          items_per_page: 10
           offset: 0
+          items_per_page: 10
       style:
         type: rss
         options:
-          description: ''
           grouping: {  }
           uses_fields: false
+          description: ''
       row:
         type: node_rss
         options:
           relationship: none
           view_mode: rss
       display_extenders: {  }
+      path: rss.xml
+      sitename_title: true
+      displays:
+        page_1: page_1
+        default: ''
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_interface'
         - 'user.node_grants:view'
         - user.permissions
-      max-age: -1
       tags: {  }
   page_1:
-    display_options:
-      path: node
-      display_extenders: {  }
-    display_plugin: page
-    display_title: Page
     id: page_1
+    display_title: Page
+    display_plugin: page
     position: 1
+    display_options:
+      display_extenders: {  }
+      path: node
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_interface'
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
-      max-age: -1
       tags: {  }

--- a/conf/drupal/config/views.view.glossary.yml
+++ b/conf/drupal/config/views.view.glossary.yml
@@ -23,59 +23,17 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      query:
-        type: views_query
-        options:
-          query_comment: ''
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_tags: {  }
-      use_ajax: true
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 36
-          offset: 0
-          id: 0
-          total_pages: 0
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
       fields:
         title:
           id: title
           table: node_field_data
           field: title
-          plugin_id: field
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: Title
           exclude: false
           alter:
@@ -117,18 +75,17 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          entity_type: node
-          entity_field: title
         name:
           id: name
           table: users_field_data
           field: name
-          label: Author
           relationship: uid
-          plugin_id: field
-          type: user_name
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+          label: Author
           exclude: false
           alter:
             alter_text: false
@@ -169,111 +126,197 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          entity_type: user
-          entity_field: name
+          type: user_name
         changed:
           id: changed
           table: node_field_data
           field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
           label: 'Last update'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
           type: timestamp
           settings:
             date_format: long
             custom_date_format: ''
             timezone: ''
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          entity_type: node
-          entity_field: changed
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 36
+          total_pages: 0
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
       arguments:
         title:
           id: title
           table: node_field_data
           field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
           default_action: default
           exception:
             title_enable: true
+          title_enable: false
+          title: ''
           default_argument_type: fixed
           default_argument_options:
             argument: a
+          default_argument_skip_url: false
+          summary_options: {  }
           summary:
             format: default_summary
           specify_validation: true
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
           glossary: true
           limit: 1
           case: upper
           path_case: lower
           transform_dash: false
-          plugin_id: string
+          break_phrase: false
+      filters:
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
           relationship: none
           group_type: group
           admin_label: ''
-          title_enable: false
-          title: ''
-          default_argument_skip_url: false
-          summary_options: {  }
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: false
           entity_type: node
-          entity_field: title
-      relationships:
-        uid:
-          id: uid
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        status:
+          id: status
           table: node_field_data
-          field: uid
-          plugin_id: standard
-          relationship: none
-          group_type: group
-          admin_label: author
-          required: false
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
       style:
         type: table
         options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
           columns:
             title: title
             name: name
@@ -291,82 +334,40 @@ display:
               separator: ''
           override: true
           sticky: false
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          uses_fields: false
-          order: asc
           summary: ''
+          order: asc
           empty_table: false
       row:
         type: fields
         options:
+          default_field_elements: true
           inline: {  }
           separator: ''
           hide_empty: false
-          default_field_elements: true
-      header: {  }
-      footer: {  }
-      empty: {  }
-      sorts: {  }
-      filters:
-        langcode:
-          id: langcode
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        uid:
+          id: uid
           table: node_field_data
-          field: langcode
+          field: uid
           relationship: none
           group_type: group
-          admin_label: ''
-          operator: in
-          value:
-            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: language
-          entity_type: node
-          entity_field: langcode
-        status:
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          field: status
-          group: 1
-          id: status
-          table: node_field_data
-          value: '1'
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
+          admin_label: author
+          plugin_id: standard
+          required: false
+      use_ajax: true
+      header: {  }
+      footer: {  }
       display_extenders: {  }
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -374,7 +375,6 @@ display:
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
-      max-age: -1
       tags: {  }
   attachment_1:
     id: attachment_1
@@ -382,59 +382,60 @@ display:
     display_plugin: attachment
     position: 2
     display_options:
-      query:
-        type: views_query
-        options: {  }
       pager:
         type: none
         options:
           offset: 0
           items_per_page: 0
-      defaults:
-        arguments: false
       arguments:
         title:
           id: title
           table: node_field_data
           field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
           default_action: summary
           exception:
             title_enable: true
+          title_enable: false
+          title: ''
           default_argument_type: fixed
           default_argument_options:
             argument: a
-          summary:
-            format: unformatted_summary
+          default_argument_skip_url: false
           summary_options:
             items_per_page: 25
             inline: true
             separator: ' | '
+          summary:
+            format: unformatted_summary
           specify_validation: true
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
           glossary: true
           limit: 1
           case: upper
           path_case: lower
           transform_dash: false
-          plugin_id: string
-          relationship: none
-          group_type: group
-          admin_label: ''
-          title_enable: false
-          title: ''
-          default_argument_skip_url: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
           break_phrase: false
-          entity_type: node
-          entity_field: title
+      query:
+        type: views_query
+        options: {  }
+      defaults:
+        arguments: false
+      display_extenders: {  }
       displays:
         default: default
         page_1: page_1
       inherit_arguments: false
-      display_extenders: {  }
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -442,7 +443,6 @@ display:
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
-      max-age: -1
       tags: {  }
   page_1:
     id: page_1
@@ -453,6 +453,7 @@ display:
       query:
         type: views_query
         options: {  }
+      display_extenders: {  }
       path: glossary
       menu:
         type: normal
@@ -460,8 +461,8 @@ display:
         weight: 0
         menu_name: main
         parent: ''
-      display_extenders: {  }
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -469,5 +470,4 @@ display:
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
-      max-age: -1
       tags: {  }

--- a/conf/drupal/config/views.view.jobs_board.yml
+++ b/conf/drupal/config/views.view.jobs_board.yml
@@ -23,70 +23,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
-          quantity: 9
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: l-1up
-          default_row_class: true
-      row:
-        type: fields
-        options:
-          default_field_elements: true
-          inline: {  }
-          separator: ''
-          hide_empty: false
+      title: 'Job Board'
       fields:
         title:
           id: title
@@ -95,6 +37,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -150,7 +93,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_sponsor_company:
           id: field_sponsor_company
           table: node__field_sponsor_company
@@ -158,6 +100,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -213,7 +156,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         nothing:
           id: nothing
           table: views
@@ -221,11 +163,14 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: custom
           label: ''
           exclude: false
           alter:
             alter_text: true
-            text: "<hr>\n<strong>{{ title }} at {{ field_sponsor_company }}</strong>"
+            text: |-
+              <hr>
+              <strong>{{ title }} at {{ field_sponsor_company }}</strong>
             make_link: false
             path: ''
             absolute: false
@@ -262,7 +207,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: false
-          plugin_id: custom
         field_job_location:
           id: field_job_location
           table: node__field_job_location
@@ -270,6 +214,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -325,7 +270,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_job_type:
           id: field_job_type
           table: node__field_job_type
@@ -333,6 +277,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -387,7 +332,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_job_skill_level:
           id: field_job_skill_level
           table: node__field_job_skill_level
@@ -395,6 +339,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -449,7 +394,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_job_description:
           id: field_job_description
           table: node__field_job_description
@@ -457,6 +401,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -512,30 +457,96 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: '<p>There are no job postings yet.</p>'
+            format: basic_html
+          tokenize: false
+      sorts:
+        random:
+          id: random
+          table: views
+          field: random
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: random
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: random
+          exposed: false
+      arguments: {  }
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            job: job
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            job: job
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -546,6 +557,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: list_field
           operator: or
           value: {  }
           group: 1
@@ -556,6 +568,8 @@ display:
             description: ''
             use_operator: false
             operator: field_job_type_value_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_job_type_value
             required: false
             remember: false
@@ -565,8 +579,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -580,7 +592,6 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          plugin_id: list_field
         field_job_skill_level_value:
           id: field_job_skill_level_value
           table: node__field_job_skill_level
@@ -588,6 +599,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: list_field
           operator: or
           value: {  }
           group: 1
@@ -598,6 +610,8 @@ display:
             description: ''
             use_operator: false
             operator: field_job_skill_level_value_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_job_skill_level_value
             required: false
             remember: false
@@ -607,8 +621,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -622,21 +634,28 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          plugin_id: list_field
-      sorts:
-        random:
-          id: random
-          table: views
-          field: random
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: random
-      title: 'Job Board'
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: l-1up
+          default_row_class: true
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header:
         area:
           id: area
@@ -645,29 +664,15 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: "<p>Job postings are a benefit of MidCamp sponsors. If you are a sponsor and need help getting your jobs posted, shoot us an email and we&rsquo;ll gladly help out.</p>\n<p>If you are not currently a MidCamp sponsor and have jobs to post, take a look at our <a href=\"/become-a-sponsor\">prospectus</a>!</p>"
-            format: basic_html
           plugin_id: text
+          empty: true
+          content:
+            value: |-
+              <p>Job postings are a benefit of MidCamp sponsors. If you are a sponsor and need help getting your jobs posted, shoot us an email and we&rsquo;ll gladly help out.</p>
+              <p>If you are not currently a MidCamp sponsor and have jobs to post, take a look at our <a href="/become-a-sponsor">prospectus</a>!</p>
+            format: basic_html
+          tokenize: false
       footer: {  }
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: '<p>There are no job postings yet.</p>'
-            format: basic_html
-          plugin_id: text
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: 0
@@ -685,74 +690,12 @@ display:
         - 'config:field.storage.node.field_job_type'
         - 'config:field.storage.node.field_sponsor_company'
   block_1:
-    display_plugin: block
     id: block_1
     display_title: Block
+    display_plugin: block
     position: 2
     display_options:
-      display_extenders: {  }
       title: ''
-      defaults:
-        title: false
-        arguments: false
-        relationships: false
-        header: false
-        css_class: false
-        fields: false
-        empty: false
-        sorts: false
-      arguments:
-        field_sponsor_company_target_id:
-          id: field_sponsor_company_target_id
-          table: node__field_sponsor_company
-          field: field_sponsor_company_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: raw
-          default_argument_options:
-            index: 1
-            use_alias: false
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: false
-          not: false
-          plugin_id: numeric
-      relationships: {  }
-      block_description: 'Sponsor Jobs'
-      header:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: true
-          content: '<h2>Jobs at {{ field_sponsor_company }}</h2>'
-          plugin_id: text_custom
-      css_class: l-1up
       fields:
         title:
           id: title
@@ -761,6 +704,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -816,7 +760,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_sponsor_company:
           id: field_sponsor_company
           table: node__field_sponsor_company
@@ -824,6 +767,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -879,7 +823,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         nothing:
           id: nothing
           table: views
@@ -887,11 +830,14 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: custom
           label: ''
           exclude: false
           alter:
             alter_text: true
-            text: "<hr>\n<strong>{{ title }} at {{ field_sponsor_company }}</strong>"
+            text: |-
+              <hr>
+              <strong>{{ title }} at {{ field_sponsor_company }}</strong>
             make_link: false
             path: ''
             absolute: false
@@ -928,7 +874,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: false
-          plugin_id: custom
         field_job_location:
           id: field_job_location
           table: node__field_job_location
@@ -936,6 +881,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -991,7 +937,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_job_type:
           id: field_job_type
           table: node__field_job_type
@@ -999,6 +944,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1053,7 +999,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_job_skill_level:
           id: field_job_skill_level
           table: node__field_job_skill_level
@@ -1061,6 +1006,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1115,7 +1061,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_job_description:
           id: field_job_description
           table: node__field_job_description
@@ -1123,6 +1068,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1178,7 +1124,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
       empty: {  }
       sorts:
         title:
@@ -1188,13 +1133,76 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
           entity_type: node
           entity_field: title
           plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: title
+          exposed: false
+      arguments:
+        field_sponsor_company_target_id:
+          id: field_sponsor_company_target_id
+          table: node__field_sponsor_company
+          field: field_sponsor_company_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: raw
+          default_argument_options:
+            index: 1
+            use_alias: false
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      defaults:
+        empty: false
+        title: false
+        css_class: false
+        relationships: false
+        fields: false
+        sorts: false
+        arguments: false
+        header: false
+      relationships: {  }
+      css_class: l-1up
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: false
+          content: '<h2>Jobs at {{ field_sponsor_company }}</h2>'
+          tokenize: true
+      display_extenders: {  }
+      block_description: 'Sponsor Jobs'
     cache_metadata:
       max-age: -1
       contexts:
@@ -1211,13 +1219,18 @@ display:
         - 'config:field.storage.node.field_job_type'
         - 'config:field.storage.node.field_sponsor_company'
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Page
+    display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
-      path: jobs
+      pager:
+        type: none
+        options:
+          offset: 0
+      defaults:
+        pager: false
+        header: false
       header:
         area:
           id: area
@@ -1226,19 +1239,14 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: true
-          tokenize: false
           content:
             value: "<p>Job postings are a benefit of MidCamp sponsors. If you are a sponsor and need help getting your jobs posted, shoot us an email and we&rsquo;ll gladly help out.</p>\r\n<p>If you are not currently a MidCamp sponsor and have jobs to post, take a look at our <a href=\"/become-a-sponsor\">prospectus</a>!</p>\r\n<p>Regular sponsors get full access to our job board. For only $250 you can get access to post up to 3 jobs on our Job Board, targeting our audience of experienced web professionals from Chicagoland and beyond. MidCamp attracts Front End Developers, Engineers, Team Leads, Project Managers, Designers, and more. Over 50% of our audience have 3 or more years experience in the field. We promote the board before camp on social media and during camp during all of our announcements. To get started, email <a href=\"mailto:sponsor@midcamp.org\">sponsor@midcamp.org</a>.</p>\r\n"
             format: basic_html
-          plugin_id: text
-      defaults:
-        header: false
-        pager: false
-      pager:
-        type: none
-        options:
-          offset: 0
+          tokenize: false
+      display_extenders: {  }
+      path: jobs
     cache_metadata:
       max-age: 0
       contexts:

--- a/conf/drupal/config/views.view.live_sessions.yml
+++ b/conf/drupal/config/views.view.live_sessions.yml
@@ -26,58 +26,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: some
-        options:
-          items_per_page: 0
-          offset: 0
-      style:
-        type: default
-        options:
-          grouping:
-            -
-              field: field_schedule_time
-              rendered: false
-              rendered_strip: false
-          row_class: schedule__teaser
-          default_row_class: false
-      row:
-        type: fields
-        options:
-          default_field_elements: false
-          inline: {  }
-          separator: ''
-          hide_empty: false
+      title: 'Live Sessions'
       fields:
         field_schedule_time:
           id: field_schedule_time
@@ -86,6 +40,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -143,7 +98,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_track:
           id: field_track
           table: node__field_track
@@ -151,6 +105,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -206,7 +161,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -214,6 +168,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -269,9 +226,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -279,6 +233,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -334,7 +289,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_schedule_location:
           id: field_schedule_location
           table: node__field_schedule_location
@@ -342,6 +296,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -397,30 +352,68 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        field_schedule_time_value:
+          id: field_schedule_time_value
+          table: node__field_schedule_time
+          field: field_schedule_time_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: field_schedule_time_value
+          exposed: false
+          granularity: second
+      arguments: {  }
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            topic: topic
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            topic: topic
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -431,6 +424,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             234: 234
@@ -464,12 +458,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_schedule_time_value:
           id: field_schedule_time_value
           table: node__field_schedule_time
@@ -477,6 +470,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           operator: '<='
           value:
             min: now
@@ -491,17 +485,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -514,7 +508,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
         field_schedule_time_end_value:
           id: field_schedule_time_end_value
           table: node__field_schedule_time
@@ -522,6 +515,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           operator: '>='
           value:
             min: now
@@ -536,17 +530,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -559,22 +553,33 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
-      sorts:
-        field_schedule_time_value:
-          id: field_schedule_time_value
-          table: node__field_schedule_time
-          field: field_schedule_time_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-          plugin_id: datetime
-      title: 'Live Sessions'
+      style:
+        type: default
+        options:
+          grouping:
+            -
+              field: field_schedule_time
+              rendered: false
+              rendered_strip: false
+          row_class: schedule__teaser
+          default_row_class: false
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: schedule
       header:
         area:
           id: area
@@ -583,18 +588,14 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: false
-          tokenize: false
           content:
             value: "<h2 class=\"banner-title\">Sessions Live Now</h2>\r\n<hr />"
             format: full_html
-          plugin_id: text
+          tokenize: false
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
-      css_class: schedule
     cache_metadata:
       max-age: -1
       contexts:
@@ -609,13 +610,13 @@ display:
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
   block_1:
-    display_plugin: block
     id: block_1
     display_title: Block
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
-      block_description: 'Live Sessions: Live Now'
+      defaults:
+        footer: false
       footer:
         view:
           id: view
@@ -624,12 +625,12 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: view
           empty: false
           view_to_insert: 'live_sessions:block_2'
           inherit_arguments: false
-          plugin_id: view
-      defaults:
-        footer: false
+      display_extenders: {  }
+      block_description: 'Live Sessions: Live Now'
     cache_metadata:
       max-age: -1
       contexts:
@@ -644,55 +645,35 @@ display:
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
   block_2:
-    display_plugin: block
     id: block_2
     display_title: 'Block 2'
+    display_plugin: block
     position: 2
     display_options:
-      display_extenders: {  }
       title: 'Sessions Coming Next'
-      defaults:
-        title: false
-        header: false
-        filters: false
-        filter_groups: false
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: "<h2 class=\"banner-title\">Sessions Coming Up</h2>\r\n<hr />"
-            format: full_html
-          plugin_id: text
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            topic: topic
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            topic: topic
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -703,6 +684,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             234: 234
@@ -736,12 +718,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_schedule_time_value:
           id: field_schedule_time_value
           table: node__field_schedule_time
@@ -749,6 +730,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           operator: '>='
           value:
             min: now
@@ -763,17 +745,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -786,7 +768,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
         field_schedule_time_end_value:
           id: field_schedule_time_end_value
           table: node__field_schedule_time
@@ -794,6 +775,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           operator: '<='
           value:
             min: now
@@ -808,17 +790,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -831,11 +813,30 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        title: false
+        filters: false
+        filter_groups: false
+        header: false
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: "<h2 class=\"banner-title\">Sessions Coming Up</h2>\r\n<hr />"
+            format: full_html
+          tokenize: false
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.media.yml
+++ b/conf/drupal/config/views.view.media.yml
@@ -19,122 +19,12 @@ base_table: media_field_data
 base_field: mid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access media overview'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
-          quantity: 9
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            name: name
-            bundle: bundle
-            changed: changed
-            uid: uid
-            status: status
-            thumbnail__target_id: thumbnail__target_id
-          info:
-            name:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            bundle:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            changed:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            uid:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            status:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            thumbnail__target_id:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: changed
-          empty_table: false
-      row:
-        type: fields
+      title: Media
       fields:
         media_bulk_form:
           id: media_bulk_form
@@ -143,6 +33,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: media_bulk_form
           label: ''
           exclude: false
           alter:
@@ -187,8 +79,6 @@ display:
           action_title: Action
           include_exclude: exclude
           selected_actions: {  }
-          entity_type: media
-          plugin_id: media_bulk_form
         thumbnail__target_id:
           id: thumbnail__target_id
           table: media_field_data
@@ -196,6 +86,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: thumbnail
+          plugin_id: field
           label: Thumbnail
           exclude: false
           alter:
@@ -240,8 +133,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: thumbnail
             image_link: ''
+            image_style: thumbnail
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -252,34 +145,27 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: thumbnail
-          plugin_id: field
         name:
           id: name
           table: media_field_data
           field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: media
           entity_field: media
+          plugin_id: field
+          label: 'Media name'
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: 'Media name'
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -289,9 +175,13 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -309,6 +199,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: bundle
+          plugin_id: field
           label: Provider
           exclude: false
           alter:
@@ -364,9 +257,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: bundle
-          plugin_id: field
         uid:
           id: uid
           table: media_field_data
@@ -374,6 +264,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: uid
+          plugin_id: field
           label: Author
           exclude: false
           alter:
@@ -429,9 +322,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: uid
-          plugin_id: field
         status:
           id: status
           table: media_field_data
@@ -439,6 +329,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: status
+          plugin_id: field
           label: Status
           exclude: false
           alter:
@@ -484,8 +377,8 @@ display:
           type: boolean
           settings:
             format: custom
-            format_custom_true: Published
             format_custom_false: Unpublished
+            format_custom_true: Published
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -496,9 +389,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: status
-          plugin_id: field
         changed:
           id: changed
           table: media_field_data
@@ -506,6 +396,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: changed
+          plugin_id: field
           label: Updated
           exclude: false
           alter:
@@ -563,9 +456,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: changed
-          plugin_id: field
         operations:
           id: operations
           table: media
@@ -573,6 +463,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: entity_operations
           label: Operations
           exclude: false
           alter:
@@ -615,8 +507,74 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: true
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access media overview'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No content available.'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: media_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: media
-          plugin_id: entity_operations
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments: {  }
       filters:
         status:
           id: status
@@ -625,6 +583,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -635,14 +596,14 @@ display:
             description: null
             use_operator: false
             operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: status
             required: true
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: true
           group_info:
             label: 'Publishing status'
@@ -663,9 +624,6 @@ display:
                 title: Unpublished
                 operator: '='
                 value: '0'
-          plugin_id: boolean
-          entity_type: media
-          entity_field: status
         bundle:
           id: bundle
           table: media_field_data
@@ -673,6 +631,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: bundle
+          plugin_id: bundle
           operator: in
           value: {  }
           group: 1
@@ -683,6 +644,8 @@ display:
             description: ''
             use_operator: false
             operator: bundle_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: provider
             required: false
             remember: false
@@ -692,8 +655,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -706,9 +667,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: media
-          entity_field: bundle
-          plugin_id: bundle
         name:
           id: name
           table: media_field_data
@@ -716,6 +674,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: name
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -726,6 +687,8 @@ display:
             description: ''
             use_operator: false
             operator: name_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: name
             required: false
             remember: false
@@ -735,8 +698,6 @@ display:
               anonymous: '0'
               administrator: '0'
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -749,9 +710,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: media
-          entity_field: name
-          plugin_id: string
         langcode:
           id: langcode
           table: media_field_data
@@ -759,6 +717,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: langcode
+          plugin_id: language
           operator: in
           value: {  }
           group: 1
@@ -769,6 +730,8 @@ display:
             description: ''
             use_operator: false
             operator: langcode_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: langcode
             required: false
             remember: false
@@ -778,8 +741,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -792,81 +753,121 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: media
-          entity_field: langcode
-          plugin_id: language
         status_extra:
-          group_info:
-            widget: select
-            group_items: {  }
-            multiple: false
-            description: ''
-            default_group_multiple: {  }
-            default_group: All
-            label: ''
-            identifier: ''
-            optional: true
-            remember: false
-          group: 1
+          id: status_extra
+          table: media_field_data
+          field: status_extra
           relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          plugin_id: media_status
+          operator: '='
+          value: ''
+          group: 1
           exposed: false
           expose:
-            use_operator: false
-            remember: false
             operator_id: ''
-            multiple: false
-            description: ''
-            required: false
             label: ''
-            operator_limit_selection: false
+            description: ''
+            use_operator: false
             operator: ''
-            identifier: ''
+            operator_limit_selection: false
             operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
             remember_roles:
               authenticated: authenticated
-          entity_type: media
-          value: ''
-          field: status_extra
           is_grouped: false
-          admin_label: ''
-          operator: '='
-          table: media_field_data
-          plugin_id: media_status
-          id: status_extra
-          group_type: group
-      sorts:
-        created:
-          id: created
-          table: media_field_data
-          field: created
-          order: DESC
-          entity_type: media
-          entity_field: created
-          plugin_id: date
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exposed: false
-          expose:
+          group_info:
             label: ''
-          granularity: second
-      title: Media
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            name: name
+            bundle: bundle
+            changed: changed
+            uid: uid
+            status: status
+            thumbnail__target_id: thumbnail__target_id
+          default: changed
+          info:
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            bundle:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            changed:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            thumbnail__target_id:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header: {  }
       footer: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'No content available.'
-          plugin_id: text_custom
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: 0
@@ -879,14 +880,14 @@ display:
         - user.permissions
       tags: {  }
   media_page_list:
-    display_plugin: page
     id: media_page_list
     display_title: Media
+    display_plugin: page
     position: 1
     display_options:
+      display_description: ''
       display_extenders: {  }
       path: admin/content/media
-      display_description: ''
     cache_metadata:
       max-age: 0
       contexts:

--- a/conf/drupal/config/views.view.media_library.yml
+++ b/conf/drupal/config/views.view.media_library.yml
@@ -5,14 +5,14 @@ dependencies:
   config:
     - core.entity_view_mode.media.media_library
     - image.style.media_library
-  enforced:
-    module:
-      - media_library
   module:
     - image
     - media
     - media_library
     - user
+  enforced:
+    module:
+      - media_library
 _core:
   default_config_hash: 5sfZZetHlReG1VQx9CbyIBhKFWYSZEU94dOy0yy0deE
 id: media_library
@@ -24,67 +24,12 @@ base_table: media_field_data
 base_field: mid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access media overview'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: 'Apply filters'
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: false
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 24
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '6, 12, 24, 48'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: 'media-library-item media-library-item--grid js-media-library-item js-click-to-select'
-          default_row_class: true
-      row:
-        type: fields
-        options:
-          default_field_elements: true
-          inline: {  }
-          separator: ''
-          hide_empty: false
+      title: Media
       fields:
         media_bulk_form:
           id: media_bulk_form
@@ -93,6 +38,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: bulk_form
           label: ''
           exclude: false
           alter:
@@ -137,8 +84,6 @@ display:
           action_title: Action
           include_exclude: exclude
           selected_actions: {  }
-          entity_type: media
-          plugin_id: bulk_form
         rendered_entity:
           id: rendered_entity
           table: media
@@ -146,6 +91,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: rendered_entity
           label: ''
           exclude: false
           alter:
@@ -188,8 +135,100 @@ display:
           empty_zero: false
           hide_alter_empty: true
           view_mode: media_library
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 24
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '6, 12, 24, 48'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: 'Apply filters'
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: false
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access media overview'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No media available.'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: media_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: media
-          plugin_id: rendered_entity
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: 'Newest first'
+            field_identifier: created
+          exposed: true
+          granularity: second
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: name
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: 'Name (A-Z)'
+            field_identifier: name
+          exposed: true
+        name_1:
+          id: name_1
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: name
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: 'Name (Z-A)'
+            field_identifier: name_1
+          exposed: true
       filters:
         status:
           id: status
@@ -198,6 +237,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -208,14 +250,14 @@ display:
             description: null
             use_operator: false
             operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: status
             required: true
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: true
           group_info:
             label: Published
@@ -236,9 +278,6 @@ display:
                 title: Unpublished
                 operator: '='
                 value: '0'
-          plugin_id: boolean
-          entity_type: media
-          entity_field: status
         name:
           id: name
           table: media_field_data
@@ -246,6 +285,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: name
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -256,6 +298,8 @@ display:
             description: ''
             use_operator: false
             operator: name_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: name
             required: false
             remember: false
@@ -264,8 +308,6 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -278,9 +320,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: media
-          entity_field: name
-          plugin_id: string
         bundle:
           id: bundle
           table: media_field_data
@@ -288,6 +327,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: bundle
+          plugin_id: bundle
           operator: in
           value: {  }
           group: 1
@@ -298,6 +340,8 @@ display:
             description: ''
             use_operator: false
             operator: bundle_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: type
             required: false
             remember: false
@@ -307,8 +351,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: 'Media type'
@@ -324,9 +366,6 @@ display:
               1: {  }
               2: {  }
               3: {  }
-          entity_type: media
-          entity_field: bundle
-          plugin_id: bundle
         langcode:
           id: langcode
           table: media_field_data
@@ -334,144 +373,108 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: langcode
+          plugin_id: language
           operator: in
           value: {  }
           group: 1
           exposed: true
           expose:
-            use_operator: false
-            remember: false
             operator_id: langcode_op
-            multiple: false
-            description: ''
-            required: false
-            reduce: false
             label: Language
-            operator_limit_selection: false
+            description: ''
+            use_operator: false
             operator: langcode_op
-            identifier: langcode
+            operator_limit_selection: false
             operator_list: {  }
+            identifier: langcode
+            required: false
+            remember: false
+            multiple: false
             remember_roles:
               administrator: '0'
               authenticated: authenticated
               anonymous: '0'
+            reduce: false
           is_grouped: false
           group_info:
-            widget: select
-            group_items: {  }
-            multiple: false
-            description: ''
-            default_group_multiple: {  }
-            default_group: All
             label: ''
+            description: ''
             identifier: ''
             optional: true
+            widget: select
+            multiple: false
             remember: false
-          entity_type: media
-          entity_field: langcode
-          plugin_id: language
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         status_extra:
-          group_info:
-            widget: select
-            group_items: {  }
-            multiple: false
-            description: ''
-            default_group_multiple: {  }
-            default_group: All
-            label: ''
-            identifier: ''
-            optional: true
-            remember: false
-          group: 1
+          id: status_extra
+          table: media_field_data
+          field: status_extra
           relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          plugin_id: media_status
+          operator: '='
+          value: ''
+          group: 1
           exposed: false
           expose:
-            use_operator: false
-            remember: false
             operator_id: ''
-            multiple: false
-            description: ''
-            required: false
             label: ''
-            operator_limit_selection: false
+            description: ''
+            use_operator: false
             operator: ''
-            identifier: ''
+            operator_limit_selection: false
             operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
             remember_roles:
               authenticated: authenticated
-          entity_type: media
-          value: ''
-          field: status_extra
           is_grouped: false
-          admin_label: ''
-          operator: '='
-          table: media_field_data
-          plugin_id: media_status
-          id: status_extra
-          group_type: group
-      sorts:
-        created:
-          id: created
-          table: media_field_data
-          field: created
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: true
-          expose:
-            label: 'Newest first'
-          granularity: second
-          entity_type: media
-          entity_field: created
-          plugin_id: date
-        name:
-          id: name
-          table: media_field_data
-          field: name
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: true
-          expose:
-            label: 'Name (A-Z)'
-          entity_type: media
-          entity_field: name
-          plugin_id: standard
-        name_1:
-          id: name_1
-          table: media_field_data
-          field: name
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: true
-          expose:
-            label: 'Name (Z-A)'
-          entity_type: media
-          entity_field: name
-          plugin_id: standard
-      title: Media
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: 'media-library-item media-library-item--grid js-media-library-item js-click-to-select'
+          default_row_class: true
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: 'media-library-view js-media-library-view'
+      use_ajax: true
       header: {  }
       footer: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'No media available.'
-          plugin_id: text_custom
-      relationships: {  }
       display_extenders: {  }
-      use_ajax: true
-      css_class: 'media-library-view js-media-library-view'
     cache_metadata:
       max-age: 0
       contexts:
@@ -488,13 +491,11 @@ display:
         - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.video.media_library'
   page:
-    display_plugin: page
     id: page
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
-      path: admin/content/media-grid
       fields:
         media_bulk_form:
           id: media_bulk_form
@@ -503,6 +504,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: bulk_form
           label: ''
           exclude: false
           alter:
@@ -547,8 +550,6 @@ display:
           action_title: Action
           include_exclude: exclude
           selected_actions: {  }
-          entity_type: media
-          plugin_id: bulk_form
         name:
           id: name
           table: media_field_data
@@ -556,6 +557,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: name
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -611,9 +615,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: media
-          entity_field: name
-          plugin_id: field
         edit_media:
           id: edit_media
           table: media
@@ -621,6 +622,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: entity_link_edit
           label: ''
           exclude: false
           alter:
@@ -665,8 +668,6 @@ display:
           text: Edit
           output_url_as_text: false
           absolute: false
-          entity_type: media
-          plugin_id: entity_link_edit
         delete_media:
           id: delete_media
           table: media
@@ -674,6 +675,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: entity_link_delete
           label: ''
           exclude: false
           alter:
@@ -718,8 +721,6 @@ display:
           text: Delete
           output_url_as_text: false
           absolute: false
-          entity_type: media
-          plugin_id: entity_link_delete
         rendered_entity:
           id: rendered_entity
           table: media
@@ -727,6 +728,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: rendered_entity
           label: ''
           exclude: false
           alter:
@@ -769,10 +772,10 @@ display:
           empty_zero: false
           hide_alter_empty: true
           view_mode: media_library
-          entity_type: media
-          plugin_id: rendered_entity
       defaults:
         fields: false
+      display_extenders: {  }
+      path: admin/content/media-grid
     cache_metadata:
       max-age: 0
       contexts:
@@ -790,13 +793,11 @@ display:
         - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.video.media_library'
   widget:
-    display_plugin: page
     id: widget
     display_title: Widget
+    display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
-      path: admin/content/media-widget
       fields:
         rendered_entity:
           id: rendered_entity
@@ -805,6 +806,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: rendered_entity
           label: ''
           exclude: false
           alter:
@@ -847,8 +850,6 @@ display:
           empty_zero: false
           hide_alter_empty: true
           view_mode: media_library
-          entity_type: media
-          plugin_id: rendered_entity
         media_library_select_form:
           id: media_library_select_form
           table: media
@@ -856,6 +857,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          plugin_id: media_library_select_form
           label: ''
           exclude: false
           alter:
@@ -897,148 +900,10 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          entity_type: media
-          plugin_id: media_library_select_form
-      defaults:
-        fields: false
-        access: false
-        filters: false
-        filter_groups: false
-        arguments: false
-        header: false
-        css_class: false
-      display_description: ''
       access:
         type: perm
         options:
           perm: 'view media'
-      filters:
-        status:
-          id: status
-          table: media_field_data
-          field: status
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: media
-          entity_field: status
-          plugin_id: boolean
-        name:
-          id: name
-          table: media_field_data
-          field: name
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: name_op
-            label: Name
-            description: ''
-            use_operator: false
-            operator: name_op
-            identifier: name
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: media
-          entity_field: name
-          plugin_id: string
-        default_langcode:
-          id: default_langcode
-          table: media_field_data
-          field: default_langcode
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            use_operator: false
-            remember: false
-            operator_id: ''
-            multiple: false
-            description: ''
-            required: false
-            label: ''
-            operator_limit_selection: false
-            operator: ''
-            identifier: ''
-            operator_list: {  }
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            widget: select
-            group_items: {  }
-            multiple: false
-            description: ''
-            default_group_multiple: {  }
-            default_group: All
-            label: ''
-            identifier: ''
-            optional: true
-            remember: false
-          entity_type: media
-          entity_field: default_langcode
-          plugin_id: boolean
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
       arguments:
         bundle:
           id: bundle
@@ -1047,6 +912,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: bundle
+          plugin_id: string
           default_action: ignore
           exception:
             value: all
@@ -1061,8 +929,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 24
             override: false
+            items_per_page: 24
           summary:
             sort_order: asc
             number_of_records: 0
@@ -1078,28 +946,163 @@ display:
           path_case: none
           transform_dash: false
           break_phrase: false
+      filters:
+        status:
+          id: status
+          table: media_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: media
-          entity_field: bundle
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: name
           plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: name_op
+            label: Name
+            description: ''
+            use_operator: false
+            operator: name_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        default_langcode:
+          id: default_langcode
+          table: media_field_data
+          field: default_langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: default_langcode
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      defaults:
+        access: false
+        css_class: false
+        fields: false
+        arguments: false
+        filters: false
+        filter_groups: false
+        header: false
+      css_class: 'media-library-view js-media-library-view media-library-view--widget'
+      display_description: ''
       header:
         display_link_grid:
           id: display_link_grid
           table: views
           field: display_link
-          display_id: widget
-          label: Grid
           plugin_id: display_link
+          label: Grid
           empty: true
+          display_id: widget
         display_link_table:
           id: display_link_table
           table: views
           field: display_link
-          display_id: widget_table
-          label: Table
           plugin_id: display_link
+          label: Table
           empty: true
-      css_class: 'media-library-view js-media-library-view media-library-view--widget'
+          display_id: widget_table
       rendering_language: '***LANGUAGE_language_interface***'
+      display_extenders: {  }
+      path: admin/content/media-widget
     cache_metadata:
       max-age: -1
       contexts:
@@ -1115,88 +1118,69 @@ display:
         - 'config:core.entity_view_display.media.video.default'
         - 'config:core.entity_view_display.media.video.media_library'
   widget_table:
-    display_plugin: page
     id: widget_table
     display_title: 'Widget (table)'
+    display_plugin: page
     position: 3
     display_options:
-      display_extenders: {  }
-      path: admin/content/media-widget-table
-      style:
-        type: table
-        options:
-          row_class: 'media-library-item media-library-item--table js-media-library-item js-click-to-select'
-          default_row_class: true
-      defaults:
-        style: false
-        row: false
-        fields: false
-        access: false
-        filters: false
-        filter_groups: false
-        arguments: false
-        header: false
-        css_class: false
-      row:
-        type: fields
       fields:
         media_library_select_form:
           id: media_library_select_form
-          label: ''
           table: media
           field: media_library_select_form
           relationship: none
           entity_type: media
           plugin_id: media_library_select_form
-          element_wrapper_class: 'js-click-to-select-checkbox media-library-item__click-to-select-checkbox'
+          label: ''
           element_class: ''
+          element_wrapper_class: 'js-click-to-select-checkbox media-library-item__click-to-select-checkbox'
         thumbnail__target_id:
           id: thumbnail__target_id
-          label: Thumbnail
           table: media_field_data
           field: thumbnail__target_id
           relationship: none
-          type: image
           entity_type: media
           entity_field: thumbnail
           plugin_id: field
+          label: Thumbnail
+          type: image
           settings:
-            image_style: media_library
             image_link: ''
+            image_style: media_library
         name:
           id: name
-          label: Name
           table: media_field_data
           field: name
           relationship: none
-          type: string
           entity_type: media
           entity_field: name
           plugin_id: field
+          label: Name
+          type: string
           settings:
             link_to_entity: false
         uid:
           id: uid
-          label: Author
           table: media_field_revision
           field: uid
           relationship: none
-          type: entity_reference_label
           entity_type: media
           entity_field: uid
           plugin_id: field
+          label: Author
+          type: entity_reference_label
           settings:
             link: true
         changed:
           id: changed
-          label: Updated
           table: media_field_data
           field: changed
           relationship: none
-          type: timestamp
           entity_type: media
           entity_field: changed
           plugin_id: field
+          label: Updated
+          type: timestamp
           settings:
             date_format: short
             custom_date_format: ''
@@ -1205,133 +1189,6 @@ display:
         type: perm
         options:
           perm: 'view media'
-      filters:
-        status:
-          id: status
-          table: media_field_data
-          field: status
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: media
-          entity_field: status
-          plugin_id: boolean
-        name:
-          id: name
-          table: media_field_data
-          field: name
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: name_op
-            label: Name
-            description: ''
-            use_operator: false
-            operator: name_op
-            identifier: name
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: media
-          entity_field: name
-          plugin_id: string
-        default_langcode:
-          id: default_langcode
-          table: media_field_data
-          field: default_langcode
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            use_operator: false
-            remember: false
-            operator_id: ''
-            multiple: false
-            description: ''
-            required: false
-            label: ''
-            operator_limit_selection: false
-            operator: ''
-            identifier: ''
-            operator_list: {  }
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            widget: select
-            group_items: {  }
-            multiple: false
-            description: ''
-            default_group_multiple: {  }
-            default_group: All
-            label: ''
-            identifier: ''
-            optional: true
-            remember: false
-          entity_type: media
-          entity_field: default_langcode
-          plugin_id: boolean
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
       arguments:
         bundle:
           id: bundle
@@ -1340,6 +1197,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: media
+          entity_field: bundle
+          plugin_id: string
           default_action: ignore
           exception:
             value: all
@@ -1354,8 +1214,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 24
             override: false
+            items_per_page: 24
           summary:
             sort_order: asc
             number_of_records: 0
@@ -1371,28 +1231,171 @@ display:
           path_case: none
           transform_dash: false
           break_phrase: false
+      filters:
+        status:
+          id: status
+          table: media_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: media
-          entity_field: bundle
+          entity_field: status
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        name:
+          id: name
+          table: media_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: name
           plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: name_op
+            label: Name
+            description: ''
+            use_operator: false
+            operator: name_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        default_langcode:
+          id: default_langcode
+          table: media_field_data
+          field: default_langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: media
+          entity_field: default_langcode
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          row_class: 'media-library-item media-library-item--table js-media-library-item js-click-to-select'
+          default_row_class: true
+      row:
+        type: fields
+      defaults:
+        access: false
+        css_class: false
+        style: false
+        row: false
+        fields: false
+        arguments: false
+        filters: false
+        filter_groups: false
+        header: false
+      css_class: 'media-library-view js-media-library-view media-library-view--widget'
       header:
         display_link_grid:
           id: display_link_grid
           table: views
           field: display_link
-          display_id: widget
-          label: Grid
           plugin_id: display_link
+          label: Grid
           empty: true
+          display_id: widget
         display_link_table:
           id: display_link_table
           table: views
           field: display_link
-          display_id: widget_table
-          label: Table
           plugin_id: display_link
+          label: Table
           empty: true
-      css_class: 'media-library-view js-media-library-view media-library-view--widget'
+          display_id: widget_table
       rendering_language: '***LANGUAGE_language_interface***'
+      display_extenders: {  }
+      path: admin/content/media-widget-table
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.news.yml
+++ b/conf/drupal/config/views.view.news.yml
@@ -27,72 +27,34 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: none
-        options:
-          offset: 0
-      style:
-        type: default
-      row:
-        type: 'entity:node'
-        options:
-          view_mode: teaser
+      title: News
       fields:
         title:
           id: title
           table: node_field_data
           field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: title
+          plugin_id: field
           label: ''
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -102,9 +64,13 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -115,29 +81,69 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+      pager:
+        type: none
+        options:
+          offset: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments: {  }
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            article: article
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            article: article
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -148,6 +154,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -158,14 +165,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -178,7 +185,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -186,6 +192,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             - 2
@@ -197,6 +204,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -204,8 +213,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -219,34 +226,28 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: textfield
-          limit: true
           vid: event
+          type: textfield
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      sorts:
-        created:
-          id: created
-          table: node_field_data
-          field: created
-          order: DESC
-          entity_type: node
-          entity_field: created
-          plugin_id: date
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-      title: News
+      style:
+        type: default
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header: {  }
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -258,9 +259,9 @@ display:
         - user.permissions
       tags: {  }
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
       display_extenders: {  }
@@ -268,8 +269,8 @@ display:
       menu:
         type: normal
         title: News
-        menu_name: main
         weight: -47
+        menu_name: main
         parent: 'menu_link_content:c9f1023e-8d4d-472e-bd1a-e27b96e58a36'
     cache_metadata:
       max-age: -1
@@ -281,45 +282,34 @@ display:
         - user.permissions
       tags: {  }
   page_2:
-    display_plugin: page
     id: page_2
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
-      path: 2019/news
-      menu:
-        type: normal
-        title: News
-        description: ''
-        expanded: false
-        parent: 'menu_link_content:db3c8044-0b1c-4432-b89f-8a2b03de0754'
-        weight: -45
-        context: '0'
-        menu_name: midcamp-2019-navigation
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            article: article
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            article: article
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -330,6 +320,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -340,14 +331,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -360,7 +351,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -368,6 +358,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             - 97
@@ -379,6 +370,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -386,8 +379,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -401,19 +392,29 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: textfield
-          limit: true
           vid: event
+          type: textfield
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      defaults:
-        filters: false
-        filter_groups: false
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+      display_extenders: {  }
+      path: 2019/news
+      menu:
+        type: normal
+        title: News
+        description: ''
+        weight: -45
+        expanded: false
+        menu_name: midcamp-2019-navigation
+        parent: 'menu_link_content:db3c8044-0b1c-4432-b89f-8a2b03de0754'
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:
@@ -424,45 +425,34 @@ display:
         - user.permissions
       tags: {  }
   page_3:
-    display_plugin: page
     id: page_3
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
-      path: 2020/news
-      menu:
-        type: normal
-        title: News
-        description: ''
-        expanded: false
-        parent: 'menu_link_content:db3c8044-0b1c-4432-b89f-8a2b03de0754'
-        weight: -45
-        context: '0'
-        menu_name: midcamp-2019-navigation
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            article: article
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            article: article
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -473,6 +463,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -483,14 +474,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -503,7 +494,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -511,6 +501,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             - 143
@@ -522,6 +513,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -529,8 +522,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -544,19 +535,29 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: textfield
-          limit: true
           vid: event
+          type: textfield
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      defaults:
-        filters: false
-        filter_groups: false
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+      display_extenders: {  }
+      path: 2020/news
+      menu:
+        type: normal
+        title: News
+        description: ''
+        weight: -45
+        expanded: false
+        menu_name: midcamp-2019-navigation
+        parent: 'menu_link_content:db3c8044-0b1c-4432-b89f-8a2b03de0754'
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:
@@ -567,45 +568,34 @@ display:
         - user.permissions
       tags: {  }
   page_4:
-    display_plugin: page
     id: page_4
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
-      path: 2021/news
-      menu:
-        type: normal
-        title: News
-        description: ''
-        expanded: false
-        parent: ''
-        weight: -50
-        context: '0'
-        menu_name: midcamp-2021-navigation
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            article: article
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            article: article
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -616,6 +606,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -626,14 +617,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -646,7 +637,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -654,6 +644,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             - 234
@@ -687,19 +678,29 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: textfield
-          limit: true
           vid: event
+          type: textfield
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      defaults:
-        filters: false
-        filter_groups: false
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+      display_extenders: {  }
+      path: 2021/news
+      menu:
+        type: normal
+        title: News
+        description: ''
+        weight: -50
+        expanded: false
+        menu_name: midcamp-2021-navigation
+        parent: ''
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.organizers.yml
+++ b/conf/drupal/config/views.view.organizers.yml
@@ -24,81 +24,34 @@ base_table: users_field_data
 base_field: uid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access user profiles'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: none
-        options:
-          items_per_page: 0
-          offset: 0
-      style:
-        type: grid
-        options:
-          uses_fields: false
-          columns: 3
-          automatic_width: false
-          alignment: horizontal
-          col_class_default: false
-          col_class_custom: 'l-3up speaker-item'
-          row_class_default: false
-          row_class_custom: ''
-      row:
-        type: 'entity:user'
-        options:
-          relationship: none
-          view_mode: featured_speaker
+      title: Organizers
       fields:
         name:
           id: name
           table: users_field_data
           field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: user
           entity_field: name
+          plugin_id: field
           label: ''
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -108,6 +61,8 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: user_name
@@ -122,20 +77,58 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+      pager:
+        type: none
+        options:
+          offset: 0
+          items_per_page: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access user profiles'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        field_name_family:
+          id: field_name_family
+          table: user__field_name
+          field: field_name_family
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: field_name_family
+          exposed: false
+      arguments: {  }
       filters:
         status:
-          value: '1'
+          id: status
           table: users_field_data
           field: status
-          plugin_id: boolean
           entity_type: user
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_organizer_year_target_id:
           id: field_organizer_year_target_id
           table: user__field_organizer_year
@@ -143,6 +136,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             2: 2
@@ -154,6 +148,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -161,8 +157,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -176,26 +170,36 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      sorts:
-        field_name_family:
-          id: field_name_family
-          table: user__field_name
-          field: field_name_family
+      style:
+        type: grid
+        options:
+          uses_fields: false
+          columns: 3
+          automatic_width: false
+          alignment: horizontal
+          row_class_custom: ''
+          row_class_default: false
+          col_class_custom: 'l-3up speaker-item'
+          col_class_default: false
+      row:
+        type: 'entity:user'
+        options:
           relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: standard
-      title: Organizers
+          view_mode: featured_speaker
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header:
         area:
           id: area
@@ -204,16 +208,13 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: false
-          tokenize: false
           content:
             value: '<p>MidCamp is organized by a group of volunteers from the Drupal community in Chicago, and beyond!</p>'
             format: basic_html
-          plugin_id: text
+          tokenize: false
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -224,28 +225,25 @@ display:
         - user.permissions
       tags: {  }
   attachment_1:
-    display_plugin: attachment
     id: attachment_1
     display_title: '20201 Leadership Attachment'
+    display_plugin: attachment
     position: 5
     display_options:
-      display_extenders: {  }
-      displays:
-        page_4: page_4
       filters:
         status:
-          value: '1'
+          id: status
           table: users_field_data
           field: status
-          plugin_id: boolean
           entity_type: user
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_leadership_year_target_id:
           id: field_leadership_year_target_id
           table: user__field_leadership_year
@@ -253,6 +251,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             - 234
@@ -286,21 +285,20 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: textfield
-          limit: true
           vid: event
+          type: textfield
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       defaults:
         filters: false
         filter_groups: false
         header: false
         footer: false
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
       display_description: ''
       header:
         area:
@@ -310,12 +308,12 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: false
-          tokenize: false
           content:
             value: '<h2>Leadership</h2>'
             format: basic_html
-          plugin_id: text
+          tokenize: false
       footer:
         area:
           id: area
@@ -324,12 +322,15 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: false
-          tokenize: false
           content:
             value: '<h2>Organizers</h2>'
             format: basic_html
-          plugin_id: text
+          tokenize: false
+      display_extenders: {  }
+      displays:
+        page_4: page_4
     cache_metadata:
       max-age: -1
       contexts:
@@ -339,9 +340,9 @@ display:
         - user.permissions
       tags: {  }
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
       display_extenders: {  }
@@ -355,27 +356,25 @@ display:
         - user.permissions
       tags: {  }
   page_2:
-    display_plugin: page
     id: page_2
     display_title: 'Page 2'
+    display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
-      path: 2019/organizers
       filters:
         status:
-          value: '1'
+          id: status
           table: users_field_data
           field: status
-          plugin_id: boolean
           entity_type: user
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_organizer_year_target_id:
           id: field_organizer_year_target_id
           table: user__field_organizer_year
@@ -383,6 +382,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             97: 97
@@ -394,6 +394,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -401,8 +403,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -416,28 +416,29 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      defaults:
-        filters: false
-        filter_groups: false
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+      display_extenders: {  }
+      path: 2019/organizers
       menu:
         type: normal
         title: Organizers
         description: ''
-        expanded: false
-        parent: 'menu_link_content:db3c8044-0b1c-4432-b89f-8a2b03de0754'
         weight: -43
-        context: '0'
+        expanded: false
         menu_name: midcamp-2019-navigation
+        parent: 'menu_link_content:db3c8044-0b1c-4432-b89f-8a2b03de0754'
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:
@@ -447,27 +448,25 @@ display:
         - user.permissions
       tags: {  }
   page_3:
-    display_plugin: page
     id: page_3
     display_title: '2020 Organizers'
+    display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
-      path: 2020/organizers
       filters:
         status:
-          value: '1'
+          id: status
           table: users_field_data
           field: status
-          plugin_id: boolean
           entity_type: user
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_organizer_year_target_id:
           id: field_organizer_year_target_id
           table: user__field_organizer_year
@@ -475,6 +474,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             143: 143
@@ -486,6 +486,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -493,8 +495,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -508,29 +508,30 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      defaults:
-        filters: false
-        filter_groups: false
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+      display_description: ''
+      display_extenders: {  }
+      path: 2020/organizers
       menu:
         type: normal
         title: Organizers
         description: ''
-        expanded: false
-        parent: 'menu_link_content:8a08e9a9-1692-43db-8f38-b20ee4b9c7f0'
         weight: -43
-        context: '0'
+        expanded: false
         menu_name: midcamp-2020-navigation
-      display_description: ''
+        parent: 'menu_link_content:8a08e9a9-1692-43db-8f38-b20ee4b9c7f0'
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:
@@ -540,27 +541,25 @@ display:
         - user.permissions
       tags: {  }
   page_4:
-    display_plugin: page
     id: page_4
     display_title: '2021 Organizers'
+    display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
-      path: 2021/organizers
       filters:
         status:
-          value: '1'
+          id: status
           table: users_field_data
           field: status
-          plugin_id: boolean
           entity_type: user
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_organizer_year_target_id:
           id: field_organizer_year_target_id
           table: user__field_organizer_year
@@ -568,6 +567,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             234: 234
@@ -601,12 +601,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_leadership_year_target_id:
           id: field_leadership_year_target_id
           table: user__field_leadership_year
@@ -614,6 +613,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: not
           value:
             - 234
@@ -647,29 +647,19 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: textfield
-          limit: true
           vid: event
+          type: textfield
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      defaults:
-        filters: false
-        filter_groups: false
-        header: false
       filter_groups:
         operator: AND
         groups:
           1: AND
-      menu:
-        type: none
-        title: Organizers
-        description: ''
-        expanded: false
-        parent: ''
-        weight: -43
-        context: '0'
-        menu_name: midcamp-2021-navigation
+      defaults:
+        filters: false
+        filter_groups: false
+        header: false
       display_description: ''
       header:
         area:
@@ -679,12 +669,23 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: false
-          tokenize: false
           content:
             value: '<p>MidCamp is organized by a group of volunteers from the Drupal community in Chicago, and beyond!</p>'
             format: basic_html
-          plugin_id: text
+          tokenize: false
+      display_extenders: {  }
+      path: 2021/organizers
+      menu:
+        type: none
+        title: Organizers
+        description: ''
+        weight: -43
+        expanded: false
+        menu_name: midcamp-2021-navigation
+        parent: ''
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.random_session.yml
+++ b/conf/drupal/config/views.view.random_session.yml
@@ -28,54 +28,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: some
-        options:
-          items_per_page: 1
-          offset: 0
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: schedule__teaser
-          default_row_class: false
-      row:
-        type: fields
-        options:
-          default_field_elements: false
-          inline: {  }
-          separator: ''
-          hide_empty: false
+      title: 'Random Session'
       fields:
         user_picture:
           id: user_picture
@@ -84,6 +42,7 @@ display:
           relationship: field_people
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -128,8 +87,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: schedule_presenter
             image_link: ''
+            image_style: schedule_presenter
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -140,7 +99,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_track:
           id: field_track
           table: node__field_track
@@ -148,6 +106,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -203,7 +162,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -211,6 +169,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -266,9 +227,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         body:
           id: body
           table: node__body
@@ -276,6 +234,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -331,7 +290,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -339,6 +297,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -394,7 +353,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_schedule_location:
           id: field_schedule_location
           table: node__field_schedule_location
@@ -402,6 +360,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -457,30 +416,67 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 1
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        random:
+          id: random
+          table: views
+          field: random
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: random
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: random
+          exposed: false
+      arguments: {  }
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            topic: topic
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            topic: topic
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -491,6 +487,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             - 143
@@ -502,6 +499,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -509,8 +508,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -524,12 +521,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: textfield
-          limit: true
           vid: event
+          type: textfield
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         user_picture_target_id:
           id: user_picture_target_id
           table: user__user_picture
@@ -537,6 +533,7 @@ display:
           relationship: field_people
           group_type: group
           admin_label: ''
+          plugin_id: numeric
           operator: 'not empty'
           value:
             min: ''
@@ -550,17 +547,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -573,7 +570,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: numeric
         field_accepted_confirmed_value:
           id: field_accepted_confirmed_value
           table: node__field_accepted_confirmed
@@ -581,6 +577,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -591,14 +588,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -611,37 +608,27 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
-      sorts:
-        random:
-          id: random
-          table: views
-          field: random
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: random
-      title: 'Random Session'
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: '<h2 class="banner-title">Featured Session</h2>'
-            format: full_html
-          plugin_id: text
-      footer: {  }
-      empty: {  }
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: schedule__teaser
+          default_row_class: false
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         field_people:
           id: field_people
@@ -650,9 +637,23 @@ display:
           relationship: none
           group_type: group
           admin_label: 'field_people: User'
-          required: true
           plugin_id: standard
-      arguments: {  }
+          required: true
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: '<h2 class="banner-title">Featured Session</h2>'
+            format: full_html
+          tokenize: false
+      footer: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: 0
@@ -669,9 +670,9 @@ display:
         - 'config:field.storage.node.field_track'
         - 'config:field.storage.user.user_picture'
   block_1:
-    display_plugin: block
     id: block_1
     display_title: Block
+    display_plugin: block
     position: 1
     display_options:
       display_extenders: {  }

--- a/conf/drupal/config/views.view.redirect.yml
+++ b/conf/drupal/config/views.view.redirect.yml
@@ -17,122 +17,12 @@ base_table: redirect
 base_field: rid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'administer redirects'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: '‹ previous'
-            next: 'next ›'
-            first: '« first'
-            last: 'last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            redirect_source__path: redirect_source__path
-            redirect_redirect__uri: redirect_redirect__uri
-            status_code: status_code
-            language: language
-            created: created
-            operations: operations
-          info:
-            redirect_source__path:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            redirect_redirect__uri:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            status_code:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            language:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            created:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            operations:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: created
-          empty_table: false
-      row:
-        type: fields
+      title: Redirect
       fields:
         redirect_bulk_form:
           id: redirect_bulk_form
@@ -141,6 +31,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: redirect
+          plugin_id: redirect_bulk_form
           label: ''
           exclude: false
           alter:
@@ -185,8 +77,6 @@ display:
           action_title: 'With selection'
           include_exclude: exclude
           selected_actions: {  }
-          entity_type: redirect
-          plugin_id: redirect_bulk_form
         redirect_source__path:
           id: redirect_source__path
           table: redirect
@@ -194,6 +84,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: redirect
+          entity_field: redirect_source
+          plugin_id: field
           label: From
           exclude: false
           alter:
@@ -248,9 +141,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: redirect
-          entity_field: redirect_source
-          plugin_id: field
         redirect_redirect__uri:
           id: redirect_redirect__uri
           table: redirect
@@ -279,6 +169,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: redirect
+          entity_field: created
+          plugin_id: date
           label: Created
           exclude: false
           alter:
@@ -323,15 +216,64 @@ display:
           date_format: fallback
           custom_date_format: ''
           timezone: ''
-          entity_type: redirect
-          entity_field: created
-          plugin_id: date
         operations:
           id: operations
           table: redirect
           field: operations
           entity_type: redirect
           plugin_id: entity_operations
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: 'next ›'
+            previous: '‹ previous'
+            first: '« first'
+            last: 'last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer redirects'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'There is no redirect yet.'
+          tokenize: false
+      sorts: {  }
+      arguments: {  }
       filters:
         redirect_source__path:
           id: redirect_source__path
@@ -340,6 +282,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: redirect
+          entity_field: redirect_source
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -350,6 +295,8 @@ display:
             description: ''
             use_operator: false
             operator: redirect_source__path_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: redirect_source__path
             required: false
             remember: false
@@ -359,8 +306,6 @@ display:
               anonymous: '0'
               administrator: '0'
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -373,9 +318,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: redirect
-          entity_field: redirect_source
-          plugin_id: string
         redirect_redirect__uri:
           id: redirect_redirect__uri
           table: redirect
@@ -383,6 +325,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: redirect
+          entity_field: redirect_redirect
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -393,6 +338,8 @@ display:
             description: ''
             use_operator: false
             operator: redirect_redirect__uri_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: redirect_redirect__uri
             required: false
             remember: false
@@ -402,8 +349,6 @@ display:
               anonymous: '0'
               administrator: '0'
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -416,9 +361,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: redirect
-          entity_field: redirect_redirect
-          plugin_id: string
         status_code:
           id: status_code
           table: redirect
@@ -426,6 +368,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: redirect
+          entity_field: status_code
+          plugin_id: numeric
           operator: '='
           value:
             min: ''
@@ -439,6 +384,8 @@ display:
             description: ''
             use_operator: false
             operator: status_code_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: status_code
             required: false
             remember: false
@@ -447,11 +394,9 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: true
           group_info:
             label: 'Status code'
@@ -468,54 +413,51 @@ display:
                 title: '300 Multiple Choices'
                 operator: '='
                 value:
-                  value: '300'
                   min: ''
                   max: ''
+                  value: '300'
               2:
                 title: '301 Moved Permanently'
                 operator: '='
                 value:
-                  value: '301'
                   min: ''
                   max: ''
+                  value: '301'
               3:
                 title: '302 Found'
                 operator: '='
                 value:
-                  value: '302'
                   min: ''
                   max: ''
+                  value: '302'
               4:
                 title: '303 See Other'
                 operator: '='
                 value:
-                  value: '303'
                   min: ''
                   max: ''
+                  value: '303'
               5:
                 title: '304 Not Modified'
                 operator: '='
                 value:
-                  value: '304'
                   min: ''
                   max: ''
+                  value: '304'
               6:
                 title: '305 Use Proxy'
                 operator: '='
                 value:
-                  value: '305'
                   min: ''
                   max: ''
+                  value: '305'
               7:
                 title: '307 Temporary Redirect'
                 operator: '='
                 value:
-                  value: '307'
                   min: ''
                   max: ''
-          entity_type: redirect
-          entity_field: status_code
-          plugin_id: numeric
+                  value: '307'
         language:
           id: language
           table: redirect
@@ -523,6 +465,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: redirect
+          entity_field: language
+          plugin_id: language
           operator: in
           value: {  }
           group: 1
@@ -533,6 +478,8 @@ display:
             description: ''
             use_operator: false
             operator: language_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: language
             required: false
             remember: false
@@ -542,8 +489,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -556,57 +501,112 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: redirect
-          entity_field: language
-          plugin_id: language
-      sorts: {  }
-      title: Redirect
-      header: {  }
-      footer: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'There is no redirect yet.'
-          plugin_id: text_custom
-      relationships: {  }
-      arguments: {  }
-      display_extenders: {  }
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            redirect_source__path: redirect_source__path
+            redirect_redirect__uri: redirect_redirect__uri
+            status_code: status_code
+            language: language
+            created: created
+            operations: operations
+          default: created
+          info:
+            redirect_source__path:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            redirect_redirect__uri:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status_code:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            language:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - user.permissions
-      cacheable: false
-      max-age: 0
       tags: {  }
+      cacheable: false
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
       display_extenders: {  }
       path: admin/config/search/redirect
     cache_metadata:
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - user.permissions
-      cacheable: false
-      max-age: 0
       tags: {  }
+      cacheable: false

--- a/conf/drupal/config/views.view.schedule.yml
+++ b/conf/drupal/config/views.view.schedule.yml
@@ -21,58 +21,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: none
-        options:
-          items_per_page: 0
-          offset: 0
-      style:
-        type: default
-        options:
-          grouping:
-            -
-              field: field_schedule_time
-              rendered: true
-              rendered_strip: false
-          row_class: schedule__teaser
-          default_row_class: true
-      row:
-        type: fields
-        options:
-          default_field_elements: false
-          inline: {  }
-          separator: ''
-          hide_empty: false
+      title: 'Camp Schedule'
       fields:
         field_schedule_time:
           id: field_schedule_time
@@ -81,6 +35,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -138,7 +93,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_track:
           id: field_track
           table: node__field_track
@@ -146,6 +100,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -201,7 +156,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -209,6 +163,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -264,9 +221,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -274,6 +228,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -329,7 +284,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_schedule_location:
           id: field_schedule_location
           table: node__field_schedule_location
@@ -337,6 +291,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -392,21 +347,30 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
-      filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
+      pager:
+        type: none
+        options:
+          offset: 0
+          items_per_page: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
         field_schedule_time_value:
           id: field_schedule_time_value
           table: node__field_schedule_time
@@ -414,6 +378,51 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: field_schedule_time_value
+          exposed: false
+          granularity: minute
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: title
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        field_schedule_time_value:
+          id: field_schedule_time_value
+          table: node__field_schedule_time
+          field: field_schedule_time_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
           operator: between
           value:
             min: '2018-03-09 00:00:00'
@@ -428,17 +437,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -451,36 +460,33 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
-      sorts:
-        field_schedule_time_value:
-          id: field_schedule_time_value
-          table: node__field_schedule_time
-          field: field_schedule_time_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          granularity: minute
-          plugin_id: datetime
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          entity_type: node
-          entity_field: title
-          plugin_id: standard
-      title: 'Camp Schedule'
+      style:
+        type: default
+        options:
+          grouping:
+            -
+              field: field_schedule_time
+              rendered: true
+              rendered_strip: false
+          row_class: schedule__teaser
+          default_row_class: true
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: schedule
       header:
         area:
           id: area
@@ -489,18 +495,14 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: false
-          tokenize: false
           content:
             value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2018/training\">Thursday</a> | <a href=\"/2018/schedule/friday\">Friday</a> | <a href=\"/2018/schedule/saturday\">Saturday</a> | <a href=\"/2018/sprints\">Sunday</a>\r\n</div>\r\n<h2>Friday, March 9, 2018</h2>"
             format: full_html
-          plugin_id: text
+          tokenize: false
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
-      css_class: schedule
     cache_metadata:
       max-age: -1
       contexts:
@@ -514,14 +516,14 @@ display:
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Friday
+    display_plugin: page
     position: 1
     display_options:
+      display_description: ''
       display_extenders: {  }
       path: 2018/schedule/friday
-      display_description: ''
     cache_metadata:
       max-age: -1
       contexts:
@@ -535,45 +537,25 @@ display:
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
   page_2:
-    display_plugin: page
     id: page_2
     display_title: Saturday
+    display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
-      path: 2018/schedule/saturday
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2018/training\">Thursday</a> | <a href=\"/2018/schedule/friday\">Friday</a> | <a href=\"/2018/schedule/saturday\">Saturday</a> | <a href=\"/2018/sprints\">Sunday</a>\r\n</div>\r\n<h2>Saturday, March 10, 2018</h2>"
-            format: full_html
-          plugin_id: text
-      defaults:
-        header: false
-        filters: false
-        filter_groups: false
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_schedule_time_value:
           id: field_schedule_time_value
           table: node__field_schedule_time
@@ -581,6 +563,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           operator: between
           value:
             min: '2018-03-10 05:00:00'
@@ -595,17 +578,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -618,12 +601,31 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+        header: false
       display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2018/training\">Thursday</a> | <a href=\"/2018/schedule/friday\">Friday</a> | <a href=\"/2018/schedule/saturday\">Saturday</a> | <a href=\"/2018/sprints\">Sunday</a>\r\n</div>\r\n<h2>Saturday, March 10, 2018</h2>"
+            format: full_html
+          tokenize: false
+      display_extenders: {  }
+      path: 2018/schedule/saturday
     cache_metadata:
       max-age: -1
       contexts:
@@ -637,14 +639,12 @@ display:
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
   page_3:
-    display_plugin: page
     id: page_3
     display_title: 'Speaker Socials'
+    display_plugin: page
     position: 3
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      path: 2018/Dwayne-social-butterfly
+      enabled: false
       fields:
         field_schedule_time:
           id: field_schedule_time
@@ -653,6 +653,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -710,7 +711,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -718,6 +718,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -773,9 +776,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -783,6 +783,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -838,25 +839,20 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
-      defaults:
-        fields: false
-        filters: false
-        filter_groups: false
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_schedule_time_value:
           id: field_schedule_time_value
           table: node__field_schedule_time
@@ -864,6 +860,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           operator: between
           value:
             min: '2018-03-09 00:00:00'
@@ -878,17 +875,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -901,12 +898,17 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
       filter_groups:
         operator: AND
         groups:
           1: AND
-      enabled: false
+      defaults:
+        fields: false
+        filters: false
+        filter_groups: false
+      display_description: ''
+      display_extenders: {  }
+      path: 2018/Dwayne-social-butterfly
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.schedule_2019.yml
+++ b/conf/drupal/config/views.view.schedule_2019.yml
@@ -30,58 +30,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: none
-        options:
-          items_per_page: 0
-          offset: 0
-      style:
-        type: default
-        options:
-          grouping:
-            -
-              field: field_schedule_time
-              rendered: false
-              rendered_strip: false
-          row_class: schedule__teaser
-          default_row_class: false
-      row:
-        type: fields
-        options:
-          default_field_elements: false
-          inline: {  }
-          separator: ''
-          hide_empty: false
+      title: 'Camp Schedule'
       fields:
         field_schedule_time:
           id: field_schedule_time
@@ -90,6 +44,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -147,7 +102,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_track:
           id: field_track
           table: node__field_track
@@ -155,6 +109,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -210,7 +165,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -218,6 +172,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -273,9 +230,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -283,6 +237,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -338,7 +293,6 @@ display:
           multi_type: separator
           separator: ' '
           field_api_classes: false
-          plugin_id: field
         field_schedule_location:
           id: field_schedule_location
           table: node__field_schedule_location
@@ -346,6 +300,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -401,21 +356,30 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
-      filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
+      pager:
+        type: none
+        options:
+          offset: 0
+          items_per_page: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
         field_schedule_time_value:
           id: field_schedule_time_value
           table: node__field_schedule_time
@@ -423,6 +387,64 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: field_schedule_time_value
+          exposed: false
+          granularity: minute
+        field_schedule_location_target_id:
+          id: field_schedule_location_target_id
+          table: node__field_schedule_location
+          field: field_schedule_location_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: field_schedule_location_target_id
+          exposed: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: title
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        field_schedule_time_value:
+          id: field_schedule_time_value
+          table: node__field_schedule_time
+          field: field_schedule_time_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
           operator: between
           value:
             min: '2019-03-21 00:00:00'
@@ -437,17 +459,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -460,48 +482,33 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
-      sorts:
-        field_schedule_time_value:
-          id: field_schedule_time_value
-          table: node__field_schedule_time
-          field: field_schedule_time_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          granularity: minute
-          plugin_id: datetime
-        field_schedule_location_target_id:
-          id: field_schedule_location_target_id
-          table: node__field_schedule_location
-          field: field_schedule_location_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: standard
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          entity_type: node
-          entity_field: title
-          plugin_id: standard
-      title: 'Camp Schedule'
+      style:
+        type: default
+        options:
+          grouping:
+            -
+              field: field_schedule_time
+              rendered: false
+              rendered_strip: false
+          row_class: schedule__teaser
+          default_row_class: false
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: schedule
       header:
         area:
           id: area
@@ -510,18 +517,14 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: false
-          tokenize: false
           content:
             value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/schedule/wednesday\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/sprints\">Saturday</a>\r\n</div>\r\n<h2>Thursday, March 21, 2019</h2>"
             format: full_html
-          plugin_id: text
+          tokenize: false
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
-      css_class: schedule
     cache_metadata:
       max-age: -1
       contexts:
@@ -535,27 +538,25 @@ display:
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
   block_1:
-    display_plugin: block
     id: block_1
     display_title: 'Wednesday Social'
+    display_plugin: block
     position: 4
     display_options:
-      display_extenders: {  }
-      display_description: ''
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_schedule_time_value:
           id: field_schedule_time_value
           table: node__field_schedule_time
@@ -563,6 +564,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           operator: between
           value:
             min: '2019-03-20 00:00:00'
@@ -577,17 +579,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -600,16 +602,17 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
-      defaults:
-        filters: false
-        filter_groups: false
-        header: false
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+        header: false
+      display_description: ''
       header: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -623,13 +626,13 @@ display:
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Thursday
+    display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
-      path: 2019/schedule/thursday
+      defaults:
+        header: false
       display_description: ''
       header:
         area:
@@ -639,14 +642,14 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: false
-          tokenize: false
           content:
             value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/schedule/wednesday\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/contribution-day\">Saturday</a>\r\n</div>\r\n<h2>Thursday, March 21, 2019</h2>"
             format: full_html
-          plugin_id: text
-      defaults:
-        header: false
+          tokenize: false
+      display_extenders: {  }
+      path: 2019/schedule/thursday
     cache_metadata:
       max-age: -1
       contexts:
@@ -660,45 +663,25 @@ display:
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
   page_2:
-    display_plugin: page
     id: page_2
     display_title: Friday
+    display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
-      path: 2019/schedule/friday
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/schedule/wednesday\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/contribution-day\">Saturday</a>\r\n</div>\r\n<h2>Friday, March 22, 2019</h2>"
-            format: full_html
-          plugin_id: text
-      defaults:
-        header: false
-        filters: false
-        filter_groups: false
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_schedule_time_value:
           id: field_schedule_time_value
           table: node__field_schedule_time
@@ -706,6 +689,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           operator: between
           value:
             min: '2019-03-22 05:00:00'
@@ -720,17 +704,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -743,12 +727,31 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+        header: false
       display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/schedule/wednesday\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/contribution-day\">Saturday</a>\r\n</div>\r\n<h2>Friday, March 22, 2019</h2>"
+            format: full_html
+          tokenize: false
+      display_extenders: {  }
+      path: 2019/schedule/friday
     cache_metadata:
       max-age: -1
       contexts:
@@ -762,173 +765,12 @@ display:
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
   page_3:
-    display_plugin: page
     id: page_3
     display_title: Wednesday
+    display_plugin: page
     position: 3
     display_options:
-      display_extenders: {  }
-      path: 2019/schedule/wednesday
       title: 'Camp Schedule'
-      defaults:
-        title: false
-        filters: false
-        filter_groups: false
-        fields: false
-        header: false
-        sorts: false
-        style: false
-        row: false
-        footer: false
-      filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: in
-          value:
-            summit: summit
-            training: training
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-        field_event_target_id:
-          id: field_event_target_id
-          table: node__field_event
-          field: field_event_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: or
-          value:
-            97: 97
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          type: select
-          limit: true
-          vid: event
-          hierarchy: false
-          error_message: true
-          plugin_id: taxonomy_index_tid
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '!='
-          value: 'Getting started with the Drupal issue queue'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: node
-          entity_field: title
-          plugin_id: string
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
-      display_description: ''
       fields:
         field_track:
           id: field_track
@@ -937,6 +779,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -992,7 +835,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -1000,6 +842,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1055,9 +900,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         body:
           id: body
           table: node__body
@@ -1065,6 +907,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1120,7 +963,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -1128,6 +970,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1183,7 +1026,6 @@ display:
           multi_type: separator
           separator: ' '
           field_api_classes: false
-          plugin_id: field
         type:
           id: type
           table: node_field_data
@@ -1191,6 +1033,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -1246,23 +1091,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: type
-          plugin_id: field
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/schedule/wednesday\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/sprints\">Saturday</a>\r\n</div>\r\n<h2>Wednesday, March 20, 2019</h2>"
-            format: full_html
-          plugin_id: text
       sorts:
         type:
           id: type
@@ -1271,13 +1099,14 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
           entity_type: node
           entity_field: type
           plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: type
+          exposed: false
         title:
           id: title
           table: node_field_data
@@ -1285,13 +1114,162 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
           entity_type: node
           entity_field: title
           plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: title
+          exposed: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            summit: summit
+            training: training
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value:
+            97: 97
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: event
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          operator: '!='
+          value: 'Getting started with the Drupal issue queue'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: default
         options:
@@ -1309,6 +1287,31 @@ display:
           inline: {  }
           separator: ''
           hide_empty: false
+      defaults:
+        title: false
+        style: false
+        row: false
+        fields: false
+        sorts: false
+        filters: false
+        filter_groups: false
+        header: false
+        footer: false
+      display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/schedule/wednesday\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/sprints\">Saturday</a>\r\n</div>\r\n<h2>Wednesday, March 20, 2019</h2>"
+            format: full_html
+          tokenize: false
       footer:
         view:
           id: view
@@ -1317,10 +1320,12 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: view
           empty: false
           view_to_insert: 'schedule_2019:block_1'
           inherit_arguments: false
-          plugin_id: view
+      display_extenders: {  }
+      path: 2019/schedule/wednesday
     cache_metadata:
       max-age: -1
       contexts:
@@ -1334,172 +1339,12 @@ display:
         - 'config:field.storage.node.field_people'
         - 'config:field.storage.node.field_track'
   page_4:
-    display_plugin: page
     id: page_4
     display_title: 'Historical Sessions'
+    display_plugin: page
     position: 5
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      path: 2019/sessions
-      filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-        field_accepted_confirmed_value:
-          id: field_accepted_confirmed_value
-          table: node__field_accepted_confirmed
-          field: field_accepted_confirmed_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: boolean
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: in
-          value:
-            topic: topic
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-        field_event_target_id:
-          id: field_event_target_id
-          table: node__field_event
-          field: field_event_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: or
-          value:
-            97: 97
-          group: 1
-          exposed: false
-          expose:
-            operator_id: field_event_target_id_op
-            label: Event
-            description: ''
-            use_operator: false
-            operator: field_event_target_id_op
-            identifier: field_event_target_id
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              speaker: '0'
-              content_editor: '0'
-              administrator: '0'
-              sponsor: '0'
-              organizer: '0'
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          type: select
-          limit: true
-          vid: event
-          hierarchy: false
-          error_message: true
-          plugin_id: taxonomy_index_tid
-      defaults:
-        filters: false
-        filter_groups: false
-        fields: false
-        header: false
-        title: false
-        style: false
-        row: false
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
+      title: '2019 Sessions'
       fields:
         field_schedule_time:
           id: field_schedule_time
@@ -1508,6 +1353,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -1565,7 +1411,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_track:
           id: field_track
           table: node__field_track
@@ -1573,6 +1418,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1628,7 +1474,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -1636,6 +1481,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1691,9 +1539,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -1701,6 +1546,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1756,22 +1602,156 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
-      header:
-        area:
-          id: area
-          table: views
-          field: area
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        field_accepted_confirmed_value:
+          id: field_accepted_confirmed_value
+          table: node__field_accepted_confirmed
+          field: field_accepted_confirmed_value
           relationship: none
           group_type: group
           admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: ''
-            format: full_html
-          plugin_id: text
-      title: '2019 Sessions'
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            topic: topic
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value:
+            97: 97
+          group: 1
+          exposed: false
+          expose:
+            operator_id: field_event_target_id_op
+            label: Event
+            description: ''
+            use_operator: false
+            operator: field_event_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_event_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              speaker: '0'
+              content_editor: '0'
+              administrator: '0'
+              sponsor: '0'
+              organizer: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: event
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: default
         options:
@@ -1785,6 +1765,31 @@ display:
           inline: {  }
           separator: ''
           hide_empty: false
+      defaults:
+        title: false
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+        header: false
+      display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: ''
+            format: full_html
+          tokenize: false
+      display_extenders: {  }
+      path: 2019/sessions
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.schedule_2020.yml
+++ b/conf/drupal/config/views.view.schedule_2020.yml
@@ -31,58 +31,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: none
-        options:
-          items_per_page: 0
-          offset: 0
-      style:
-        type: default
-        options:
-          grouping:
-            -
-              field: field_schedule_time
-              rendered: false
-              rendered_strip: false
-          row_class: schedule__teaser
-          default_row_class: false
-      row:
-        type: fields
-        options:
-          default_field_elements: false
-          inline: {  }
-          separator: ''
-          hide_empty: false
+      title: 'Camp Schedule'
       fields:
         field_schedule_time:
           id: field_schedule_time
@@ -91,6 +45,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -148,7 +103,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_track:
           id: field_track
           table: node__field_track
@@ -156,6 +110,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -211,7 +166,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -219,6 +173,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -274,9 +231,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -284,6 +238,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -339,7 +294,6 @@ display:
           multi_type: separator
           separator: ' '
           field_api_classes: false
-          plugin_id: field
         field_schedule_location:
           id: field_schedule_location
           table: node__field_schedule_location
@@ -347,6 +301,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -402,21 +357,30 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
-      filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
+      pager:
+        type: none
+        options:
+          offset: 0
+          items_per_page: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
         field_schedule_time_value:
           id: field_schedule_time_value
           table: node__field_schedule_time
@@ -424,6 +388,64 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: field_schedule_time_value
+          exposed: false
+          granularity: minute
+        field_schedule_location_target_id:
+          id: field_schedule_location_target_id
+          table: node__field_schedule_location
+          field: field_schedule_location_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: field_schedule_location_target_id
+          exposed: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: title
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        field_schedule_time_value:
+          id: field_schedule_time_value
+          table: node__field_schedule_time
+          field: field_schedule_time_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
           operator: between
           value:
             min: '2020-03-19 00:00:00'
@@ -438,17 +460,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -461,48 +483,33 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
-      sorts:
-        field_schedule_time_value:
-          id: field_schedule_time_value
-          table: node__field_schedule_time
-          field: field_schedule_time_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          granularity: minute
-          plugin_id: datetime
-        field_schedule_location_target_id:
-          id: field_schedule_location_target_id
-          table: node__field_schedule_location
-          field: field_schedule_location_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: standard
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          entity_type: node
-          entity_field: title
-          plugin_id: standard
-      title: 'Camp Schedule'
+      style:
+        type: default
+        options:
+          grouping:
+            -
+              field: field_schedule_time
+              rendered: false
+              rendered_strip: false
+          row_class: schedule__teaser
+          default_row_class: false
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: schedule
       header:
         area:
           id: area
@@ -511,18 +518,14 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: false
-          tokenize: false
           content:
             value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/schedule/wednesday\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/sprints\">Saturday</a>\r\n</div>\r\n<h2>Thursday, March 21, 2019</h2>"
             format: full_html
-          plugin_id: text
+          tokenize: false
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
-      css_class: schedule
     cache_metadata:
       max-age: -1
       contexts:
@@ -536,27 +539,25 @@ display:
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
   block_1:
-    display_plugin: block
     id: block_1
     display_title: 'Wednesday Social'
+    display_plugin: block
     position: 4
     display_options:
-      display_extenders: {  }
-      display_description: ''
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_schedule_time_value:
           id: field_schedule_time_value
           table: node__field_schedule_time
@@ -564,6 +565,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           operator: between
           value:
             min: '2020-03-18 00:00:00'
@@ -578,17 +580,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -601,16 +603,17 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
-      defaults:
-        filters: false
-        filter_groups: false
-        header: false
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+        header: false
+      display_description: ''
       header: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -624,13 +627,13 @@ display:
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Thursday
+    display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
-      path: 2020/schedule/thursday
+      defaults:
+        header: false
       display_description: ''
       header:
         area:
@@ -640,23 +643,23 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: false
-          tokenize: false
           content:
             value: "<div class=\"schedule__nav\">\r\n      <!--a href=\"/2020/schedule/wednesday\">Wednesday</a> | --><a href=\"/2020/schedule/thursday\">Thursday</a> | <a href=\"/2020/schedule/friday\">Friday</a> | <a href=\"/2020/contribution-day\">Saturday</a>\r\n</div>\r\n<h2>Thursday, March 19, 2020</h2>"
             format: full_html
-          plugin_id: text
-      defaults:
-        header: false
+          tokenize: false
+      display_extenders: {  }
+      path: 2020/schedule/thursday
       menu:
         type: normal
         title: 'Sessions (Thu)'
         description: ''
-        expanded: false
-        parent: 'menu_link_content:9aa75b79-01c2-41b7-ba8d-b3b46afb3eb8'
         weight: -49
-        context: '0'
+        expanded: false
         menu_name: midcamp-2020-navigation
+        parent: 'menu_link_content:9aa75b79-01c2-41b7-ba8d-b3b46afb3eb8'
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:
@@ -670,45 +673,25 @@ display:
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
   page_2:
-    display_plugin: page
     id: page_2
     display_title: Friday
+    display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
-      path: 2020/schedule/friday
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: "<div class=\"schedule__nav\">\r\n      <!--a href=\"/2020/schedule/wednesday\">Wednesday</a> | --><a href=\"/2020/schedule/thursday\">Thursday</a> | <a href=\"/2020/schedule/friday\">Friday</a> | <a href=\"/2020/contribution-day\">Saturday</a>\r\n</div>\r\n<h2>Friday, March 20, 2020</h2>"
-            format: full_html
-          plugin_id: text
-      defaults:
-        header: false
-        filters: false
-        filter_groups: false
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_schedule_time_value:
           id: field_schedule_time_value
           table: node__field_schedule_time
@@ -716,6 +699,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           operator: between
           value:
             min: '2020-03-20 00:00:00'
@@ -730,17 +714,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -753,21 +737,40 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+        header: false
       display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: "<div class=\"schedule__nav\">\r\n      <!--a href=\"/2020/schedule/wednesday\">Wednesday</a> | --><a href=\"/2020/schedule/thursday\">Thursday</a> | <a href=\"/2020/schedule/friday\">Friday</a> | <a href=\"/2020/contribution-day\">Saturday</a>\r\n</div>\r\n<h2>Friday, March 20, 2020</h2>"
+            format: full_html
+          tokenize: false
+      display_extenders: {  }
+      path: 2020/schedule/friday
       menu:
         type: normal
         title: 'Sessions (Fri)'
         description: ''
-        expanded: false
-        parent: 'menu_link_content:9aa75b79-01c2-41b7-ba8d-b3b46afb3eb8'
         weight: -48
-        context: '0'
+        expanded: false
         menu_name: midcamp-2020-navigation
+        parent: 'menu_link_content:9aa75b79-01c2-41b7-ba8d-b3b46afb3eb8'
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:
@@ -781,133 +784,12 @@ display:
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
   page_3:
-    display_plugin: page
     id: page_3
     display_title: Wednesday
+    display_plugin: page
     position: 3
     display_options:
-      display_extenders: {  }
-      path: 2020/schedule/wednesday
       title: 'Camp Schedule'
-      defaults:
-        title: false
-        filters: false
-        filter_groups: false
-        fields: false
-        header: false
-        sorts: false
-        style: false
-        row: false
-        footer: false
-        pager: false
-      filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: in
-          value:
-            summit: summit
-            training: training
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-        field_event_target_id:
-          id: field_event_target_id
-          table: node__field_event
-          field: field_event_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: or
-          value:
-            143: 143
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          type: select
-          limit: true
-          vid: event
-          hierarchy: false
-          error_message: true
-          plugin_id: taxonomy_index_tid
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
-      display_description: ''
       fields:
         field_track:
           id: field_track
@@ -916,6 +798,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -971,7 +854,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -979,6 +861,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1034,9 +919,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         body:
           id: body
           table: node__body
@@ -1044,6 +926,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1099,7 +982,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -1107,6 +989,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1162,7 +1045,6 @@ display:
           multi_type: separator
           separator: ' '
           field_api_classes: false
-          plugin_id: field
         type:
           id: type
           table: node_field_data
@@ -1170,6 +1052,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -1225,23 +1110,11 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: type
-          plugin_id: field
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: "<div class=\"schedule__nav\">\r\n      <!--a href=\"/2020/schedule/wednesday\">Wednesday</a> | --><a href=\"/2020/schedule/thursday\">Thursday</a> | <a href=\"/2020/schedule/friday\">Friday</a> | <a href=\"/2020/contribution-day\">Saturday</a>\r\n</div>\r\n<h2>Wednesday, March 18, 2020</h2>\r\n<strong>Registration 8 am. Events run 9 am - 5 pm.</strong>"
-            format: full_html
-          plugin_id: text
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 6
       sorts:
         type:
           id: type
@@ -1250,13 +1123,14 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
           entity_type: node
           entity_field: type
           plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: type
+          exposed: false
         title:
           id: title
           table: node_field_data
@@ -1264,13 +1138,121 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
           entity_type: node
           entity_field: title
           plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: title
+          exposed: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            summit: summit
+            training: training
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value:
+            143: 143
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: event
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: default
         options:
@@ -1288,6 +1270,32 @@ display:
           inline: {  }
           separator: ''
           hide_empty: false
+      defaults:
+        title: false
+        pager: false
+        style: false
+        row: false
+        fields: false
+        sorts: false
+        filters: false
+        filter_groups: false
+        header: false
+        footer: false
+      display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: "<div class=\"schedule__nav\">\r\n      <!--a href=\"/2020/schedule/wednesday\">Wednesday</a> | --><a href=\"/2020/schedule/thursday\">Thursday</a> | <a href=\"/2020/schedule/friday\">Friday</a> | <a href=\"/2020/contribution-day\">Saturday</a>\r\n</div>\r\n<h2>Wednesday, March 18, 2020</h2>\r\n<strong>Registration 8 am. Events run 9 am - 5 pm.</strong>"
+            format: full_html
+          tokenize: false
       footer:
         view:
           id: view
@@ -1296,25 +1304,22 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: view
           empty: false
           view_to_insert: 'schedule_2020:block_1'
           inherit_arguments: false
-          plugin_id: view
+      display_extenders: {  }
+      path: 2020/schedule/wednesday
       menu:
         type: normal
         title: 'Summits & Training (Wed)'
         description: ''
-        expanded: false
-        parent: 'menu_link_content:9aa75b79-01c2-41b7-ba8d-b3b46afb3eb8'
         weight: -50
-        context: '0'
-        menu_name: midcamp-2020-navigation
         enabled: false
-      pager:
-        type: some
-        options:
-          items_per_page: 6
-          offset: 0
+        expanded: false
+        menu_name: midcamp-2020-navigation
+        parent: 'menu_link_content:9aa75b79-01c2-41b7-ba8d-b3b46afb3eb8'
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:
@@ -1328,172 +1333,13 @@ display:
         - 'config:field.storage.node.field_people'
         - 'config:field.storage.node.field_track'
   page_4:
-    display_plugin: page
     id: page_4
     display_title: 'Historical Sessions'
+    display_plugin: page
     position: 5
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      path: 2020/sessions
-      filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-        field_accepted_confirmed_value:
-          id: field_accepted_confirmed_value
-          table: node__field_accepted_confirmed
-          field: field_accepted_confirmed_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: boolean
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: in
-          value:
-            topic: topic
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-        field_event_target_id:
-          id: field_event_target_id
-          table: node__field_event
-          field: field_event_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: or
-          value:
-            143: 143
-          group: 1
-          exposed: false
-          expose:
-            operator_id: field_event_target_id_op
-            label: Event
-            description: ''
-            use_operator: false
-            operator: field_event_target_id_op
-            identifier: field_event_target_id
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              speaker: '0'
-              content_editor: '0'
-              administrator: '0'
-              sponsor: '0'
-              organizer: '0'
-            reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          reduce_duplicates: false
-          type: select
-          limit: true
-          vid: event
-          hierarchy: false
-          error_message: true
-          plugin_id: taxonomy_index_tid
-      defaults:
-        filters: false
-        filter_groups: false
-        fields: false
-        header: false
-        title: false
-        style: false
-        row: false
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
+      enabled: false
+      title: '2019 Sessions'
       fields:
         field_schedule_time:
           id: field_schedule_time
@@ -1502,6 +1348,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -1559,7 +1406,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_track:
           id: field_track
           table: node__field_track
@@ -1567,6 +1413,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1622,7 +1469,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -1630,6 +1476,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1685,9 +1534,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -1695,6 +1541,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1750,22 +1597,156 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
-      header:
-        area:
-          id: area
-          table: views
-          field: area
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        field_accepted_confirmed_value:
+          id: field_accepted_confirmed_value
+          table: node__field_accepted_confirmed
+          field: field_accepted_confirmed_value
           relationship: none
           group_type: group
           admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: ''
-            format: full_html
-          plugin_id: text
-      title: '2019 Sessions'
+          plugin_id: boolean
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            topic: topic
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: taxonomy_index_tid
+          operator: or
+          value:
+            143: 143
+          group: 1
+          exposed: false
+          expose:
+            operator_id: field_event_target_id_op
+            label: Event
+            description: ''
+            use_operator: false
+            operator: field_event_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_event_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              speaker: '0'
+              content_editor: '0'
+              administrator: '0'
+              sponsor: '0'
+              organizer: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          vid: event
+          type: select
+          hierarchy: false
+          limit: true
+          error_message: true
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: default
         options:
@@ -1779,16 +1760,40 @@ display:
           inline: {  }
           separator: ''
           hide_empty: false
+      defaults:
+        title: false
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+        header: false
+      display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: ''
+            format: full_html
+          tokenize: false
+      display_extenders: {  }
+      path: 2020/sessions
       menu:
         type: normal
         title: 'All Sessions'
         description: ''
-        expanded: false
-        parent: 'menu_link_content:9aa75b79-01c2-41b7-ba8d-b3b46afb3eb8'
         weight: -6
-        context: '0'
+        expanded: false
         menu_name: midcamp-2020-navigation
-      enabled: false
+        parent: 'menu_link_content:9aa75b79-01c2-41b7-ba8d-b3b46afb3eb8'
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.schedule_2021.yml
+++ b/conf/drupal/config/views.view.schedule_2021.yml
@@ -23,58 +23,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: none
-        options:
-          items_per_page: 0
-          offset: 0
-      style:
-        type: default
-        options:
-          grouping:
-            -
-              field: field_schedule_time
-              rendered: false
-              rendered_strip: false
-          row_class: schedule__teaser
-          default_row_class: false
-      row:
-        type: fields
-        options:
-          default_field_elements: false
-          inline: {  }
-          separator: ''
-          hide_empty: false
+      title: 'Camp Schedule'
       fields:
         field_schedule_time:
           id: field_schedule_time
@@ -83,6 +37,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -140,7 +95,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_track:
           id: field_track
           table: node__field_track
@@ -148,6 +102,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -203,7 +158,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -211,6 +165,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -266,9 +223,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         body:
           id: body
           table: node__body
@@ -276,6 +230,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -331,7 +286,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -339,6 +293,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -394,7 +349,6 @@ display:
           multi_type: separator
           separator: ' '
           field_api_classes: false
-          plugin_id: field
         field_schedule_location:
           id: field_schedule_location
           table: node__field_schedule_location
@@ -402,6 +356,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -457,21 +412,30 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
-      filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
-          expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
+      pager:
+        type: none
+        options:
+          offset: 0
+          items_per_page: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
         field_schedule_time_value:
           id: field_schedule_time_value
           table: node__field_schedule_time
@@ -479,6 +443,64 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: field_schedule_time_value
+          exposed: false
+          granularity: minute
+        field_schedule_location_target_id:
+          id: field_schedule_location_target_id
+          table: node__field_schedule_location
+          field: field_schedule_location_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: field_schedule_location_target_id
+          exposed: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: title
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        field_schedule_time_value:
+          id: field_schedule_time_value
+          table: node__field_schedule_time
+          field: field_schedule_time_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
           operator: between
           value:
             min: '2020-03-19 00:00:00'
@@ -493,17 +515,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -516,48 +538,33 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
-      sorts:
-        field_schedule_time_value:
-          id: field_schedule_time_value
-          table: node__field_schedule_time
-          field: field_schedule_time_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          granularity: minute
-          plugin_id: datetime
-        field_schedule_location_target_id:
-          id: field_schedule_location_target_id
-          table: node__field_schedule_location
-          field: field_schedule_location_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: standard
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          entity_type: node
-          entity_field: title
-          plugin_id: standard
-      title: 'Camp Schedule'
+      style:
+        type: default
+        options:
+          grouping:
+            -
+              field: field_schedule_time
+              rendered: false
+              rendered_strip: false
+          row_class: schedule__teaser
+          default_row_class: false
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      css_class: schedule
       header:
         area:
           id: area
@@ -566,18 +573,14 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: false
-          tokenize: false
           content:
             value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2019/schedule/wednesday\">Wednesday</a> | <a href=\"/2019/schedule/thursday\">Thursday</a> | <a href=\"/2019/schedule/friday\">Friday</a> | <a href=\"/2019/sprints\">Saturday</a>\r\n</div>\r\n<h2>Thursday, March 21, 2019</h2>"
             format: full_html
-          plugin_id: text
+          tokenize: false
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
-      css_class: schedule
     cache_metadata:
       max-age: -1
       contexts:
@@ -592,55 +595,25 @@ display:
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Thursday
+    display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
-      path: 2021/schedule/thursday
-      display_description: ''
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2021/get-started-drupal\">Wednesday</a> | <a href=\"/2021/meet-drupal-community\">Thursday</a> | <a href=\"/2021/share-your-knowledge\">Friday</a> | <a href=\"/2021/contribution-day\">Saturday</a>\r\n</div>"
-            format: full_html
-          plugin_id: text
-      defaults:
-        header: false
-        filters: false
-        filter_groups: false
-      menu:
-        type: none
-        title: 'Sessions (Thu)'
-        description: ''
-        expanded: false
-        parent: 'menu_link_content:9aa75b79-01c2-41b7-ba8d-b3b46afb3eb8'
-        weight: -49
-        context: '0'
-        menu_name: midcamp-2020-navigation
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_schedule_time_value:
           id: field_schedule_time_value
           table: node__field_schedule_time
@@ -648,6 +621,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           operator: between
           value:
             min: '2021-03-25 00:00:00'
@@ -670,9 +644,9 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -685,11 +659,40 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+        header: false
+      display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2021/get-started-drupal\">Wednesday</a> | <a href=\"/2021/meet-drupal-community\">Thursday</a> | <a href=\"/2021/share-your-knowledge\">Friday</a> | <a href=\"/2021/contribution-day\">Saturday</a>\r\n</div>"
+            format: full_html
+          tokenize: false
+      display_extenders: {  }
+      path: 2021/schedule/thursday
+      menu:
+        type: none
+        title: 'Sessions (Thu)'
+        description: ''
+        weight: -49
+        expanded: false
+        menu_name: midcamp-2020-navigation
+        parent: 'menu_link_content:9aa75b79-01c2-41b7-ba8d-b3b46afb3eb8'
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:
@@ -704,45 +707,25 @@ display:
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
   page_2:
-    display_plugin: page
     id: page_2
     display_title: Friday
+    display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
-      path: 2021/schedule/friday
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2021/get-started-drupal\">Wednesday</a> | <a href=\"/2021/meet-drupal-community\">Thursday</a> | <a href=\"/2021/share-your-knowledge\">Friday</a> | <a href=\"/2021/contribution-day\">Saturday</a>\r\n</div>"
-            format: full_html
-          plugin_id: text
-      defaults:
-        header: false
-        filters: false
-        filter_groups: false
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_schedule_time_value:
           id: field_schedule_time_value
           table: node__field_schedule_time
@@ -750,6 +733,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           operator: between
           value:
             min: '2021-03-26 00:00:00'
@@ -772,9 +756,9 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -787,21 +771,40 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+        header: false
       display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2021/get-started-drupal\">Wednesday</a> | <a href=\"/2021/meet-drupal-community\">Thursday</a> | <a href=\"/2021/share-your-knowledge\">Friday</a> | <a href=\"/2021/contribution-day\">Saturday</a>\r\n</div>"
+            format: full_html
+          tokenize: false
+      display_extenders: {  }
+      path: 2021/schedule/friday
       menu:
         type: none
         title: 'Sessions (Fri)'
         description: ''
-        expanded: false
-        parent: 'menu_link_content:9aa75b79-01c2-41b7-ba8d-b3b46afb3eb8'
         weight: -48
-        context: '0'
+        expanded: false
         menu_name: midcamp-2020-navigation
+        parent: 'menu_link_content:9aa75b79-01c2-41b7-ba8d-b3b46afb3eb8'
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:
@@ -816,55 +819,25 @@ display:
         - 'config:field.storage.node.field_schedule_time'
         - 'config:field.storage.node.field_track'
   page_5:
-    display_plugin: page
     id: page_5
     display_title: Wednesday
+    display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
-      path: 2021/schedule/wednesday
-      display_description: ''
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2021/get-started-drupal\">Wednesday</a> | <a href=\"/2021/meet-drupal-community\">Thursday</a> | <a href=\"/2021/share-your-knowledge\">Friday</a> | <a href=\"/2021/contribution-day\">Saturday</a>\r\n</div>"
-            format: full_html
-          plugin_id: text
-      defaults:
-        header: false
-        filters: false
-        filter_groups: false
-      menu:
-        type: none
-        title: 'Sessions (Wed)'
-        description: ''
-        expanded: false
-        parent: 'menu_link_content:9aa75b79-01c2-41b7-ba8d-b3b46afb3eb8'
-        weight: -49
-        context: '0'
-        menu_name: midcamp-2020-navigation
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_schedule_time_value:
           id: field_schedule_time_value
           table: node__field_schedule_time
@@ -872,6 +845,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           operator: between
           value:
             min: '2021-03-24 00:00:00'
@@ -894,9 +868,9 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -909,11 +883,40 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+        header: false
+      display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: "<div class=\"schedule__nav\">\r\n      <a href=\"/2021/get-started-drupal\">Wednesday</a> | <a href=\"/2021/meet-drupal-community\">Thursday</a> | <a href=\"/2021/share-your-knowledge\">Friday</a> | <a href=\"/2021/contribution-day\">Saturday</a>\r\n</div>"
+            format: full_html
+          tokenize: false
+      display_extenders: {  }
+      path: 2021/schedule/wednesday
+      menu:
+        type: none
+        title: 'Sessions (Wed)'
+        description: ''
+        weight: -49
+        expanded: false
+        menu_name: midcamp-2020-navigation
+        parent: 'menu_link_content:9aa75b79-01c2-41b7-ba8d-b3b46afb3eb8'
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.scheduler_scheduled_content.yml
+++ b/conf/drupal/config/views.view.scheduler_scheduled_content.yml
@@ -17,116 +17,19 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
+    id: default
+    display_title: Master
+    display_plugin: default
+    position: 0
     display_options:
-      access:
-        type: scheduler
-      cache:
-        type: tag
-      query:
-        type: views_query
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Filter
-          reset_button: true
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 50
-          tags:
-            previous: '‹ previous'
-            next: 'next ›'
-            first: '« first'
-            last: 'last »'
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: true
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            node_bulk_form: node_bulk_form
-            title: title
-            type: type
-            name: name
-            status: status
-            publish_on: publish_on
-            unpublish_on: unpublish_on
-            operations: operations
-          info:
-            node_bulk_form:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            title:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            type:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            name:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            status:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            publish_on:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            unpublish_on:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            operations:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: '-1'
-          empty_table: true
-      row:
-        type: fields
+      title: 'Scheduled Content'
       fields:
         node_bulk_form:
           id: node_bulk_form
           table: node
           field: node_bulk_form
+          entity_type: node
+          plugin_id: node_bulk_form
           label: ''
           exclude: false
           alter:
@@ -137,12 +40,13 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: node_bulk_form
-          entity_type: node
         title:
           id: title
           table: node_field_data
           field: title
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: Title
           exclude: false
           alter:
@@ -153,12 +57,9 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          entity_type: node
-          entity_field: title
           type: string
           settings:
             link_to_entity: true
-          plugin_id: field
         type:
           id: type
           table: node_field_data
@@ -166,6 +67,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: field
           label: 'Content Type'
           exclude: false
           alter:
@@ -221,14 +125,14 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: type
-          plugin_id: field
         name:
           id: name
           table: users_field_data
           field: name
           relationship: uid
+          entity_type: user
+          entity_field: name
+          plugin_id: field
           label: Author
           exclude: false
           alter:
@@ -239,14 +143,14 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: field
           type: user_name
-          entity_type: user
-          entity_field: name
         status:
           id: status
           table: node_field_data
           field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: field
           label: Status
           exclude: false
           alter:
@@ -260,11 +164,8 @@ display:
           type: boolean
           settings:
             format: custom
-            format_custom_true: Published
             format_custom_false: Unpublished
-          plugin_id: field
-          entity_type: node
-          entity_field: status
+            format_custom_true: Published
         publish_on:
           id: publish_on
           table: node_field_data
@@ -272,6 +173,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: publish_on
+          plugin_id: date
           label: 'Publish on'
           exclude: false
           alter:
@@ -316,9 +220,6 @@ display:
           date_format: short
           custom_date_format: ''
           timezone: ''
-          entity_type: node
-          entity_field: publish_on
-          plugin_id: date
         unpublish_on:
           id: unpublish_on
           table: node_field_data
@@ -326,6 +227,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: unpublish_on
+          plugin_id: date
           label: 'Unpublish on'
           exclude: false
           alter:
@@ -370,9 +274,6 @@ display:
           date_format: short
           custom_date_format: ''
           timezone: ''
-          entity_type: node
-          entity_field: unpublish_on
-          plugin_id: date
         operations:
           id: operations
           table: node
@@ -380,6 +281,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: entity_operations
           label: Operations
           exclude: false
           alter:
@@ -422,7 +324,43 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: true
-          plugin_id: entity_operations
+      pager:
+        type: full
+        options:
+          items_per_page: 50
+          tags:
+            next: 'next ›'
+            previous: '‹ previous'
+            first: '« first'
+            last: 'last »'
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: scheduler
+      cache:
+        type: tag
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No scheduled content.'
+          tokenize: false
+      sorts: {  }
+      arguments: {  }
       filters:
         status:
           id: status
@@ -431,6 +369,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -441,14 +382,14 @@ display:
             description: ''
             use_operator: false
             operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: status
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: true
           group_info:
             label: 'Published status'
@@ -469,9 +410,6 @@ display:
                 title: Unpublished
                 operator: '='
                 value: '0'
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
         type:
           id: type
           table: node_field_data
@@ -479,6 +417,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
           operator: in
           value: {  }
           group: 1
@@ -489,6 +430,8 @@ display:
             description: ''
             use_operator: false
             operator: type_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: type
             required: false
             remember: false
@@ -498,8 +441,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -512,9 +453,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: bundle
-          entity_type: node
-          entity_field: type
         title:
           id: title
           table: node_field_data
@@ -522,6 +460,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -532,6 +473,8 @@ display:
             description: ''
             use_operator: false
             operator: title_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: title
             required: false
             remember: false
@@ -541,8 +484,6 @@ display:
               anonymous: '0'
               administrator: '0'
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -555,9 +496,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: string
-          entity_type: node
-          entity_field: title
         langcode:
           id: langcode
           table: node_field_data
@@ -565,6 +503,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
           operator: in
           value: {  }
           group: 1
@@ -575,6 +516,8 @@ display:
             description: ''
             use_operator: false
             operator: langcode_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: langcode
             required: false
             remember: false
@@ -584,8 +527,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -598,9 +539,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: language
-          entity_type: node
-          entity_field: langcode
         publish_on:
           id: publish_on
           table: node_field_data
@@ -608,6 +546,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: publish_on
+          plugin_id: date
           operator: 'not empty'
           value:
             min: ''
@@ -622,6 +563,8 @@ display:
             description: ''
             use_operator: true
             operator: publish_on_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: publish_on
             required: false
             remember: false
@@ -630,11 +573,9 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: 'Publish on'
@@ -650,9 +591,6 @@ display:
               1: {  }
               2: {  }
               3: {  }
-          entity_type: node
-          entity_field: publish_on
-          plugin_id: date
         unpublish_on:
           id: unpublish_on
           table: node_field_data
@@ -660,6 +598,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: unpublish_on
+          plugin_id: date
           operator: 'not empty'
           value:
             min: ''
@@ -674,6 +615,8 @@ display:
             description: ''
             use_operator: false
             operator: unpublish_on_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: unpublish_on
             required: false
             remember: false
@@ -682,11 +625,9 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -699,11 +640,153 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: unpublish_on
-          plugin_id: date
-      sorts: {  }
-      title: 'Scheduled Content'
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+          2: OR
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            node_bulk_form: node_bulk_form
+            title: title
+            type: type
+            name: name
+            status: status
+            publish_on: publish_on
+            unpublish_on: unpublish_on
+            operations: operations
+          default: '-1'
+          info:
+            node_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            publish_on:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            unpublish_on:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            operations:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: true
+          summary: ''
+          empty_table: true
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+      relationships:
+        uid:
+          id: uid
+          table: node_field_data
+          field: uid
+          admin_label: author
+          plugin_id: standard
+          required: true
+      show_admin_links: false
+      display_extenders: {  }
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+      tags: {  }
+      cacheable: false
+  overview:
+    id: overview
+    display_title: 'Content Overview'
+    display_plugin: page
+    position: 1
+    display_options:
+      display_description: 'Overview of all scheduled content, as a tab on main ''content admin'' page'
+      display_extenders: {  }
+      path: admin/content/scheduled
+      menu:
+        type: tab
+        title: Scheduled
+        description: ''
+        weight: -10
+        menu_name: admin
+        parent: system.admin_content
+        context: '0'
+      tab_options:
+        type: normal
+        title: Content
+        description: 'Find and manage scheduled content'
+        weight: -10
+        menu_name: admin
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+      tags: {  }
+      cacheable: false
+  user_page:
+    id: user_page
+    display_title: 'User profile tab'
+    display_plugin: page
+    position: 2
+    display_options:
       empty:
         area_text_custom:
           id: area_text_custom
@@ -712,100 +795,10 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'No scheduled content.'
           plugin_id: text_custom
-      arguments: {  }
-      relationships:
-        uid:
-          id: uid
-          table: node_field_data
-          field: uid
-          admin_label: author
-          required: true
-          plugin_id: standard
-      show_admin_links: false
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
-          2: OR
-      display_extenders: {  }
-    display_plugin: default
-    display_title: Master
-    id: default
-    position: 0
-    cache_metadata:
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - url.query_args
-        - user
-        - 'user.node_grants:view'
-      cacheable: false
-      max-age: 0
-      tags: {  }
-  overview:
-    display_options:
-      path: admin/content/scheduled
-      menu:
-        type: tab
-        title: Scheduled
-        description: ''
-        parent: system.admin_content
-        weight: -10
-        context: '0'
-        menu_name: admin
-      tab_options:
-        type: normal
-        title: Content
-        description: 'Find and manage scheduled content'
-        menu_name: admin
-        weight: -10
-      display_extenders: {  }
-      display_description: 'Overview of all scheduled content, as a tab on main ''content admin'' page'
-    display_plugin: page
-    display_title: 'Content Overview'
-    id: overview
-    position: 1
-    cache_metadata:
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - url.query_args
-        - user
-        - 'user.node_grants:view'
-      cacheable: false
-      max-age: 0
-      tags: {  }
-  user_page:
-    display_options:
-      path: user/%user/scheduled
-      menu:
-        type: tab
-        title: Scheduled
-        description: ''
-        parent: system.admin_content
-        weight: -10
-        context: '0'
-        menu_name: admin
-      tab_options:
-        type: normal
-        title: Content
-        description: 'Find and manage scheduled content'
-        menu_name: admin
-        weight: -10
-      display_extenders: {  }
-      display_description: 'Scheduled content tab on user profile, showing just that user''s scheduled content'
-      defaults:
-        filters: true
-        filter_groups: true
-        arguments: false
-        access: true
-        empty: false
+          empty: true
+          content: 'No scheduled content for user {{ arguments.uid }}'
+          tokenize: true
       arguments:
         uid:
           id: uid
@@ -814,6 +807,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: uid
+          plugin_id: numeric
           default_action: empty
           exception:
             value: all
@@ -828,8 +824,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -841,26 +837,31 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
-          entity_type: node
-          entity_field: uid
-          plugin_id: numeric
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: true
-          content: 'No scheduled content for user {{ arguments.uid }}'
-          plugin_id: text_custom
-    display_plugin: page
-    display_title: 'User profile tab'
-    id: user_page
-    position: 2
+      defaults:
+        empty: false
+        access: true
+        arguments: false
+        filters: true
+        filter_groups: true
+      display_description: 'Scheduled content tab on user profile, showing just that user''s scheduled content'
+      display_extenders: {  }
+      path: user/%user/scheduled
+      menu:
+        type: tab
+        title: Scheduled
+        description: ''
+        weight: -10
+        menu_name: admin
+        parent: system.admin_content
+        context: '0'
+      tab_options:
+        type: normal
+        title: Content
+        description: 'Find and manage scheduled content'
+        weight: -10
+        menu_name: admin
     cache_metadata:
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -868,6 +869,5 @@ display:
         - url.query_args
         - user
         - 'user.node_grants:view'
-      cacheable: false
-      max-age: 0
       tags: {  }
+      cacheable: false

--- a/conf/drupal/config/views.view.session_feedback.yml
+++ b/conf/drupal/config/views.view.session_feedback.yml
@@ -15,80 +15,23 @@ base_table: webform_submission
 base_field: sid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: none
-        options: {  }
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: true
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: some
-        options:
-          items_per_page: 20
-          offset: 0
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          uses_fields: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            rendered_entity: rendered_entity
-          info:
-            rendered_entity:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: '-1'
-          empty_table: false
-      row:
-        type: 'entity:webform_submission'
-        options:
-          relationship: none
-          view_mode: default
+      title: 'Session Feedback'
       fields:
         rendered_entity:
+          id: rendered_entity
           table: webform_submission
           field: rendered_entity
-          id: rendered_entity
-          entity_type: null
-          entity_field: null
-          plugin_id: rendered_entity
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: rendered_entity
           label: ''
           exclude: false
           alter:
@@ -131,46 +74,27 @@ display:
           empty_zero: false
           hide_alter_empty: true
           view_mode: default
-      filters:
-        webform_id:
-          id: webform_id
-          table: webform_submission
-          field: webform_id
-          value:
-            session_feedback: session_feedback
-          entity_type: webform_submission
-          entity_field: webform_id
-          plugin_id: bundle
-          expose:
-            operator_limit_selection: false
-            operator_list: {  }
-      sorts: {  }
-      title: 'Session Feedback'
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          tokenize: false
-          content:
-            value: "<h2>Session Feedback</h2>\r\n<p>This block is only available to listed speakers on <em>this session</em> and site administrators.</p>"
-            format: basic_html
-          plugin_id: text
-        result:
-          id: result
-          table: views
-          field: result
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          content: 'Displaying @start - @end of @total responses.'
-          plugin_id: result
-      footer: {  }
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 20
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
       empty:
         area:
           id: area
@@ -179,13 +103,13 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: true
-          tokenize: false
           content:
             value: 'There is no feedback available for this session.'
             format: basic_html
-          plugin_id: text
-      relationships: {  }
+          tokenize: false
+      sorts: {  }
       arguments:
         entity_id:
           id: entity_id
@@ -194,6 +118,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: entity_id
+          plugin_id: string
           default_action: default
           exception:
             value: all
@@ -209,8 +136,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -226,9 +153,82 @@ display:
           path_case: none
           transform_dash: false
           break_phrase: false
+      filters:
+        webform_id:
+          id: webform_id
+          table: webform_submission
+          field: webform_id
           entity_type: webform_submission
-          entity_field: entity_id
-          plugin_id: string
+          entity_field: webform_id
+          plugin_id: bundle
+          value:
+            session_feedback: session_feedback
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: true
+          columns:
+            rendered_entity: rendered_entity
+          default: '-1'
+          info:
+            rendered_entity:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: 'entity:webform_submission'
+        options:
+          relationship: none
+          view_mode: default
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: true
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: false
+          content:
+            value: "<h2>Session Feedback</h2>\r\n<p>This block is only available to listed speakers on <em>this session</em> and site administrators.</p>"
+            format: basic_html
+          tokenize: false
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total responses.'
+      footer: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -238,9 +238,9 @@ display:
         - user
       tags: {  }
   block_1:
-    display_plugin: block
     id: block_1
     display_title: Block
+    display_plugin: block
     position: 1
     display_options:
       display_extenders: {  }

--- a/conf/drupal/config/views.view.session_management.yml
+++ b/conf/drupal/config/views.view.session_management.yml
@@ -22,128 +22,34 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: role
-        options:
-          role:
-            administrator: administrator
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            title: title
-            field_people: field_people
-            field_schedule_time: field_schedule_time
-            field_schedule_location: field_schedule_location
-          info:
-            title:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            field_people:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            field_schedule_time:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            field_schedule_location:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: field_schedule_time
-          empty_table: false
-      row:
-        type: fields
+      title: 'Session Management'
       fields:
         title:
           id: title
           table: node_field_data
           field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: title
+          plugin_id: field
+          label: Title
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: Title
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -153,9 +59,13 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -173,6 +83,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Presenters
           exclude: false
           alter:
@@ -228,7 +139,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_schedule_location:
           id: field_schedule_location
           table: node__field_schedule_location
@@ -236,6 +146,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Location
           exclude: false
           alter:
@@ -291,7 +202,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_schedule_time:
           id: field_schedule_time
           table: node__field_schedule_time
@@ -299,6 +209,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Time
           exclude: false
           alter:
@@ -356,30 +267,98 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: role
+        options:
+          role:
+            administrator: administrator
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        field_schedule_time_value:
+          id: field_schedule_time_value
+          table: node__field_schedule_time
+          field: field_schedule_time_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: field_schedule_time_value
+          exposed: false
+          granularity: second
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments: {  }
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            topic: topic
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            topic: topic
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -390,6 +369,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -400,14 +380,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -420,7 +400,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
         field_schedule_time_value:
           id: field_schedule_time_value
           table: node__field_schedule_time
@@ -428,6 +407,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: datetime
           operator: '>='
           value:
             min: ''
@@ -442,17 +422,17 @@ display:
             description: null
             use_operator: false
             operator: field_schedule_time_value_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_schedule_time_value
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: null
             min_placeholder: null
             max_placeholder: null
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: null
           is_grouped: false
           group_info:
             label: ''
@@ -465,42 +445,64 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: datetime
-      sorts:
-        field_schedule_time_value:
-          id: field_schedule_time_value
-          table: node__field_schedule_time
-          field: field_schedule_time_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-          plugin_id: datetime
-        created:
-          id: created
-          table: node_field_data
-          field: created
-          order: DESC
-          entity_type: node
-          entity_field: created
-          plugin_id: date
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-      title: 'Session Management'
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            title: title
+            field_people: field_people
+            field_schedule_time: field_schedule_time
+            field_schedule_location: field_schedule_location
+          default: field_schedule_time
+          info:
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_people:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_schedule_time:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_schedule_location:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header: {  }
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -515,9 +517,9 @@ display:
         - 'config:field.storage.node.field_schedule_location'
         - 'config:field.storage.node.field_schedule_time'
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
       display_extenders: {  }

--- a/conf/drupal/config/views.view.session_selection.yml
+++ b/conf/drupal/config/views.view.session_selection.yml
@@ -30,103 +30,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: role
-        options:
-          role:
-            administrator: administrator
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: none
-        options:
-          offset: 0
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            edit_node: edit_node
-            field_schedule_time: field_schedule_time
-            field_schedule_location: field_schedule_location
-            title: title
-            field_session_length: field_session_length
-          info:
-            edit_node:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            field_schedule_time:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            field_schedule_location:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            title:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            field_session_length:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: title
-          empty_table: false
-      row:
-        type: fields
-        options:
-          inline: {  }
-          separator: ''
-          hide_empty: false
-          default_field_elements: true
+      title: 'Select Accepted and Confirmed Sessions'
       fields:
         node_bulk_form:
           id: node_bulk_form
@@ -135,6 +44,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: node_bulk_form
           label: ''
           exclude: false
           alter:
@@ -181,8 +92,6 @@ display:
           selected_actions:
             - topic_accept_confirm
             - topic_reject
-          entity_type: node
-          plugin_id: node_bulk_form
         field_accepted_confirmed:
           id: field_accepted_confirmed
           table: node__field_accepted_confirmed
@@ -190,6 +99,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -235,8 +145,8 @@ display:
           type: boolean
           settings:
             format: unicode-yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -247,7 +157,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -255,6 +164,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: Title
           exclude: false
           alter:
@@ -310,9 +222,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         field_session_length:
           id: field_session_length
           table: node__field_session_length
@@ -320,6 +229,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: 'Session Length'
           exclude: false
           alter:
@@ -374,7 +284,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -382,6 +291,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Presenters
           exclude: false
           alter:
@@ -437,7 +347,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         uid:
           id: uid
           table: node_field_data
@@ -445,6 +354,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: uid
+          plugin_id: field
           label: 'Authored by'
           exclude: false
           alter:
@@ -501,9 +413,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: uid
-          plugin_id: field
         view_node:
           id: view_node
           table: node
@@ -511,6 +420,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: entity_link
           label: 'Link to Content'
           exclude: false
           alter:
@@ -553,24 +464,63 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: view
-          entity_type: node
-          plugin_id: entity_link
           output_url_as_text: false
           absolute: false
+      pager:
+        type: none
+        options:
+          offset: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: role
+        options:
+          role:
+            administrator: administrator
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments: {  }
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_topic_type_target_id:
           id: field_topic_type_target_id
           table: node__field_topic_type
@@ -578,6 +528,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             14: 14
@@ -589,6 +540,8 @@ display:
             description: ''
             use_operator: false
             operator: field_topic_type_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_topic_type_target_id
             required: false
             remember: false
@@ -601,8 +554,6 @@ display:
               administrator: '0'
               sponsor: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -616,12 +567,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: topic_type
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_accepted_confirmed_value:
           id: field_accepted_confirmed_value
           table: node__field_accepted_confirmed
@@ -629,6 +579,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: All
           group: 1
@@ -639,6 +590,8 @@ display:
             description: ''
             use_operator: false
             operator: field_accepted_confirmed_value_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_accepted_confirmed_value
             required: false
             remember: false
@@ -650,8 +603,6 @@ display:
               content_editor: '0'
               administrator: '0'
               sponsor: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -664,7 +615,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -672,6 +622,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value: {  }
           group: 1
@@ -682,6 +633,8 @@ display:
             description: ''
             use_operator: false
             operator: field_event_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_event_target_id
             required: false
             remember: false
@@ -695,8 +648,6 @@ display:
               sponsor: '0'
               organizer: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -710,12 +661,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_session_length_value:
           id: field_session_length_value
           table: node__field_session_length
@@ -723,6 +673,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: list_field
           operator: or
           value: {  }
           group: 1
@@ -733,6 +684,8 @@ display:
             description: ''
             use_operator: false
             operator: field_session_length_value_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_session_length_value
             required: false
             remember: false
@@ -746,8 +699,6 @@ display:
               sponsor: '0'
               organizer: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -761,36 +712,76 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          plugin_id: list_field
-      sorts:
-        created:
-          id: created
-          table: node_field_data
-          field: created
-          order: ASC
-          entity_type: node
-          entity_field: created
-          plugin_id: date
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-      header:
-        result:
-          id: result
-          table: views
-          field: result
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          content: 'Displaying @start - @end of @total'
-          plugin_id: result
-      footer: {  }
-      empty: {  }
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            edit_node: edit_node
+            field_schedule_time: field_schedule_time
+            field_schedule_location: field_schedule_location
+            title: title
+            field_session_length: field_session_length
+          default: title
+          info:
+            edit_node:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_schedule_time:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_schedule_location:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_session_length:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         uid:
           id: uid
@@ -799,14 +790,24 @@ display:
           relationship: none
           group_type: group
           admin_label: author
-          required: false
           entity_type: node
           entity_field: uid
           plugin_id: standard
-      arguments: {  }
-      display_extenders: {  }
+          required: false
       group_by: false
-      title: 'Select Accepted and Confirmed Sessions'
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: 0
       contexts:
@@ -822,9 +823,9 @@ display:
         - 'config:field.storage.node.field_people'
         - 'config:field.storage.node.field_session_length'
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Page
+    display_plugin: page
     position: 2
     display_options:
       display_extenders: {  }
@@ -844,20 +845,12 @@ display:
         - 'config:field.storage.node.field_people'
         - 'config:field.storage.node.field_session_length'
   scheduling:
-    display_plugin: page
     id: scheduling
     display_title: Scheduling
+    display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
-      path: admin/session-scheduling
       title: 'Schedule Sessions'
-      defaults:
-        title: false
-        fields: false
-        filters: false
-        filter_groups: false
-        sorts: false
       fields:
         edit_node:
           id: edit_node
@@ -866,6 +859,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: entity_link_edit
           label: ''
           exclude: false
           alter:
@@ -910,8 +905,6 @@ display:
           text: Edit
           output_url_as_text: false
           absolute: false
-          entity_type: node
-          plugin_id: entity_link_edit
         field_schedule_time:
           id: field_schedule_time
           table: node__field_schedule_time
@@ -919,6 +912,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Time
           exclude: false
           alter:
@@ -976,7 +970,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_schedule_location:
           id: field_schedule_location
           table: node__field_schedule_location
@@ -984,6 +977,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Room
           exclude: false
           alter:
@@ -1039,7 +1033,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -1047,6 +1040,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: Title
           exclude: false
           alter:
@@ -1102,9 +1098,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         field_session_length:
           id: field_session_length
           table: node__field_session_length
@@ -1112,6 +1105,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Length
           exclude: false
           alter:
@@ -1166,21 +1160,63 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      sorts:
+        field_schedule_time_value:
+          id: field_schedule_time_value
+          table: node__field_schedule_time
+          field: field_schedule_time_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: datetime
+          order: ASC
+          expose:
+            label: 'Time (field_schedule_time)'
+            field_identifier: field_schedule_time_value
+          exposed: false
+          granularity: minute
+        field_schedule_location_target_id:
+          id: field_schedule_location_target_id
+          table: node__field_schedule_location
+          field: field_schedule_location_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: 'Location (field_schedule_location)'
+            field_identifier: field_schedule_location_target_id
+          exposed: false
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: Title
+            field_identifier: title
+          exposed: false
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_topic_type_target_id:
           id: field_topic_type_target_id
           table: node__field_topic_type
@@ -1188,6 +1224,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             14: 14
@@ -1199,6 +1236,8 @@ display:
             description: ''
             use_operator: false
             operator: field_topic_type_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_topic_type_target_id
             required: false
             remember: false
@@ -1211,8 +1250,6 @@ display:
               administrator: '0'
               sponsor: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1226,12 +1263,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: topic_type
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -1239,6 +1275,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             143: 143
@@ -1250,6 +1287,8 @@ display:
             description: ''
             use_operator: false
             operator: field_event_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_event_target_id
             required: false
             remember: false
@@ -1263,8 +1302,6 @@ display:
               sponsor: '0'
               organizer: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1278,12 +1315,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_accepted_confirmed_value:
           id: field_accepted_confirmed_value
           table: node__field_accepted_confirmed
@@ -1291,6 +1327,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -1301,6 +1338,8 @@ display:
             description: ''
             use_operator: false
             operator: field_accepted_confirmed_value_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_accepted_confirmed_value
             required: true
             remember: true
@@ -1313,8 +1352,6 @@ display:
               administrator: '0'
               sponsor: '0'
               organizer: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1327,52 +1364,19 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
       filter_groups:
         operator: AND
         groups:
           1: AND
-      sorts:
-        field_schedule_time_value:
-          id: field_schedule_time_value
-          table: node__field_schedule_time
-          field: field_schedule_time_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: 'Time (field_schedule_time)'
-          granularity: minute
-          plugin_id: datetime
-        field_schedule_location_target_id:
-          id: field_schedule_location_target_id
-          table: node__field_schedule_location
-          field: field_schedule_location_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: 'Location (field_schedule_location)'
-          plugin_id: standard
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: Title
-          entity_type: node
-          entity_field: title
-          plugin_id: standard
+      defaults:
+        title: false
+        fields: false
+        sorts: false
+        filters: false
+        filter_groups: false
       display_description: ''
+      display_extenders: {  }
+      path: admin/session-scheduling
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.sessions.yml
+++ b/conf/drupal/config/views.view.sessions.yml
@@ -34,46 +34,70 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
+      title: 'Submitted Sessions'
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
       pager:
         type: full
         options:
-          items_per_page: 0
           offset: 0
-          id: 0
+          items_per_page: 0
           total_pages: null
+          id: 0
           tags:
-            previous: ‹‹
             next: ››
+            previous: ‹‹
             first: '« First'
             last: 'Last »'
           expose:
@@ -85,64 +109,52 @@ display:
             offset: false
             offset_label: Offset
           quantity: 9
-      style:
-        type: default
+      exposed_form:
+        type: basic
         options:
-          row_class: schedule__teaser
-          default_row_class: true
-          uses_fields: false
-      row:
-        type: 'entity:node'
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
         options:
-          view_mode: teaser
-      fields:
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          entity_type: node
-          entity_field: title
-          label: ''
-          alter:
-            alter_text: false
-            make_link: false
-            absolute: false
-            trim: false
-            word_boundary: false
-            ellipsis: false
-            strip_tags: false
-            html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
           relationship: none
           group_type: group
           admin_label: ''
-          exclude: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
+          plugin_id: text
+          empty: true
+          content:
+            value: 'No sessions submitted yet. What are you waiting for?'
+            format: basic_html
+          tokenize: false
+      sorts:
+        random:
+          id: random
+          table: views
+          field: random
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: random
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: random
+          exposed: false
+      arguments: {  }
       filters:
         status:
           id: status
@@ -151,6 +163,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -161,14 +176,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -181,18 +196,15 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            topic: topic
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            topic: topic
           group: 1
           expose:
             operator_limit_selection: false
@@ -204,6 +216,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             14: 14
@@ -215,6 +228,8 @@ display:
             description: ''
             use_operator: false
             operator: field_topic_type_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_topic_type_target_id
             required: false
             remember: false
@@ -226,8 +241,6 @@ display:
               content_editor: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -241,26 +254,34 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: topic_type
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      sorts:
-        random:
-          id: random
-          table: views
-          field: random
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: random
-      title: 'Submitted Sessions'
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: default
+        options:
+          row_class: schedule__teaser
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header:
         area:
           id: area
@@ -269,34 +290,16 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: "<p>MidCamp is looking for folks just like you to speak to our Drupal audience! Experienced speakers are always welcome, but camp is also a great place to start for first-time speakers. From the opening of session submission through the beginning of camp, we'll have communication to assist speakers (new and old) in creating engaging and informative sessions.</p>\n<p>Sessions submission will close January 26, 2018. <a href=\"/node/add/topic\">Submit your session today!</a></p>"
-            format: basic_html
           plugin_id: text
+          empty: true
+          content:
+            value: |-
+              <p>MidCamp is looking for folks just like you to speak to our Drupal audience! Experienced speakers are always welcome, but camp is also a great place to start for first-time speakers. From the opening of session submission through the beginning of camp, we'll have communication to assist speakers (new and old) in creating engaging and informative sessions.</p>
+              <p>Sessions submission will close January 26, 2018. <a href="/node/add/topic">Submit your session today!</a></p>
+            format: basic_html
+          tokenize: false
       footer: {  }
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: 'No sessions submitted yet. What are you waiting for?'
-            format: basic_html
-          plugin_id: text
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
     cache_metadata:
       max-age: 0
       contexts:
@@ -308,66 +311,12 @@ display:
         - user.permissions
       tags: {  }
   accepted:
-    display_plugin: page
     id: accepted
     display_title: 'Accepted 2018'
+    display_plugin: page
     position: 4
     display_options:
-      display_extenders: {  }
-      display_description: ''
       title: 'Accepted Sessions'
-      defaults:
-        title: false
-        style: false
-        row: false
-        header: false
-        empty: false
-        fields: false
-        filters: false
-        filter_groups: false
-        sorts: false
-      style:
-        type: default
-        options:
-          row_class: schedule__teaser
-          default_row_class: true
-          uses_fields: false
-      row:
-        type: fields
-        options:
-          default_field_elements: true
-          inline: {  }
-          separator: ''
-          hide_empty: false
-      path: 2018/accepted-sessions
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: '<p>Below is the list of accepted and confirmed sessions. We still have a handful of sessions to confirm and will post the full session schedule shortly. Thanks to all who submitted!</p>'
-            format: basic_html
-          plugin_id: text
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: 'Session selection and confirmation is still underway. Check back again soon.'
-            format: basic_html
-          plugin_id: text
       fields:
         field_track:
           id: field_track
@@ -376,6 +325,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -431,7 +381,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -439,6 +388,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -494,9 +446,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -504,6 +453,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -559,7 +509,36 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'Session selection and confirmation is still underway. Check back again soon.'
+            format: basic_html
+          tokenize: false
+      sorts:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: title
+          exposed: false
       filters:
         status:
           id: status
@@ -568,6 +547,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -578,14 +560,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -598,18 +580,15 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            topic: topic
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            topic: topic
           group: 1
           expose:
             operator_limit_selection: false
@@ -621,6 +600,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             14: 14
@@ -632,6 +612,8 @@ display:
             description: ''
             use_operator: false
             operator: field_topic_type_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_topic_type_target_id
             required: false
             remember: false
@@ -643,8 +625,6 @@ display:
               content_editor: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -658,12 +638,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: topic_type
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_track_target_id:
           id: field_track_target_id
           table: node__field_track
@@ -671,6 +650,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value: {  }
           group: 1
@@ -681,6 +661,8 @@ display:
             description: ''
             use_operator: false
             operator: field_track_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_track_target_id
             required: false
             remember: false
@@ -693,8 +675,6 @@ display:
               administrator: '0'
               sponsor: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -708,12 +688,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: session_tracks
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_accepted_confirmed_value:
           id: field_accepted_confirmed_value
           table: node__field_accepted_confirmed
@@ -721,6 +700,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -731,14 +711,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -751,7 +731,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -759,6 +738,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             2: 2
@@ -770,6 +750,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -777,8 +759,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -792,31 +772,55 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
-      sorts:
-        title:
-          id: title
-          table: node_field_data
-          field: title
+      style:
+        type: default
+        options:
+          row_class: schedule__teaser
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      defaults:
+        empty: false
+        title: false
+        style: false
+        row: false
+        fields: false
+        sorts: false
+        filters: false
+        filter_groups: false
+        header: false
+      display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
           relationship: none
           group_type: group
           admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          entity_type: node
-          entity_field: title
-          plugin_id: standard
+          plugin_id: text
+          empty: true
+          content:
+            value: '<p>Below is the list of accepted and confirmed sessions. We still have a handful of sessions to confirm and will post the full session schedule shortly. Thanks to all who submitted!</p>'
+            format: basic_html
+          tokenize: false
+      display_extenders: {  }
+      path: 2018/accepted-sessions
     cache_metadata:
       max-age: -1
       contexts:
@@ -831,14 +835,11 @@ display:
         - 'config:field.storage.node.field_people'
         - 'config:field.storage.node.field_track'
   page_1:
-    display_plugin: page
     id: page_1
     display_title: 'Submitted 2018'
+    display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
-      path: 2018/submitted-sessions
-      display_description: ''
       filters:
         status:
           id: status
@@ -847,6 +848,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -857,14 +861,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -877,18 +881,15 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            topic: topic
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            topic: topic
           group: 1
           expose:
             operator_limit_selection: false
@@ -900,6 +901,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             14: 14
@@ -911,6 +913,8 @@ display:
             description: ''
             use_operator: false
             operator: field_topic_type_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_topic_type_target_id
             required: false
             remember: false
@@ -922,8 +926,6 @@ display:
               content_editor: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -937,12 +939,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: topic_type
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -950,6 +951,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             2: 2
@@ -961,6 +963,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -968,8 +972,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -983,19 +985,21 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      defaults:
-        filters: false
-        filter_groups: false
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+      display_description: ''
+      display_extenders: {  }
+      path: 2018/submitted-sessions
     cache_metadata:
       max-age: 0
       contexts:
@@ -1007,133 +1011,33 @@ display:
         - user.permissions
       tags: {  }
   page_2:
-    display_plugin: page
     id: page_2
     display_title: Admin
+    display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: "<p>MidCamp is looking for folks just like you to speak to our Drupal audience! Experienced speakers are always welcome, but camp is also a great place to start for first-time speakers. From the opening of session submission through the beginning of camp, we'll have communication to assist speakers (new and old) in creating engaging and informative sessions.</p>\n<p>Sessions submission will close January 26, 2018. <a href=\"/node/add/topic\">Submit your session today!</a></p>"
-            format: basic_html
-          plugin_id: text
-        result:
-          id: result
-          table: views
-          field: result
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          content: 'Displaying @start - @end of @total'
-          plugin_id: result
-      defaults:
-        header: false
-        style: false
-        row: false
-        fields: false
-        filters: false
-        filter_groups: false
-        sorts: false
-        access: false
-      path: admin/content/sessions
-      menu:
-        type: none
-        title: Sessions
-        description: ''
-        expanded: false
-        parent: comment.admin
-        weight: 0
-        context: '0'
-        menu_name: admin
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            title: title
-            field_topic_type: field_topic_type
-            body: body
-            field_track: field_track
-          info:
-            title:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            field_topic_type:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            body:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            field_track:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: '-1'
-          empty_table: false
-      row:
-        type: fields
-        options:
-          default_field_elements: true
-          inline: {  }
-          separator: ''
-          hide_empty: false
       fields:
         title:
           id: title
           table: node_field_data
           field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: title
+          plugin_id: field
           label: ''
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -1143,9 +1047,13 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1163,6 +1071,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1218,7 +1127,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         body:
           id: body
           table: node__body
@@ -1226,6 +1134,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1281,7 +1190,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_track:
           id: field_track
           table: node__field_track
@@ -1289,6 +1197,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1344,17 +1253,37 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      access:
+        type: perm
+        options:
+          perm: 'administer nodes'
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
       filters:
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            topic: topic
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            topic: topic
           group: 1
           expose:
             operator_limit_selection: false
@@ -1366,6 +1295,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             14: 14
@@ -1378,6 +1308,8 @@ display:
             description: ''
             use_operator: false
             operator: field_topic_type_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_topic_type_target_id
             required: false
             remember: false
@@ -1390,8 +1322,6 @@ display:
               administrator: '0'
               sponsor: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1405,12 +1335,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: topic_type
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         uid:
           id: uid
           table: node_field_revision
@@ -1418,6 +1347,9 @@ display:
           relationship: none
           group_type: group
           admin_label: 'Not Larry'
+          entity_type: node
+          entity_field: uid
+          plugin_id: numeric
           operator: '!='
           value:
             min: ''
@@ -1431,17 +1363,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -1454,9 +1386,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: uid
-          plugin_id: numeric
         field_track_target_id:
           id: field_track_target_id
           table: node__field_track
@@ -1464,6 +1393,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value: {  }
           group: 1
@@ -1474,6 +1404,8 @@ display:
             description: ''
             use_operator: false
             operator: field_track_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_track_target_id
             required: false
             remember: false
@@ -1486,8 +1418,6 @@ display:
               administrator: '0'
               sponsor: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1501,37 +1431,114 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: session_tracks
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            title: title
+            field_topic_type: field_topic_type
+            body: body
+            field_track: field_track
+          default: '-1'
+          info:
+            title:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_topic_type:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            body:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_track:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      defaults:
+        access: false
+        style: false
+        row: false
+        fields: false
+        sorts: false
+        filters: false
+        filter_groups: false
+        header: false
       display_description: ''
-      sorts:
-        created:
-          id: created
-          table: node_field_data
-          field: created
+      header:
+        area:
+          id: area
+          table: views
+          field: area
           relationship: none
           group_type: group
           admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-          entity_type: node
-          entity_field: created
-          plugin_id: date
-      access:
-        type: perm
-        options:
-          perm: 'administer nodes'
+          plugin_id: text
+          empty: true
+          content:
+            value: |-
+              <p>MidCamp is looking for folks just like you to speak to our Drupal audience! Experienced speakers are always welcome, but camp is also a great place to start for first-time speakers. From the opening of session submission through the beginning of camp, we'll have communication to assist speakers (new and old) in creating engaging and informative sessions.</p>
+              <p>Sessions submission will close January 26, 2018. <a href="/node/add/topic">Submit your session today!</a></p>
+            format: basic_html
+          tokenize: false
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
+      display_extenders: {  }
+      path: admin/content/sessions
+      menu:
+        type: none
+        title: Sessions
+        description: ''
+        weight: 0
+        expanded: false
+        menu_name: admin
+        parent: comment.admin
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:
@@ -1547,14 +1554,11 @@ display:
         - 'config:field.storage.node.field_topic_type'
         - 'config:field.storage.node.field_track'
   page_3:
-    display_plugin: page
     id: page_3
     display_title: 'Submitted 2019'
+    display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
-      path: 2019/submitted-sessions
-      display_description: ''
       filters:
         status:
           id: status
@@ -1563,6 +1567,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -1573,14 +1580,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1593,18 +1600,15 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            topic: topic
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            topic: topic
           group: 1
           expose:
             operator_limit_selection: false
@@ -1616,6 +1620,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             14: 14
@@ -1627,6 +1632,8 @@ display:
             description: ''
             use_operator: false
             operator: field_topic_type_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_topic_type_target_id
             required: false
             remember: false
@@ -1638,8 +1645,6 @@ display:
               content_editor: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1653,12 +1658,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: topic_type
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -1666,6 +1670,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             97: 97
@@ -1677,6 +1682,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -1684,8 +1691,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1699,20 +1704,20 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      defaults:
-        filters: false
-        filter_groups: false
-        header: false
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        filters: false
+        filter_groups: false
+        header: false
+      display_description: ''
       header:
         area:
           id: area
@@ -1721,12 +1726,14 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: true
-          tokenize: false
           content:
             value: "<!--p>MidCamp is looking for folks just like you to speak to our Drupal audience! Experienced speakers are always welcome, but camp is also a great place to start for first-time speakers. From the opening of session submission through the beginning of camp, we'll have communication to assist speakers (new and old) in creating engaging and informative sessions.</p-->\r\n<!--p><strong>The session submission deadline has been extended to midnight December 19, 2018. <a href=\"/submit-session\">Submit your session today!</a></strong></p-->\r\n<p><strong>Session submission is now closed. Thanks to all who submitted proposals!</strong></p>"
             format: basic_html
-          plugin_id: text
+          tokenize: false
+      display_extenders: {  }
+      path: 2019/submitted-sessions
     cache_metadata:
       max-age: 0
       contexts:
@@ -1738,66 +1745,12 @@ display:
         - user.permissions
       tags: {  }
   page_4:
-    display_plugin: page
     id: page_4
     display_title: 'Accepted 2019'
+    display_plugin: page
     position: 4
     display_options:
-      display_extenders: {  }
-      display_description: ''
       title: 'Accepted Sessions'
-      defaults:
-        title: false
-        style: false
-        row: false
-        header: false
-        empty: false
-        fields: false
-        filters: false
-        filter_groups: false
-        sorts: false
-      style:
-        type: default
-        options:
-          row_class: schedule__teaser
-          default_row_class: true
-          uses_fields: false
-      row:
-        type: fields
-        options:
-          default_field_elements: true
-          inline: {  }
-          separator: ''
-          hide_empty: false
-      path: 2019/accepted-sessions
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: '<p>Below is the list of accepted and confirmed sessions. We still have a handful of sessions to confirm and will post the full session schedule shortly. Thanks to all who submitted!</p>'
-            format: basic_html
-          plugin_id: text
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: 'Session selection and confirmation is still underway. Check back again soon.'
-            format: basic_html
-          plugin_id: text
       fields:
         field_track:
           id: field_track
@@ -1806,6 +1759,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1861,7 +1815,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -1869,6 +1822,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1924,9 +1880,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -1934,6 +1887,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1989,7 +1943,36 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'Session selection and confirmation is still underway. Check back again soon.'
+            format: basic_html
+          tokenize: false
+      sorts:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: title
+          exposed: false
       filters:
         status:
           id: status
@@ -1998,6 +1981,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -2008,14 +1994,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2028,18 +2014,15 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            topic: topic
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            topic: topic
           group: 1
           expose:
             operator_limit_selection: false
@@ -2051,6 +2034,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             14: 14
@@ -2062,6 +2046,8 @@ display:
             description: ''
             use_operator: false
             operator: field_topic_type_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_topic_type_target_id
             required: false
             remember: false
@@ -2073,8 +2059,6 @@ display:
               content_editor: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2088,12 +2072,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: topic_type
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_track_target_id:
           id: field_track_target_id
           table: node__field_track
@@ -2101,6 +2084,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value: {  }
           group: 1
@@ -2111,6 +2095,8 @@ display:
             description: ''
             use_operator: false
             operator: field_track_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_track_target_id
             required: false
             remember: false
@@ -2123,8 +2109,6 @@ display:
               administrator: '0'
               sponsor: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2138,12 +2122,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: session_tracks
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_accepted_confirmed_value:
           id: field_accepted_confirmed_value
           table: node__field_accepted_confirmed
@@ -2151,6 +2134,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -2161,14 +2145,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2181,7 +2165,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -2189,6 +2172,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             97: 97
@@ -2200,6 +2184,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -2207,8 +2193,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2222,31 +2206,55 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
-      sorts:
-        title:
-          id: title
-          table: node_field_data
-          field: title
+      style:
+        type: default
+        options:
+          row_class: schedule__teaser
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      defaults:
+        empty: false
+        title: false
+        style: false
+        row: false
+        fields: false
+        sorts: false
+        filters: false
+        filter_groups: false
+        header: false
+      display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
           relationship: none
           group_type: group
           admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          entity_type: node
-          entity_field: title
-          plugin_id: standard
+          plugin_id: text
+          empty: true
+          content:
+            value: '<p>Below is the list of accepted and confirmed sessions. We still have a handful of sessions to confirm and will post the full session schedule shortly. Thanks to all who submitted!</p>'
+            format: basic_html
+          tokenize: false
+      display_extenders: {  }
+      path: 2019/accepted-sessions
     cache_metadata:
       max-age: -1
       contexts:
@@ -2261,67 +2269,12 @@ display:
         - 'config:field.storage.node.field_people'
         - 'config:field.storage.node.field_track'
   page_5:
-    display_plugin: page
     id: page_5
     display_title: 'Accepted 2020'
+    display_plugin: page
     position: 4
     display_options:
-      display_extenders: {  }
-      display_description: ''
       title: 'Accepted Sessions'
-      defaults:
-        title: false
-        style: false
-        row: false
-        header: false
-        empty: false
-        fields: false
-        filters: false
-        filter_groups: false
-        sorts: false
-        css_class: false
-      style:
-        type: default
-        options:
-          row_class: schedule__teaser
-          default_row_class: true
-          uses_fields: false
-      row:
-        type: fields
-        options:
-          default_field_elements: true
-          inline: {  }
-          separator: ''
-          hide_empty: false
-      path: 2020/accepted-sessions
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: '<p>Below is the list of accepted and confirmed sessions. We <!--still have a handful of sessions to confirm and -->will post the full session schedule shortly. Thanks to all who submitted!</p>'
-            format: full_html
-          plugin_id: text
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: 'Session selection and confirmation is still underway. Check back again soon.'
-            format: basic_html
-          plugin_id: text
       fields:
         field_track:
           id: field_track
@@ -2330,6 +2283,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -2385,7 +2339,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -2393,6 +2346,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -2448,9 +2404,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -2458,6 +2411,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -2513,7 +2467,36 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'Session selection and confirmation is still underway. Check back again soon.'
+            format: basic_html
+          tokenize: false
+      sorts:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: title
+          exposed: false
       filters:
         status:
           id: status
@@ -2522,6 +2505,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -2532,14 +2518,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2552,18 +2538,15 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            topic: topic
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            topic: topic
           group: 1
           expose:
             operator_limit_selection: false
@@ -2575,6 +2558,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             14: 14
@@ -2586,6 +2570,8 @@ display:
             description: ''
             use_operator: false
             operator: field_topic_type_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_topic_type_target_id
             required: false
             remember: false
@@ -2597,8 +2583,6 @@ display:
               content_editor: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2612,12 +2596,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: topic_type
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_track_target_id:
           id: field_track_target_id
           table: node__field_track
@@ -2625,6 +2608,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value: {  }
           group: 1
@@ -2635,6 +2619,8 @@ display:
             description: ''
             use_operator: false
             operator: field_track_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_track_target_id
             required: false
             remember: false
@@ -2647,8 +2633,6 @@ display:
               administrator: '0'
               sponsor: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2662,12 +2646,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: session_tracks
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_accepted_confirmed_value:
           id: field_accepted_confirmed_value
           table: node__field_accepted_confirmed
@@ -2675,6 +2658,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -2685,14 +2669,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2705,7 +2689,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -2713,6 +2696,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             143: 143
@@ -2724,6 +2708,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -2731,8 +2717,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -2746,32 +2730,57 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
-      sorts:
-        title:
-          id: title
-          table: node_field_data
-          field: title
+      style:
+        type: default
+        options:
+          row_class: schedule__teaser
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      defaults:
+        empty: false
+        title: false
+        css_class: false
+        style: false
+        row: false
+        fields: false
+        sorts: false
+        filters: false
+        filter_groups: false
+        header: false
+      css_class: schedule
+      display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
           relationship: none
           group_type: group
           admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          entity_type: node
-          entity_field: title
-          plugin_id: standard
-      css_class: schedule
+          plugin_id: text
+          empty: true
+          content:
+            value: '<p>Below is the list of accepted and confirmed sessions. We <!--still have a handful of sessions to confirm and -->will post the full session schedule shortly. Thanks to all who submitted!</p>'
+            format: full_html
+          tokenize: false
+      display_extenders: {  }
+      path: 2020/accepted-sessions
     cache_metadata:
       max-age: -1
       contexts:
@@ -2786,67 +2795,12 @@ display:
         - 'config:field.storage.node.field_people'
         - 'config:field.storage.node.field_track'
   page_6:
-    display_plugin: page
     id: page_6
     display_title: 'Accepted 2021'
+    display_plugin: page
     position: 4
     display_options:
-      display_extenders: {  }
-      display_description: ''
       title: 'Accepted Sessions'
-      defaults:
-        title: false
-        style: false
-        row: false
-        header: false
-        empty: false
-        fields: false
-        filters: false
-        filter_groups: false
-        sorts: false
-        css_class: false
-      style:
-        type: default
-        options:
-          row_class: schedule__teaser
-          default_row_class: true
-          uses_fields: false
-      row:
-        type: fields
-        options:
-          default_field_elements: true
-          inline: {  }
-          separator: ''
-          hide_empty: false
-      path: 2021/accepted-sessions
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: '<p>Below is the list of accepted and confirmed sessions. We <!--still have a handful of sessions to confirm and -->will post the full session schedule shortly. Thanks to all who submitted!</p>'
-            format: full_html
-          plugin_id: text
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: 'Session selection and confirmation is still underway. Check back again soon.'
-            format: basic_html
-          plugin_id: text
       fields:
         field_track:
           id: field_track
@@ -2855,6 +2809,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -2910,7 +2865,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -2918,6 +2872,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -2973,9 +2930,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -2983,6 +2937,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -3038,7 +2993,36 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'Session selection and confirmation is still underway. Check back again soon.'
+            format: basic_html
+          tokenize: false
+      sorts:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: title
+          exposed: false
       filters:
         status:
           id: status
@@ -3047,6 +3031,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -3057,14 +3044,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -3077,18 +3064,15 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            topic: topic
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            topic: topic
           group: 1
           expose:
             operator_limit_selection: false
@@ -3100,6 +3084,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             14: 14
@@ -3111,6 +3096,8 @@ display:
             description: ''
             use_operator: false
             operator: field_topic_type_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_topic_type_target_id
             required: false
             remember: false
@@ -3122,8 +3109,6 @@ display:
               content_editor: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -3137,12 +3122,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: topic_type
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_track_target_id:
           id: field_track_target_id
           table: node__field_track
@@ -3150,6 +3134,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value: {  }
           group: 1
@@ -3160,6 +3145,8 @@ display:
             description: ''
             use_operator: false
             operator: field_track_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_track_target_id
             required: false
             remember: false
@@ -3172,8 +3159,6 @@ display:
               administrator: '0'
               sponsor: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -3187,12 +3172,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: session_tracks
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_accepted_confirmed_value:
           id: field_accepted_confirmed_value
           table: node__field_accepted_confirmed
@@ -3200,6 +3184,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -3210,14 +3195,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -3230,7 +3215,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -3238,6 +3222,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             234: 234
@@ -3271,32 +3256,57 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
-      sorts:
-        title:
-          id: title
-          table: node_field_data
-          field: title
+      style:
+        type: default
+        options:
+          row_class: schedule__teaser
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      defaults:
+        empty: false
+        title: false
+        css_class: false
+        style: false
+        row: false
+        fields: false
+        sorts: false
+        filters: false
+        filter_groups: false
+        header: false
+      css_class: schedule
+      display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
           relationship: none
           group_type: group
           admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          entity_type: node
-          entity_field: title
-          plugin_id: standard
-      css_class: schedule
+          plugin_id: text
+          empty: true
+          content:
+            value: '<p>Below is the list of accepted and confirmed sessions. We <!--still have a handful of sessions to confirm and -->will post the full session schedule shortly. Thanks to all who submitted!</p>'
+            format: full_html
+          tokenize: false
+      display_extenders: {  }
+      path: 2021/accepted-sessions
     cache_metadata:
       max-age: -1
       contexts:
@@ -3311,23 +3321,16 @@ display:
         - 'config:field.storage.node.field_people'
         - 'config:field.storage.node.field_track'
   user_sessions:
-    display_plugin: page
     id: user_sessions
     display_title: 'User profile tab'
+    display_plugin: page
     position: 3
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      path: user/%user/submitted-sessions
-      menu:
-        type: tab
-        title: 'User Submitted Sessions'
-        description: ''
-        expanded: false
-        parent: ''
-        weight: 0
-        context: '0'
-        menu_name: account
+      access:
+        type: role
+        options:
+          role:
+            authenticated: authenticated
       arguments:
         uid:
           id: uid
@@ -3336,6 +3339,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: uid
+          plugin_id: numeric
           default_action: empty
           exception:
             value: all
@@ -3350,8 +3356,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -3363,57 +3369,16 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
-          entity_type: node
-          entity_field: uid
-          plugin_id: numeric
-      defaults:
-        arguments: false
-        relationships: false
-        access: false
-        header: false
-        filters: false
-        filter_groups: false
-      relationships:
-        uid:
-          id: uid
-          table: node_field_data
-          field: uid
-          relationship: none
-          group_type: group
-          admin_label: author
-          required: true
-          entity_type: node
-          entity_field: uid
-          plugin_id: standard
-      access:
-        type: role
-        options:
-          role:
-            authenticated: authenticated
-      header:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: "<p>MidCamp is looking for folks just like you to speak to our Drupal audience! Experienced speakers are always welcome, but camp is also a great place to start for first-time speakers. From the opening of session submission through the beginning of camp, we'll have communication to assist speakers (new and old) in creating engaging and informative sessions.</p>\r\n<!--p><strong>The session submission deadline has been extended to midnight December 19, 2018. <a href=\"/submit-session\">Submit your session today!</a></strong></p-->\r\n<!--p><strong>Session submission is now closed. Thanks to all who submitted proposals!</strong></p-->"
-            format: basic_html
-          plugin_id: text
       filters:
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            topic: topic
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            topic: topic
           group: 1
           expose:
             operator_limit_selection: false
@@ -3425,6 +3390,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             14: 14
@@ -3436,6 +3402,8 @@ display:
             description: ''
             use_operator: false
             operator: field_topic_type_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_topic_type_target_id
             required: false
             remember: false
@@ -3447,8 +3415,6 @@ display:
               content_editor: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -3462,12 +3428,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: topic_type
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -3475,6 +3440,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             143: 143
@@ -3486,6 +3452,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -3493,8 +3461,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -3508,16 +3474,60 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        access: false
+        relationships: false
+        arguments: false
+        filters: false
+        filter_groups: false
+        header: false
+      relationships:
+        uid:
+          id: uid
+          table: node_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: author
+          entity_type: node
+          entity_field: uid
+          plugin_id: standard
+          required: true
+      display_description: ''
+      header:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: "<p>MidCamp is looking for folks just like you to speak to our Drupal audience! Experienced speakers are always welcome, but camp is also a great place to start for first-time speakers. From the opening of session submission through the beginning of camp, we'll have communication to assist speakers (new and old) in creating engaging and informative sessions.</p>\r\n<!--p><strong>The session submission deadline has been extended to midnight December 19, 2018. <a href=\"/submit-session\">Submit your session today!</a></strong></p-->\r\n<!--p><strong>Session submission is now closed. Thanks to all who submitted proposals!</strong></p-->"
+            format: basic_html
+          tokenize: false
+      display_extenders: {  }
+      path: user/%user/submitted-sessions
+      menu:
+        type: tab
+        title: 'User Submitted Sessions'
+        description: ''
+        weight: 0
+        expanded: false
+        menu_name: account
+        parent: ''
+        context: '0'
     cache_metadata:
       max-age: 0
       contexts:

--- a/conf/drupal/config/views.view.sessions_export.yml
+++ b/conf/drupal/config/views.view.sessions_export.yml
@@ -30,99 +30,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: role
-        options:
-          role:
-            administrator: administrator
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: none
-        options:
-          offset: 0
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            title: title
-            uid: uid
-            body: body
-            field_people: field_people
-            field_track: field_track
-          info:
-            title:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            uid:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            body:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            field_people:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            field_track:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: '-1'
-          empty_table: false
-      row:
-        type: fields
-        options:
-          inline: {  }
-          separator: ''
-          hide_empty: false
-          default_field_elements: true
+      title: 'Session Export'
       fields:
         title:
           id: title
@@ -131,6 +44,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -186,9 +102,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         body:
           id: body
           table: node__body
@@ -196,6 +109,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -250,7 +164,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_people:
           id: field_people
           table: node__field_people
@@ -258,6 +171,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -313,7 +227,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_track:
           id: field_track
           table: node__field_track
@@ -321,6 +234,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -376,7 +290,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_session_length:
           id: field_session_length
           table: node__field_session_length
@@ -384,6 +297,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: 'Session Length'
           exclude: false
           alter:
@@ -438,7 +352,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         uid:
           id: uid
           table: node_field_data
@@ -446,6 +359,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: uid
+          plugin_id: field
           label: 'Authored by'
           exclude: false
           alter:
@@ -502,9 +418,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: uid
-          plugin_id: field
         field_organization:
           id: field_organization
           table: user__field_organization
@@ -512,6 +425,7 @@ display:
           relationship: uid
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Organization
           exclude: false
           alter:
@@ -567,7 +481,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         changed:
           id: changed
           table: node_field_revision
@@ -575,6 +488,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
           label: Changed
           exclude: false
           alter:
@@ -632,9 +548,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: changed
-          plugin_id: field
         view_node:
           id: view_node
           table: node
@@ -642,6 +555,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: entity_link
           label: 'Link to Content'
           exclude: false
           alter:
@@ -684,8 +599,6 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: view
-          entity_type: node
-          plugin_id: entity_link
           output_url_as_text: false
           absolute: false
         mail_1:
@@ -695,6 +608,9 @@ display:
           relationship: field_people
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: mail
+          plugin_id: field
           label: 'All THe Emails'
           exclude: false
           alter:
@@ -749,9 +665,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: user
-          entity_field: mail
-          plugin_id: field
         mail:
           id: mail
           table: users_field_data
@@ -759,6 +672,9 @@ display:
           relationship: uid
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: mail
+          plugin_id: field
           label: 'Author Email'
           exclude: false
           alter:
@@ -813,9 +729,47 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: user
-          entity_field: mail
-          plugin_id: field
+      pager:
+        type: none
+        options:
+          offset: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: role
+        options:
+          role:
+            administrator: administrator
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments: {  }
       filters:
         status:
           id: status
@@ -824,6 +778,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -834,6 +791,8 @@ display:
             description: ''
             use_operator: false
             operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: status
             required: true
             remember: false
@@ -846,8 +805,6 @@ display:
               administrator: '0'
               sponsor: '0'
               organizer: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -860,9 +817,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
         field_topic_type_target_id:
           id: field_topic_type_target_id
           table: node__field_topic_type
@@ -870,6 +824,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             14: 14
@@ -881,6 +836,8 @@ display:
             description: ''
             use_operator: false
             operator: field_topic_type_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_topic_type_target_id
             required: false
             remember: false
@@ -893,8 +850,6 @@ display:
               administrator: '0'
               sponsor: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -908,12 +863,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: topic_type
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -921,6 +875,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value: {  }
           group: 1
@@ -931,6 +886,8 @@ display:
             description: ''
             use_operator: false
             operator: field_event_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_event_target_id
             required: false
             remember: false
@@ -944,8 +901,6 @@ display:
               sponsor: '0'
               organizer: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -959,41 +914,77 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      sorts:
-        created:
-          id: created
-          table: node_field_data
-          field: created
-          order: ASC
-          entity_type: node
-          entity_field: created
-          plugin_id: date
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-      header:
-        result:
-          id: result
-          table: views
-          field: result
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          content: 'Displaying @start - @end of @total'
-          plugin_id: result
-      footer: {  }
-      empty: {  }
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            title: title
+            uid: uid
+            body: body
+            field_people: field_people
+            field_track: field_track
+          default: '-1'
+          info:
+            title:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            uid:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            body:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_people:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_track:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         uid:
           id: uid
@@ -1002,10 +993,10 @@ display:
           relationship: none
           group_type: group
           admin_label: author
-          required: false
           entity_type: node
           entity_field: uid
           plugin_id: standard
+          required: false
         field_people:
           id: field_people
           table: node__field_people
@@ -1013,12 +1004,22 @@ display:
           relationship: none
           group_type: group
           admin_label: 'field_people: User'
-          required: false
           plugin_id: standard
-      arguments: {  }
-      display_extenders: {  }
+          required: false
       group_by: false
-      title: 'Session Export'
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -1035,9 +1036,9 @@ display:
         - 'config:field.storage.node.field_track'
         - 'config:field.storage.user.field_organization'
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Page
+    display_plugin: page
     position: 2
     display_options:
       display_extenders: {  }
@@ -1058,13 +1059,12 @@ display:
         - 'config:field.storage.node.field_track'
         - 'config:field.storage.user.field_organization'
   page_2:
-    display_plugin: page
     id: page_2
     display_title: Page
+    display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
-      path: admin/sessions-export/accepted
+      title: 'Accepted Sessions'
       fields:
         title:
           id: title
@@ -1073,6 +1073,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1128,9 +1131,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         mail_1:
           id: mail_1
           table: users_field_data
@@ -1138,6 +1138,9 @@ display:
           relationship: field_people
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: mail
+          plugin_id: field
           label: 'All THe Emails'
           exclude: false
           alter:
@@ -1192,9 +1195,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: user
-          entity_field: mail
-          plugin_id: field
         field_name:
           id: field_name
           table: user__field_name
@@ -1202,6 +1202,7 @@ display:
           relationship: field_people
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Name
           exclude: false
           alter:
@@ -1265,26 +1266,20 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
-      defaults:
-        fields: false
-        filters: false
-        filter_groups: false
-        title: false
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_topic_type_target_id:
           id: field_topic_type_target_id
           table: node__field_topic_type
@@ -1292,6 +1287,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             14: 14
@@ -1303,6 +1299,8 @@ display:
             description: ''
             use_operator: false
             operator: field_topic_type_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_topic_type_target_id
             required: false
             remember: false
@@ -1315,8 +1313,6 @@ display:
               administrator: '0'
               sponsor: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1330,12 +1326,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: topic_type
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_accepted_confirmed_value:
           id: field_accepted_confirmed_value
           table: node__field_accepted_confirmed
@@ -1343,6 +1338,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -1353,14 +1349,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1373,7 +1369,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -1381,6 +1376,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value: {  }
           group: 1
@@ -1391,6 +1387,8 @@ display:
             description: ''
             use_operator: false
             operator: field_event_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_event_target_id
             required: false
             remember: false
@@ -1404,8 +1402,6 @@ display:
               sponsor: '0'
               organizer: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1419,17 +1415,22 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
-      title: 'Accepted Sessions'
+      defaults:
+        title: false
+        fields: false
+        filters: false
+        filter_groups: false
+      display_extenders: {  }
+      path: admin/sessions-export/accepted
     cache_metadata:
       max-age: -1
       contexts:
@@ -1442,13 +1443,12 @@ display:
       tags:
         - 'config:field.storage.user.field_name'
   page_3:
-    display_plugin: page
     id: page_3
     display_title: Page
+    display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
-      path: admin/sessions-export/rejected
+      title: 'Rejected Sessions'
       fields:
         title:
           id: title
@@ -1457,6 +1457,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1512,9 +1515,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         mail_1:
           id: mail_1
           table: users_field_data
@@ -1522,6 +1522,9 @@ display:
           relationship: field_people
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: mail
+          plugin_id: field
           label: 'All THe Emails'
           exclude: false
           alter:
@@ -1576,9 +1579,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: user
-          entity_field: mail
-          plugin_id: field
         field_name:
           id: field_name
           table: user__field_name
@@ -1586,6 +1586,7 @@ display:
           relationship: field_people
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: Name
           exclude: false
           alter:
@@ -1649,26 +1650,20 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
-      defaults:
-        fields: false
-        filters: false
-        filter_groups: false
-        title: false
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         field_topic_type_target_id:
           id: field_topic_type_target_id
           table: node__field_topic_type
@@ -1676,6 +1671,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             14: 14
@@ -1687,6 +1683,8 @@ display:
             description: ''
             use_operator: false
             operator: field_topic_type_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_topic_type_target_id
             required: false
             remember: false
@@ -1699,8 +1697,6 @@ display:
               administrator: '0'
               sponsor: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1714,12 +1710,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: topic_type
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_accepted_confirmed_value:
           id: field_accepted_confirmed_value
           table: node__field_accepted_confirmed
@@ -1727,6 +1722,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '0'
           group: 1
@@ -1737,14 +1733,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1757,7 +1753,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -1765,6 +1760,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value: {  }
           group: 1
@@ -1775,6 +1771,8 @@ display:
             description: ''
             use_operator: false
             operator: field_event_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_event_target_id
             required: false
             remember: false
@@ -1788,8 +1786,6 @@ display:
               sponsor: '0'
               organizer: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1803,17 +1799,22 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
       filter_groups:
         operator: AND
         groups:
           1: AND
-      title: 'Rejected Sessions'
+      defaults:
+        title: false
+        fields: false
+        filters: false
+        filter_groups: false
+      display_extenders: {  }
+      path: admin/sessions-export/rejected
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.speakers.yml
+++ b/conf/drupal/config/views.view.speakers.yml
@@ -31,76 +31,34 @@ base_table: users_field_data
 base_field: uid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access user profiles'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: some
-        options:
-          items_per_page: 3
-          offset: 0
-      style:
-        type: default
-        options:
-          row_class: l-3up
-          default_row_class: false
-          uses_fields: false
-      row:
-        type: 'entity:user'
-        options:
-          relationship: none
-          view_mode: featured_speaker
+      title: 'Featured Speakers'
       fields:
         name:
           id: name
           table: users_field_data
           field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: user
           entity_field: name
+          plugin_id: field
           label: ''
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -110,6 +68,8 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: user_name
@@ -131,6 +91,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -175,8 +136,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: medium
             image_link: content
+            image_style: medium
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -187,7 +148,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_title:
           id: field_title
           table: user__field_title
@@ -195,6 +155,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -250,7 +211,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_organization:
           id: field_organization
           table: user__field_organization
@@ -258,6 +218,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -313,7 +274,31 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 3
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access user profiles'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
       filters:
         roles_target_id:
           id: roles_target_id
@@ -322,6 +307,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          plugin_id: user_roles
           operator: or
           value:
             speaker: speaker
@@ -333,6 +320,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -340,8 +329,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -355,15 +342,28 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          entity_type: user
-          plugin_id: user_roles
-      sorts: {  }
-      title: 'Featured Speakers'
+      style:
+        type: default
+        options:
+          row_class: l-3up
+          default_row_class: false
+          uses_fields: false
+      row:
+        type: 'entity:user'
+        options:
+          relationship: none
+          view_mode: featured_speaker
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header: {  }
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -376,12 +376,12 @@ display:
         - 'config:field.storage.user.field_title'
         - 'config:field.storage.user.user_picture'
   block_1:
-    display_plugin: block
     id: block_1
     display_title: Block
+    display_plugin: block
     position: 1
     display_options:
-      display_extenders: {  }
+      empty: {  }
       filters:
         roles_target_id:
           id: roles_target_id
@@ -390,6 +390,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          plugin_id: user_roles
           operator: or
           value:
             speaker: speaker
@@ -401,6 +403,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -408,8 +412,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -423,8 +425,6 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          entity_type: user
-          plugin_id: user_roles
         entityqueue_relationship:
           id: entityqueue_relationship
           table: users_field_data
@@ -432,6 +432,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          plugin_id: entity_queue_in_queue
           operator: '='
           value: '1'
           group: 1
@@ -442,14 +444,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -462,18 +464,16 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: user
-          plugin_id: entity_queue_in_queue
-      defaults:
-        filters: false
-        filter_groups: false
-        relationships: false
-        empty: false
-        header: false
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        empty: false
+        relationships: false
+        filters: false
+        filter_groups: false
+        header: false
       relationships:
         entityqueue_relationship:
           id: entityqueue_relationship
@@ -482,11 +482,10 @@ display:
           relationship: none
           group_type: group
           admin_label: 'User queue'
-          required: true
-          limit_queue: featured_speakers
           entity_type: user
           plugin_id: entity_queue
-      empty: {  }
+          required: true
+          limit_queue: featured_speakers
       header:
         area:
           id: area
@@ -495,12 +494,13 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: text
           empty: false
-          tokenize: false
           content:
             value: '<h2 class="banner-title">[view:title]</h2>'
             format: full_html
-          plugin_id: text
+          tokenize: false
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -515,45 +515,33 @@ display:
         - entity_field_info
         - views_data
   entity_reference_1:
-    display_plugin: entity_reference
     id: entity_reference_1
     display_title: 'Entity Reference'
+    display_plugin: entity_reference
     position: 2
     display_options:
-      display_extenders: {  }
-      style:
-        type: entity_reference
-        options:
-          search_fields:
-            name: name
-            field_name: field_name
-            user_picture: '0'
-            field_title: '0'
-            field_organization: '0'
       fields:
         name:
           id: name
           table: users_field_data
           field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: user
           entity_field: name
+          plugin_id: field
           label: ''
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -563,6 +551,8 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: user_name
@@ -584,6 +574,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -628,8 +619,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: medium
             image_link: content
+            image_style: medium
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -640,7 +631,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_title:
           id: field_title
           table: user__field_title
@@ -648,6 +638,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -703,7 +694,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_organization:
           id: field_organization
           table: user__field_organization
@@ -711,6 +701,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -766,7 +757,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_name:
           id: field_name
           table: user__field_name
@@ -774,6 +764,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -837,9 +828,18 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      style:
+        type: entity_reference
+        options:
+          search_fields:
+            name: name
+            field_name: field_name
+            user_picture: '0'
+            field_title: '0'
+            field_organization: '0'
       defaults:
         fields: false
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -852,45 +852,33 @@ display:
         - 'config:field.storage.user.field_title'
         - 'config:field.storage.user.user_picture'
   entity_reference_2:
-    display_plugin: entity_reference
     id: entity_reference_2
     display_title: '2019 Speakers'
+    display_plugin: entity_reference
     position: 2
     display_options:
-      display_extenders: {  }
-      style:
-        type: entity_reference
-        options:
-          search_fields:
-            name: name
-            field_name: field_name
-            user_picture: '0'
-            field_title: '0'
-            field_organization: '0'
       fields:
         name:
           id: name
           table: users_field_data
           field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: user
           entity_field: name
+          plugin_id: field
           label: ''
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -900,6 +888,8 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: user_name
@@ -921,6 +911,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -965,8 +956,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: medium
             image_link: content
+            image_style: medium
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -977,7 +968,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_title:
           id: field_title
           table: user__field_title
@@ -985,6 +975,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1040,7 +1031,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_organization:
           id: field_organization
           table: user__field_organization
@@ -1048,6 +1038,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1103,7 +1094,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_name:
           id: field_name
           table: user__field_name
@@ -1111,6 +1101,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1174,24 +1165,10 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
-      defaults:
-        fields: false
-        relationships: false
-        filters: false
-        filter_groups: false
-      display_description: ''
-      relationships:
-        reverse__node__field_people:
-          id: reverse__node__field_people
-          table: users_field_data
-          field: reverse__node__field_people
-          relationship: none
-          group_type: group
-          admin_label: field_people
-          required: true
-          entity_type: user
-          plugin_id: entity_reverse
+      pager:
+        type: none
+        options:
+          offset: 0
       filters:
         field_event_target_id:
           id: field_event_target_id
@@ -1200,6 +1177,7 @@ display:
           relationship: reverse__node__field_people
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             97: 97
@@ -1211,6 +1189,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -1218,8 +1198,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1233,12 +1211,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_accepted_confirmed_value:
           id: field_accepted_confirmed_value
           table: node__field_accepted_confirmed
@@ -1246,6 +1223,7 @@ display:
           relationship: reverse__node__field_people
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -1256,14 +1234,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1276,15 +1254,37 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
       filter_groups:
         operator: AND
         groups:
           1: AND
-      pager:
-        type: none
+      style:
+        type: entity_reference
         options:
-          offset: 0
+          search_fields:
+            name: name
+            field_name: field_name
+            user_picture: '0'
+            field_title: '0'
+            field_organization: '0'
+      defaults:
+        relationships: false
+        fields: false
+        filters: false
+        filter_groups: false
+      relationships:
+        reverse__node__field_people:
+          id: reverse__node__field_people
+          table: users_field_data
+          field: reverse__node__field_people
+          relationship: none
+          group_type: group
+          admin_label: field_people
+          entity_type: user
+          plugin_id: entity_reverse
+          required: true
+      display_description: ''
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -1298,45 +1298,33 @@ display:
         - 'config:field.storage.user.field_title'
         - 'config:field.storage.user.user_picture'
   entity_reference_3:
-    display_plugin: entity_reference
     id: entity_reference_3
     display_title: '2020 Speakers'
+    display_plugin: entity_reference
     position: 2
     display_options:
-      display_extenders: {  }
-      style:
-        type: entity_reference
-        options:
-          search_fields:
-            name: name
-            field_name: field_name
-            user_picture: '0'
-            field_title: '0'
-            field_organization: '0'
       fields:
         name:
           id: name
           table: users_field_data
           field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: user
           entity_field: name
+          plugin_id: field
           label: ''
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -1346,6 +1334,8 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: user_name
@@ -1367,6 +1357,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1411,8 +1402,8 @@ display:
           click_sort_column: target_id
           type: image
           settings:
-            image_style: medium
             image_link: content
+            image_style: medium
           group_column: ''
           group_columns: {  }
           group_rows: true
@@ -1423,7 +1414,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_title:
           id: field_title
           table: user__field_title
@@ -1431,6 +1421,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1486,7 +1477,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_organization:
           id: field_organization
           table: user__field_organization
@@ -1494,6 +1484,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1549,7 +1540,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_name:
           id: field_name
           table: user__field_name
@@ -1557,6 +1547,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1620,24 +1611,10 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
-      defaults:
-        fields: false
-        relationships: false
-        filters: false
-        filter_groups: false
-      display_description: ''
-      relationships:
-        reverse__node__field_people:
-          id: reverse__node__field_people
-          table: users_field_data
-          field: reverse__node__field_people
-          relationship: none
-          group_type: group
-          admin_label: field_people
-          required: true
-          entity_type: user
-          plugin_id: entity_reverse
+      pager:
+        type: none
+        options:
+          offset: 0
       filters:
         field_event_target_id:
           id: field_event_target_id
@@ -1646,6 +1623,7 @@ display:
           relationship: reverse__node__field_people
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             143: 143
@@ -1657,6 +1635,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -1664,8 +1644,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1679,12 +1657,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_accepted_confirmed_value:
           id: field_accepted_confirmed_value
           table: node__field_accepted_confirmed
@@ -1692,6 +1669,7 @@ display:
           relationship: reverse__node__field_people
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -1702,14 +1680,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1722,15 +1700,37 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
       filter_groups:
         operator: AND
         groups:
           1: AND
-      pager:
-        type: none
+      style:
+        type: entity_reference
         options:
-          offset: 0
+          search_fields:
+            name: name
+            field_name: field_name
+            user_picture: '0'
+            field_title: '0'
+            field_organization: '0'
+      defaults:
+        relationships: false
+        fields: false
+        filters: false
+        filter_groups: false
+      relationships:
+        reverse__node__field_people:
+          id: reverse__node__field_people
+          table: users_field_data
+          field: reverse__node__field_people
+          relationship: none
+          group_type: group
+          admin_label: field_people
+          entity_type: user
+          plugin_id: entity_reverse
+          required: true
+      display_description: ''
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.sponsor_company_field_filter.yml
+++ b/conf/drupal/config/views.view.sponsor_company_field_filter.yml
@@ -20,80 +20,33 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: none
-        options:
-          offset: 0
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          uses_fields: false
-      row:
-        type: fields
-        options:
-          inline: {  }
-          separator: ''
-          hide_empty: false
-          default_field_elements: true
       fields:
         title:
           id: title
           table: node_field_data
           field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: title
+          plugin_id: field
           label: ''
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -103,9 +56,13 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -116,29 +73,69 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+      pager:
+        type: none
+        options:
+          offset: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments: {  }
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            sponsor: sponsor
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            sponsor: sponsor
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -149,6 +146,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             234: 234
@@ -182,33 +180,36 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      sorts:
-        created:
-          id: created
-          table: node_field_data
-          field: created
-          order: DESC
-          entity_type: node
-          entity_field: created
-          plugin_id: date
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header: {  }
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -220,17 +221,17 @@ display:
         - user.permissions
       tags: {  }
   entity_reference_1:
-    display_plugin: entity_reference
     id: entity_reference_1
     display_title: 'Entity Reference'
+    display_plugin: entity_reference
     position: 1
     display_options:
-      display_extenders: {  }
       style:
         type: entity_reference
         options:
           search_fields:
             title: title
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.summits.yml
+++ b/conf/drupal/config/views.view.summits.yml
@@ -19,67 +19,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: schedule__teaser
-          default_row_class: false
-      row:
-        type: fields
-        options:
-          default_field_elements: false
-          inline: {  }
-          separator: ''
-          hide_empty: false
+      title: 'Submitted Summits'
       fields:
         field_track:
           id: field_track
@@ -88,6 +33,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -143,7 +89,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -151,6 +96,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -206,9 +154,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         body:
           id: body
           table: node__body
@@ -216,6 +161,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -271,7 +217,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         view_node:
           id: view_node
           table: node
@@ -279,6 +224,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: entity_link
           label: ''
           exclude: false
           alter:
@@ -323,55 +270,59 @@ display:
           text: 'Read more'
           output_url_as_text: false
           absolute: false
-          entity_type: node
-          plugin_id: entity_link
-      filters:
-        status:
-          value: '1'
-          table: node_field_data
-          field: status
-          plugin_id: boolean
-          entity_type: node
-          entity_field: status
-          id: status
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
           expose:
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-        type:
-          id: type
-          table: node_field_data
-          field: type
-          value:
-            summit: summit
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
-          expose:
-            operator_limit_selection: false
-            operator_list: {  }
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
       sorts:
         created:
           id: created
           table: node_field_data
           field: created
-          order: DESC
-          entity_type: node
-          entity_field: created
-          plugin_id: date
           relationship: none
           group_type: group
           admin_label: ''
-          exposed: false
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: DESC
           expose:
             label: ''
+            field_identifier: created
+          exposed: false
           granularity: second
-      title: 'Submitted Summits'
-      header: {  }
-      footer: {  }
-      empty: {  }
-      relationships: {  }
       arguments:
         field_event_target_id:
           id: field_event_target_id
@@ -380,6 +331,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: numeric
           default_action: default
           exception:
             value: all
@@ -391,15 +343,15 @@ display:
           default_argument_options:
             term_page: '1'
             node: true
-            anyall: ','
             limit: false
             vids: {  }
+            anyall: ','
           default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -411,7 +363,56 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
-          plugin_id: numeric
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            summit: summit
+          expose:
+            operator_limit_selection: false
+            operator_list: {  }
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: schedule__teaser
+          default_row_class: false
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -426,9 +427,9 @@ display:
         - 'config:field.storage.node.body'
         - 'config:field.storage.node.field_track'
   block_1:
-    display_plugin: block
     id: block_1
     display_title: Block
+    display_plugin: block
     position: 2
     display_options:
       display_extenders: {  }

--- a/conf/drupal/config/views.view.survey_filters.yml
+++ b/conf/drupal/config/views.view.survey_filters.yml
@@ -20,94 +20,33 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          uses_fields: false
-      row:
-        type: fields
-        options:
-          inline: {  }
-          separator: ''
-          hide_empty: false
-          default_field_elements: true
       fields:
         title:
           id: title
           table: node_field_data
           field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: title
+          plugin_id: field
           label: ''
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -117,9 +56,13 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -130,29 +73,83 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments: {  }
       filters:
         status:
-          value: '1'
+          id: status
           table: node_field_data
           field: status
-          plugin_id: boolean
           entity_type: node
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            topic: topic
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            topic: topic
           expose:
             operator_limit_selection: false
             operator_list: {  }
@@ -163,6 +160,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -173,14 +171,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -193,7 +191,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -201,6 +198,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             - 143
@@ -212,6 +210,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -219,8 +219,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -234,33 +232,36 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: textfield
-          limit: true
           vid: event
+          type: textfield
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      sorts:
-        created:
-          id: created
-          table: node_field_data
-          field: created
-          order: DESC
-          entity_type: node
-          entity_field: created
-          plugin_id: date
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header: {  }
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -273,22 +274,22 @@ display:
         - user.permissions
       tags: {  }
   entity_reference_1:
-    display_plugin: entity_reference
     id: entity_reference_1
     display_title: Sessions
+    display_plugin: entity_reference
     position: 1
     display_options:
-      display_extenders: {  }
+      pager:
+        type: none
+        options:
+          offset: 0
       style:
         type: entity_reference
         options:
           search_fields:
             title: title
-      pager:
-        type: none
-        options:
-          offset: 0
       display_description: ''
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.taxonomy_term.yml
+++ b/conf/drupal/config/views.view.taxonomy_term.yml
@@ -24,21 +24,25 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      query:
-        type: views_query
+      fields: {  }
+      pager:
+        type: mini
         options:
-          query_comment: ''
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_tags: {  }
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
+          offset: 0
+          items_per_page: 10
+          total_pages: 0
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
       exposed_form:
         type: basic
         options:
@@ -49,49 +53,41 @@ display:
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
-      pager:
-        type: mini
+      access:
+        type: perm
         options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: 0
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
       sorts:
         sticky:
           id: sticky
           table: taxonomy_index
           field: sticky
-          order: DESC
-          plugin_id: standard
           relationship: none
           group_type: group
           admin_label: ''
-          exposed: false
+          plugin_id: standard
+          order: DESC
           expose:
             label: ''
+            field_identifier: sticky
+          exposed: false
         created:
           id: created
           table: taxonomy_index
           field: created
-          order: DESC
-          plugin_id: date
           relationship: none
           group_type: group
           admin_label: ''
-          exposed: false
+          plugin_id: date
+          order: DESC
           expose:
             label: ''
+            field_identifier: created
+          exposed: false
           granularity: second
       arguments:
         tid:
@@ -101,6 +97,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           default_action: 'not found'
           exception:
             value: ''
@@ -115,8 +112,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -126,15 +123,14 @@ display:
             type: 'entity:taxonomy_term'
             fail: 'not found'
           validate_options:
+            bundles: {  }
             access: true
             operation: view
             multiple: 0
-            bundles: {  }
           break_phrase: false
           add_table: false
           require_value: false
           reduce_duplicates: false
-          plugin_id: taxonomy_index_tid
       filters:
         langcode:
           id: langcode
@@ -143,6 +139,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
           operator: in
           value:
             '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
@@ -154,6 +153,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -161,8 +162,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -175,9 +174,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: language
-          entity_type: node
-          entity_field: langcode
         status:
           id: status
           table: taxonomy_index
@@ -185,6 +181,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -195,14 +192,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -215,7 +212,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: boolean
       style:
         type: default
         options:
@@ -227,6 +223,17 @@ display:
         type: 'entity:node'
         options:
           view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      link_display: page_1
+      link_url: ''
       header:
         entity_taxonomy_term:
           id: entity_taxonomy_term
@@ -235,27 +242,22 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: entity
           empty: true
-          tokenize: true
           target: '{{ raw_arguments.tid }}'
           view_mode: full
+          tokenize: true
           bypass_access: false
-          plugin_id: entity
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      fields: {  }
       display_extenders: {  }
-      link_url: ''
-      link_display: page_1
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_interface'
         - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
-      max-age: -1
       tags: {  }
   feed_1:
     id: feed_1
@@ -263,37 +265,37 @@ display:
     display_plugin: feed
     position: 2
     display_options:
-      query:
-        type: views_query
-        options: {  }
       pager:
         type: some
         options:
-          items_per_page: 10
           offset: 0
-      path: taxonomy/term/%/feed
-      displays:
-        page_1: page_1
-        default: '0'
+          items_per_page: 10
       style:
         type: rss
         options:
-          description: ''
           grouping: {  }
           uses_fields: false
+          description: ''
       row:
         type: node_rss
         options:
           relationship: none
           view_mode: default
+      query:
+        type: views_query
+        options: {  }
       display_extenders: {  }
+      path: taxonomy/term/%/feed
+      displays:
+        page_1: page_1
+        default: '0'
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_interface'
         - url
         - 'user.node_grants:view'
         - user.permissions
-      max-age: -1
       tags: {  }
   page_1:
     id: page_1
@@ -304,14 +306,14 @@ display:
       query:
         type: views_query
         options: {  }
-      path: taxonomy/term/%
       display_extenders: {  }
+      path: taxonomy/term/%
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_interface'
         - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
-      max-age: -1
       tags: {  }

--- a/conf/drupal/config/views.view.topics_.yml
+++ b/conf/drupal/config/views.view.topics_.yml
@@ -18,57 +18,11 @@ base_table: taxonomy_term_field_data
 base_field: tid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: role
-        options:
-          role:
-            administrator: administrator
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: none
-        options:
-          offset: 0
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          uses_fields: false
-      row:
-        type: fields
-        options:
-          default_field_elements: true
-          inline:
-            name: name
-            nid: nid
-          separator: ' - '
-          hide_empty: false
       fields:
         name:
           id: name
@@ -77,6 +31,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: term_name
           label: ''
           exclude: false
           alter:
@@ -140,9 +97,6 @@ display:
           format_plural_string: !!binary MQNAY291bnQ=
           prefix: ''
           suffix: ''
-          entity_type: taxonomy_term
-          entity_field: name
-          plugin_id: term_name
         nid:
           id: nid
           table: node_field_data
@@ -150,6 +104,9 @@ display:
           relationship: reverse__node__field_track
           group_type: count
           admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -191,14 +148,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          set_precision: false
-          precision: 0
-          decimal: .
-          separator: ', '
-          format_plural: 0
-          format_plural_string: !!binary MQNAY291bnQ=
-          prefix: ''
-          suffix: ''
           click_sort_column: value
           type: number_integer
           settings: {  }
@@ -210,10 +159,40 @@ display:
           delta_reversed: false
           delta_first_last: false
           multi_type: separator
+          separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: nid
-          plugin_id: field
+          set_precision: false
+          precision: 0
+          decimal: .
+          format_plural: 0
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+      pager:
+        type: none
+        options:
+          offset: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: role
+        options:
+          role:
+            administrator: administrator
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
       filters:
         vid:
           id: vid
@@ -222,6 +201,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: vid
+          plugin_id: bundle
           operator: in
           value:
             session_tracks: session_tracks
@@ -233,6 +215,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -240,8 +224,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -254,13 +236,30 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: taxonomy_term
-          entity_field: vid
-          plugin_id: bundle
-      sorts: {  }
-      header: {  }
-      footer: {  }
-      empty: {  }
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline:
+            name: name
+            nid: nid
+          separator: ' - '
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         reverse__node__field_track:
           id: reverse__node__field_track
@@ -269,12 +268,13 @@ display:
           relationship: none
           group_type: group
           admin_label: field_track
-          required: true
           entity_type: taxonomy_term
           plugin_id: entity_reverse
-      arguments: {  }
-      display_extenders: {  }
+          required: true
       group_by: true
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.training.yml
+++ b/conf/drupal/config/views.view.training.yml
@@ -22,70 +22,12 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: ‹‹
-            next: ››
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: schedule__teaser
-          default_row_class: false
-      row:
-        type: fields
-        options:
-          default_field_elements: false
-          inline: {  }
-          separator: ''
-          hide_empty: false
+      title: 'Submitted Sessions'
       fields:
         field_track:
           id: field_track
@@ -94,6 +36,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -149,7 +92,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -157,6 +99,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -212,9 +157,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         body:
           id: body
           table: node__body
@@ -222,6 +164,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -277,7 +220,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_registration_link:
           id: field_registration_link
           table: node__field_registration_link
@@ -285,6 +227,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -344,7 +287,75 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'Session selection and confirmation is still underway. Check back again soon.'
+            format: basic_html
+          tokenize: false
+      sorts:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: title
+          exposed: false
+      arguments: {  }
       filters:
         status:
           id: status
@@ -353,6 +364,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -363,14 +377,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -383,9 +397,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
         type:
           id: type
           table: node_field_data
@@ -393,6 +404,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
           operator: in
           value:
             training: training
@@ -404,6 +418,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -411,8 +427,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -425,9 +439,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
         title:
           id: title
           table: node_field_data
@@ -435,6 +446,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
           operator: '!='
           value: 'Getting started with the Drupal issue queue'
           group: 1
@@ -445,6 +459,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -452,8 +468,6 @@ display:
             remember_roles:
               authenticated: authenticated
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -466,48 +480,35 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: title
-          plugin_id: string
-      sorts:
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          entity_type: node
-          entity_field: title
-          plugin_id: standard
-      title: 'Submitted Sessions'
-      header: {  }
-      footer: {  }
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: 'Session selection and confirmation is still underway. Check back again soon.'
-            format: basic_html
-          plugin_id: text
-      relationships: {  }
-      arguments: {  }
-      display_extenders: {  }
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: schedule__teaser
+          default_row_class: false
+      row:
+        type: fields
+        options:
+          default_field_elements: false
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -521,55 +522,11 @@ display:
         - 'config:field.storage.node.field_registration_link'
         - 'config:field.storage.node.field_track'
   block_1:
-    display_plugin: block
     id: block_1
     display_title: Block
+    display_plugin: block
     position: 2
     display_options:
-      display_extenders: {  }
-      arguments:
-        field_event_target_id:
-          id: field_event_target_id
-          table: node__field_event
-          field: field_event_target_id
-          relationship: none
-          group_type: group
-          admin_label: ''
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: taxonomy_tid
-          default_argument_options:
-            term_page: '1'
-            node: true
-            anyall: ','
-            limit: false
-            vids: {  }
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            items_per_page: 25
-            override: false
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: false
-          not: false
-          plugin_id: numeric
-      defaults:
-        arguments: false
-        fields: false
       fields:
         field_track:
           id: field_track
@@ -578,6 +535,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -633,7 +591,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -641,6 +598,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -696,9 +656,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         body:
           id: body
           table: node__body
@@ -706,6 +663,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -761,7 +719,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         view_node:
           id: view_node
           table: node
@@ -769,6 +726,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          plugin_id: entity_link
           label: ''
           exclude: false
           alter:
@@ -813,8 +772,6 @@ display:
           text: 'Read more'
           output_url_as_text: false
           absolute: false
-          entity_type: node
-          plugin_id: entity_link
         field_registration_link:
           id: field_registration_link
           table: node__field_registration_link
@@ -822,6 +779,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -881,7 +839,50 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      arguments:
+        field_event_target_id:
+          id: field_event_target_id
+          table: node__field_event
+          field: field_event_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: taxonomy_tid
+          default_argument_options:
+            term_page: '1'
+            node: true
+            limit: false
+            vids: {  }
+            anyall: ','
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+      defaults:
+        fields: false
+        arguments: false
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -896,38 +897,13 @@ display:
         - 'config:field.storage.node.field_registration_link'
         - 'config:field.storage.node.field_track'
   page_2:
-    display_plugin: page
     id: page_2
     display_title: 'Training Day'
+    display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      path: training
+      enabled: false
       title: 'Full Day Training Sessions'
-      defaults:
-        title: false
-        style: false
-        row: false
-        fields: false
-        filters: false
-        filter_groups: false
-        header: false
-        empty: false
-        sorts: false
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: schedule__teaser
-          default_row_class: true
-      row:
-        type: fields
-        options:
-          default_field_elements: true
-          inline: {  }
-          separator: ''
-          hide_empty: false
       fields:
         field_track:
           id: field_track
@@ -936,6 +912,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -991,7 +968,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         title:
           id: title
           table: node_field_data
@@ -999,6 +975,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1054,9 +1033,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         body:
           id: body
           table: node__body
@@ -1064,6 +1040,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1119,7 +1096,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
         field_registration_link:
           id: field_registration_link
           table: node__field_registration_link
@@ -1127,6 +1103,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: field
           label: ''
           exclude: false
           alter:
@@ -1186,7 +1163,36 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'Session selection and confirmation is still underway. Check back again soon.'
+            format: basic_html
+          tokenize: false
+      sorts:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: title
+          exposed: false
       filters:
         status:
           id: status
@@ -1195,6 +1201,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -1205,14 +1214,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1225,9 +1234,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
         type:
           id: type
           table: node_field_data
@@ -1235,6 +1241,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
           operator: in
           value:
             training: training
@@ -1246,6 +1255,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -1253,8 +1264,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1267,13 +1276,34 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: schedule__teaser
+          default_row_class: true
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      defaults:
+        empty: false
+        title: false
+        style: false
+        row: false
+        fields: false
+        sorts: false
+        filters: false
+        filter_groups: false
+        header: false
+      display_description: ''
       header:
         area:
           id: area
@@ -1282,51 +1312,28 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: "<p>MidCamp will offer professional full day training on Thursday, March 8th to anyone interested in gaining additional hands-on knowledge on a variety of hot Drupal topics by world-class Drupal trainers.\n\n<p>Trainings are not included in the cost of a MidCamp registration. We recommend registering in advance as trainings tend to sell out. Lunch will be served and coffee will be available. \n\n<p>Registration 8 am. Trainings 9 am - 5 pm."
-            format: basic_html
           plugin_id: text
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
           empty: true
-          tokenize: false
           content:
-            value: 'Session selection and confirmation is still underway. Check back again soon.'
+            value: |-
+              <p>MidCamp will offer professional full day training on Thursday, March 8th to anyone interested in gaining additional hands-on knowledge on a variety of hot Drupal topics by world-class Drupal trainers.
+
+              <p>Trainings are not included in the cost of a MidCamp registration. We recommend registering in advance as trainings tend to sell out. Lunch will be served and coffee will be available. 
+
+              <p>Registration 8 am. Trainings 9 am - 5 pm.
             format: basic_html
-          plugin_id: text
-      sorts:
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: ASC
-          exposed: false
-          expose:
-            label: ''
-          entity_type: node
-          entity_field: title
-          plugin_id: standard
+          tokenize: false
+      display_extenders: {  }
+      path: training
       menu:
         type: normal
         title: 'Trainings (Thu)'
         description: ''
-        expanded: false
-        parent: 'menu_link_content:f76b79ad-4936-4d3f-9ae6-1f11bfbca9b4'
         weight: -50
-        context: '0'
+        expanded: false
         menu_name: main
-      enabled: false
+        parent: 'menu_link_content:f76b79ad-4936-4d3f-9ae6-1f11bfbca9b4'
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.trainings.yml
+++ b/conf/drupal/config/views.view.trainings.yml
@@ -25,86 +25,34 @@ base_table: node_field_data
 base_field: nid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
-      style:
-        type: html_list
-      row:
-        type: 'entity:node'
-        options:
-          view_mode: teaser
+      title: 'Submitted Trainings'
       fields:
         title:
           id: title
           table: node_field_data
           field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: node
           entity_field: title
+          plugin_id: field
           label: ''
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          settings:
-            link_to_entity: true
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -114,9 +62,13 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: string
+          settings:
+            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -127,6 +79,57 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'No training workshops have been submitted yet. Go <a href="https://www.midcamp.org/node/add/topic">create one</a> now!'
+            format: basic_html
+          tokenize: false
+      sorts: {  }
+      arguments: {  }
       filters:
         status:
           id: status
@@ -135,6 +138,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -145,14 +151,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -165,18 +171,15 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
         type:
           id: type
           table: node_field_data
           field: type
-          value:
-            topic: topic
           entity_type: node
           entity_field: type
           plugin_id: bundle
+          value:
+            topic: topic
           group: 1
           expose:
             operator_limit_selection: false
@@ -188,6 +191,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             - 15
@@ -199,6 +203,8 @@ display:
             description: null
             use_operator: false
             operator: field_topic_type_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: field_topic_type_target_id
             required: false
             remember: false
@@ -206,8 +212,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -221,12 +225,11 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: textfield
-          limit: true
           vid: topic_type
+          type: textfield
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -234,6 +237,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             2: 2
@@ -245,6 +249,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -252,8 +258,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -267,37 +271,33 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      sorts: {  }
-      title: 'Submitted Trainings'
-      header: {  }
-      footer: {  }
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: 'No training workshops have been submitted yet. Go <a href="https://www.midcamp.org/node/add/topic">create one</a> now!'
-            format: basic_html
-          plugin_id: text
-      relationships: {  }
-      arguments: {  }
-      display_extenders: {  }
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: html_list
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -309,14 +309,14 @@ display:
         - user.permissions
       tags: {  }
   page_1:
-    display_plugin: page
     id: page_1
     display_title: 'Submitted 2018'
+    display_plugin: page
     position: 1
     display_options:
+      display_description: ''
       display_extenders: {  }
       path: 2018/submitted-trainings
-      display_description: ''
     cache_metadata:
       max-age: -1
       contexts:
@@ -328,14 +328,15 @@ display:
         - user.permissions
       tags: {  }
   page_2:
-    display_plugin: page
     id: page_2
     display_title: 'Submitted 2019'
+    display_plugin: page
     position: 1
     display_options:
-      display_extenders: {  }
-      path: 2019/training
-      display_description: ''
+      pager:
+        type: none
+        options:
+          offset: 0
       filters:
         status:
           id: status
@@ -344,6 +345,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -354,14 +358,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -374,9 +378,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: status
-          plugin_id: boolean
         type:
           id: type
           table: node_field_data
@@ -384,6 +385,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
           operator: in
           value:
             training: training
@@ -395,6 +399,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -402,8 +408,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -416,9 +420,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
         field_event_target_id:
           id: field_event_target_id
           table: node__field_event
@@ -426,6 +427,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: taxonomy_index_tid
           operator: or
           value:
             97: 97
@@ -437,6 +439,8 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
@@ -444,8 +448,6 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -459,33 +461,31 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          type: select
-          limit: true
           vid: event
+          type: select
           hierarchy: false
+          limit: true
           error_message: true
-          plugin_id: taxonomy_index_tid
-      defaults:
-        filters: false
-        filter_groups: false
-        pager: false
       filter_groups:
         operator: AND
         groups:
           1: AND
+      defaults:
+        pager: false
+        filters: false
+        filter_groups: false
+      display_description: ''
+      display_extenders: {  }
+      path: 2019/training
       menu:
         type: none
         title: 'Training (Wed)'
         description: ''
-        expanded: false
-        parent: 'menu_link_content:48ea9bd1-f7b8-4ec7-a811-787b4ce6aaff'
         weight: -49
-        context: '0'
+        expanded: false
         menu_name: midcamp-2019-navigation
-      pager:
-        type: none
-        options:
-          offset: 0
+        parent: 'menu_link_content:48ea9bd1-f7b8-4ec7-a811-787b4ce6aaff'
+        context: '0'
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.user_admin_people.yml
+++ b/conf/drupal/config/views.view.user_admin_people.yml
@@ -15,131 +15,12 @@ base_table: users_field_data
 base_field: uid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'administer users'
-      cache:
-        type: tag
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Filter
-          reset_button: true
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: 0
-          tags:
-            previous: '‹ Previous'
-            next: 'Next ›'
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          summary: ''
-          columns:
-            user_bulk_form: user_bulk_form
-            name: name
-            status: status
-            rid: rid
-            created: created
-            access: access
-            edit_node: edit_node
-            dropbutton: dropbutton
-          info:
-            user_bulk_form:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            name:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            status:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-low
-            rid:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-low
-            created:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-low
-            access:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-low
-            edit_node:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-low
-            dropbutton:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: created
-          empty_table: true
-      row:
-        type: fields
+      title: People
       fields:
         user_bulk_form:
           id: user_bulk_form
@@ -148,6 +29,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          plugin_id: user_bulk_form
           label: 'Bulk update'
           exclude: false
           alter:
@@ -189,8 +72,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: user_bulk_form
-          entity_type: user
         name:
           id: name
           table: users_field_data
@@ -198,6 +79,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
           label: Username
           exclude: false
           alter:
@@ -239,10 +123,7 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: field
           type: user_name
-          entity_type: user
-          entity_field: name
         status:
           id: status
           table: users_field_data
@@ -250,6 +131,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: status
+          plugin_id: field
           label: Status
           exclude: false
           alter:
@@ -291,14 +175,11 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: field
           type: boolean
           settings:
             format: custom
-            format_custom_true: Active
             format_custom_false: Blocked
-          entity_type: user
-          entity_field: status
+            format_custom_true: Active
         roles_target_id:
           id: roles_target_id
           table: user__roles
@@ -306,6 +187,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: user_roles
           label: Roles
           exclude: false
           alter:
@@ -349,7 +231,6 @@ display:
           hide_alter_empty: true
           type: ul
           separator: ', '
-          plugin_id: user_roles
         created:
           id: created
           table: users_field_data
@@ -357,6 +238,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: created
+          plugin_id: field
           label: 'Member for'
           exclude: false
           alter:
@@ -403,9 +287,6 @@ display:
             future_format: '@interval'
             past_format: '@interval'
             granularity: 2
-          plugin_id: field
-          entity_type: user
-          entity_field: created
         access:
           id: access
           table: users_field_data
@@ -413,6 +294,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: access
+          plugin_id: field
           label: 'Last access'
           exclude: false
           alter:
@@ -459,9 +343,6 @@ display:
             future_format: '@interval hence'
             past_format: '@interval ago'
             granularity: 2
-          plugin_id: field
-          entity_type: user
-          entity_field: access
         operations:
           id: operations
           table: users
@@ -469,6 +350,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          plugin_id: entity_operations
           label: Operations
           exclude: false
           alter:
@@ -511,8 +394,6 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: true
-          entity_type: user
-          plugin_id: entity_operations
         mail:
           id: mail
           table: users_field_data
@@ -520,6 +401,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: mail
+          plugin_id: field
           label: ''
           exclude: true
           alter:
@@ -574,9 +458,72 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          plugin_id: field
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: 0
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'administer users'
+      cache:
+        type: tag
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No people available.'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: users_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: user
-          entity_field: mail
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
       filters:
         combine:
           id: combine
@@ -585,6 +532,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: combine
           operator: contains
           value: ''
           group: 1
@@ -595,6 +543,8 @@ display:
             description: ''
             use_operator: false
             operator: combine_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: user
             required: false
             remember: false
@@ -604,8 +554,6 @@ display:
               anonymous: '0'
               administrator: '0'
             placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -621,7 +569,6 @@ display:
           fields:
             name: name
             mail: mail
-          plugin_id: combine
         roles_target_id:
           id: roles_target_id
           table: user__roles
@@ -629,6 +576,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: user_roles
           operator: or
           value: {  }
           group: 1
@@ -639,6 +587,8 @@ display:
             description: ''
             use_operator: false
             operator: roles_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: role
             required: false
             remember: false
@@ -648,8 +598,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -663,7 +611,6 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          plugin_id: user_roles
         permission:
           id: permission
           table: user__roles
@@ -671,6 +618,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: user_permissions
           operator: or
           value: {  }
           group: 1
@@ -681,6 +629,8 @@ display:
             description: ''
             use_operator: false
             operator: permission_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: permission
             required: false
             remember: false
@@ -690,8 +640,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -705,7 +653,6 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          plugin_id: user_permissions
         status:
           id: status
           table: users_field_data
@@ -713,6 +660,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: status
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -723,6 +673,8 @@ display:
             description: ''
             use_operator: false
             operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: status
             required: false
             remember: false
@@ -731,8 +683,6 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: true
           group_info:
             label: Status
@@ -753,9 +703,6 @@ display:
                 title: Blocked
                 operator: '='
                 value: '0'
-          plugin_id: boolean
-          entity_type: user
-          entity_field: status
         default_langcode:
           id: default_langcode
           table: users_field_data
@@ -763,6 +710,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: default_langcode
+          plugin_id: boolean
           operator: '='
           value: '1'
           group: 1
@@ -773,14 +723,14 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -793,9 +743,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: user
-          entity_field: default_langcode
-          plugin_id: boolean
         uid_raw:
           id: uid_raw
           table: users_field_data
@@ -803,6 +750,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          plugin_id: numeric
           operator: '!='
           value:
             min: ''
@@ -816,17 +765,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -839,92 +788,144 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: numeric
-          entity_type: user
-      sorts:
-        created:
-          id: created
-          table: users_field_data
-          field: created
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-          plugin_id: date
-          entity_type: user
-          entity_field: created
-      title: People
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'No people available.'
-          plugin_id: text_custom
-      use_more: false
-      use_more_always: false
-      use_more_text: more
-      display_comment: ''
-      use_ajax: false
-      hide_attachment_summary: false
-      show_admin_links: true
-      group_by: false
-      link_url: ''
-      link_display: page_1
-      css_class: ''
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            user_bulk_form: user_bulk_form
+            name: name
+            status: status
+            rid: rid
+            created: created
+            access: access
+            edit_node: edit_node
+            dropbutton: dropbutton
+          default: created
+          info:
+            user_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            rid:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            created:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            access:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            edit_node:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            dropbutton:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: true
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      css_class: ''
+      use_ajax: false
+      group_by: false
+      show_admin_links: true
+      use_more: false
+      use_more_always: false
+      use_more_text: more
+      link_display: page_1
+      link_url: ''
+      display_comment: ''
+      hide_attachment_summary: false
       display_extenders: {  }
     cache_metadata:
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - user.permissions
-      max-age: 0
       tags: {  }
   page_1:
-    display_plugin: page
     id: page_1
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
-      path: admin/people/list
+      defaults:
+        show_admin_links: false
       show_admin_links: false
+      display_extenders: {  }
+      path: admin/people/list
       menu:
         type: 'default tab'
         title: List
         description: 'Find and manage people interacting with your site.'
-        menu_name: admin
         weight: -10
+        menu_name: admin
         context: ''
       tab_options:
         type: normal
         title: People
         description: 'Manage user accounts, roles, and permissions.'
-        menu_name: admin
         weight: 0
-      defaults:
-        show_admin_links: false
-      display_extenders: {  }
+        menu_name: admin
     cache_metadata:
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
         - user.permissions
-      max-age: 0
       tags: {  }

--- a/conf/drupal/config/views.view.user_entityreference.yml
+++ b/conf/drupal/config/views.view.user_entityreference.yml
@@ -16,92 +16,33 @@ base_table: users_field_data
 base_field: uid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access user profiles'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 10
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
-      style:
-        type: default
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          uses_fields: false
-      row:
-        type: fields
-        options:
-          inline: {  }
-          separator: ''
-          hide_empty: false
-          default_field_elements: true
       fields:
         name:
           id: name
           table: users_field_data
           field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: user
           entity_field: name
+          plugin_id: field
           label: ''
+          exclude: false
           alter:
             alter_text: false
             make_link: false
             absolute: false
-            trim: false
             word_boundary: false
             ellipsis: false
             strip_tags: false
+            trim: false
             html: false
-          hide_empty: false
-          empty_zero: false
-          plugin_id: field
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exclude: false
           element_type: ''
           element_class: ''
           element_label_type: ''
@@ -111,6 +52,8 @@ display:
           element_wrapper_class: ''
           element_default_classes: true
           empty: ''
+          hide_empty: false
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
           type: user_name
@@ -125,24 +68,80 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 10
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access user profiles'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
       filters:
         status:
-          value: '1'
+          id: status
           table: users_field_data
           field: status
-          plugin_id: boolean
           entity_type: user
           entity_field: status
-          id: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: ''
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
-      sorts: {  }
-      header: {  }
-      footer: {  }
-      empty: {  }
+      style:
+        type: default
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          uses_fields: false
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         reverse__node__field_people:
           id: reverse__node__field_people
@@ -151,9 +150,9 @@ display:
           relationship: none
           group_type: group
           admin_label: field_people
-          required: true
           entity_type: user
           plugin_id: entity_reverse
+          required: true
         field_schedule_location:
           id: field_schedule_location
           table: node__field_schedule_location
@@ -161,9 +160,10 @@ display:
           relationship: reverse__node__field_people
           group_type: group
           admin_label: 'field_schedule_location: Taxonomy term'
-          required: true
           plugin_id: standard
-      arguments: {  }
+          required: true
+      header: {  }
+      footer: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1
@@ -174,12 +174,16 @@ display:
         - user.permissions
       tags: {  }
   entity_reference_1:
-    display_plugin: entity_reference
     id: entity_reference_1
     display_title: 'Entity Reference'
+    display_plugin: entity_reference
     position: 1
     display_options:
-      display_extenders: {  }
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 0
       style:
         type: entity_reference
         options:
@@ -192,11 +196,7 @@ display:
           inline: {  }
           separator: '-'
           hide_empty: false
-      pager:
-        type: some
-        options:
-          items_per_page: 0
-          offset: 0
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.watchdog.yml
+++ b/conf/drupal/config/views.view.watchdog.yml
@@ -14,133 +14,12 @@ base_table: watchdog
 base_field: wid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'access site reports'
-      cache:
-        type: none
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Filter
-          reset_button: true
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: false
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: mini
-        options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          tags:
-            previous: ‹‹
-            next: ››
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: '{{ type }} {{ severity }}'
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            nothing: nothing
-            wid: wid
-            severity: severity
-            type: type
-            timestamp: timestamp
-            message: message
-            name: name
-            link: link
-          info:
-            nothing:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-medium
-            wid:
-              sortable: false
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-low
-            severity:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-low
-            type:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-medium
-            timestamp:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-low
-            message:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            name:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-medium
-            link:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: priority-low
-          default: wid
-          empty_table: false
-      row:
-        type: fields
+      title: 'Recent log messages'
       fields:
         nothing:
           id: nothing
@@ -149,6 +28,7 @@ display:
           relationship: none
           group_type: group
           admin_label: Icon
+          plugin_id: custom
           label: ''
           exclude: false
           alter:
@@ -190,7 +70,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: false
-          plugin_id: custom
         wid:
           id: wid
           table: watchdog
@@ -198,6 +77,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: standard
           label: WID
           exclude: true
           alter:
@@ -239,7 +119,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: standard
         severity:
           id: severity
           table: watchdog
@@ -247,6 +126,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: machine_name
           label: Severity
           exclude: true
           alter:
@@ -289,7 +169,6 @@ display:
           empty_zero: false
           hide_alter_empty: true
           machine_name: false
-          plugin_id: machine_name
         type:
           id: type
           table: watchdog
@@ -297,6 +176,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: standard
           label: Type
           exclude: false
           alter:
@@ -338,7 +218,6 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: standard
         timestamp:
           id: timestamp
           table: watchdog
@@ -346,6 +225,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: date
           label: Date
           exclude: false
           alter:
@@ -390,7 +270,6 @@ display:
           date_format: short
           custom_date_format: ''
           timezone: ''
-          plugin_id: date
         message:
           id: message
           table: watchdog
@@ -398,6 +277,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: dblog_message
           label: Message
           exclude: false
           alter:
@@ -440,7 +320,6 @@ display:
           empty_zero: false
           hide_alter_empty: true
           replace_variables: true
-          plugin_id: dblog_message
         name:
           id: name
           table: users_field_data
@@ -448,6 +327,9 @@ display:
           relationship: uid
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
           label: User
           exclude: false
           alter:
@@ -503,9 +385,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: user
-          entity_field: name
-          plugin_id: field
         link:
           id: link
           table: watchdog
@@ -513,6 +392,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: dblog_operations
           label: Operations
           exclude: false
           alter:
@@ -554,7 +434,70 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          plugin_id: dblog_operations
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Filter
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: false
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access site reports'
+      cache:
+        type: none
+        options: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'No log messages available.'
+            format: basic_html
+          tokenize: false
+      sorts:
+        wid:
+          id: wid
+          table: watchdog
+          field: wid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: wid
+          exposed: false
+      arguments: {  }
       filters:
         type:
           id: type
@@ -563,6 +506,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: dblog_types
           operator: in
           value: {  }
           group: 1
@@ -573,6 +517,8 @@ display:
             description: ''
             use_operator: false
             operator: type_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: type
             required: false
             remember: false
@@ -582,8 +528,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -596,7 +540,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: dblog_types
         severity:
           id: severity
           table: watchdog
@@ -604,6 +547,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: in_operator
           operator: in
           value: {  }
           group: 1
@@ -614,6 +558,8 @@ display:
             description: ''
             use_operator: false
             operator: severity_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: severity
             required: false
             remember: false
@@ -623,8 +569,6 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -637,37 +581,97 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: in_operator
-      sorts:
-        wid:
-          id: wid
-          table: watchdog
-          field: wid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-          plugin_id: standard
-      title: 'Recent log messages'
-      header: {  }
-      footer: {  }
-      empty:
-        area:
-          id: area
-          table: views
-          field: area
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content:
-            value: 'No log messages available.'
-            format: basic_html
-          plugin_id: text
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: '{{ type }} {{ severity }}'
+          default_row_class: true
+          columns:
+            nothing: nothing
+            wid: wid
+            severity: severity
+            type: type
+            timestamp: timestamp
+            message: message
+            name: name
+            link: link
+          default: wid
+          info:
+            nothing:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-medium
+            wid:
+              sortable: false
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            severity:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-medium
+            timestamp:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+            message:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-medium
+            link:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: priority-low
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
       relationships:
         uid:
           id: uid
@@ -676,15 +680,12 @@ display:
           relationship: none
           group_type: group
           admin_label: User
-          required: false
           plugin_id: standard
-      arguments: {  }
-      display_extenders: {  }
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
+          required: false
       css_class: admin-dblog
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -695,9 +696,9 @@ display:
         - user.permissions
       tags: {  }
   page:
-    display_plugin: page
     id: page
     display_title: Page
+    display_plugin: page
     position: 1
     display_options:
       display_extenders: {  }

--- a/conf/drupal/config/views.view.webform_submissions.yml
+++ b/conf/drupal/config/views.view.webform_submissions.yml
@@ -2,12 +2,12 @@ uuid: f9bdf73b-96aa-45ae-8f78-7f42f0a84c8c
 langcode: en
 status: true
 dependencies:
-  enforced:
-    module:
-      - webform
   module:
     - user
     - webform
+  enforced:
+    module:
+      - webform
 id: webform_submissions
 label: 'Webform submissions'
 module: views
@@ -17,156 +17,12 @@ base_table: webform_submission
 base_field: sid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: none
-        options: {  }
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: false
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 25
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: ‹‹
-            next: ››
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: false
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '5, 10, 25, 50, 100, 200'
-            items_per_page_options_all: false
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            webform_submission_bulk_form: webform_submission_bulk_form
-            sid: sid
-            in_draft: in_draft
-            sticky: sticky
-            locked: locked
-            created: created
-            completed: completed
-            remote_addr: remote_addr
-            view_webform_submission: view_webform_submission
-            edit_webform_submission: view_webform_submission
-          info:
-            webform_submission_bulk_form:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            sid:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            in_draft:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            sticky:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            locked:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            created:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            completed:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            remote_addr:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            view_webform_submission:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ' '
-              empty_column: false
-              responsive: ''
-            edit_webform_submission:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: created
-          empty_table: false
-      row:
-        type: fields
-        options:
-          inline: {  }
-          separator: ''
-          hide_empty: false
-          default_field_elements: true
+      title: 'Webform submissions'
       fields:
         sid:
           id: sid
@@ -175,6 +31,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sid
+          plugin_id: field
           label: '#'
           exclude: false
           alter:
@@ -231,9 +90,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sid
-          plugin_id: field
         in_draft:
           id: in_draft
           table: webform_submission
@@ -241,6 +97,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: field
           label: Draft
           exclude: false
           alter:
@@ -286,8 +145,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -298,9 +157,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: field
         created:
           id: created
           table: webform_submission
@@ -308,6 +164,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: created
+          plugin_id: field
           label: Created
           exclude: false
           alter:
@@ -365,9 +224,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: created
-          plugin_id: field
         remote_addr:
           id: remote_addr
           table: webform_submission
@@ -375,6 +231,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: remote_addr
+          plugin_id: field
           label: 'IP address'
           exclude: false
           alter:
@@ -430,9 +289,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: remote_addr
-          plugin_id: field
         view_webform_submission:
           id: view_webform_submission
           table: webform_submission
@@ -440,6 +296,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: entity_link
           label: Operations
           exclude: false
           alter:
@@ -484,22 +342,43 @@ display:
           text: view
           output_url_as_text: false
           absolute: false
-          entity_type: webform_submission
-          plugin_id: entity_link
-      filters: {  }
-      sorts: {  }
-      header:
-        result:
-          id: result
-          table: views
-          field: result
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          content: 'Displaying @start - @end of @total'
-          plugin_id: result
-      footer: {  }
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 25
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50, 100, 200'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
       empty:
         area_text_custom:
           id: area_text_custom
@@ -508,11 +387,11 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'No submissions available.'
           plugin_id: text_custom
-      relationships: {  }
+          empty: true
+          content: 'No submissions available.'
+          tokenize: false
+      sorts: {  }
       arguments:
         webform_id:
           id: webform_id
@@ -549,6 +428,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: numeric
           default_action: ignore
           exception:
             value: all
@@ -563,8 +445,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -576,42 +458,16 @@ display:
           validate_options: {  }
           break_phrase: false
           not: false
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: numeric
-      display_extenders: {  }
+      filters: {  }
       filter_groups:
         operator: AND
         groups: {  }
-      title: 'Webform submissions'
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - url.query_args
-        - user
-      tags: {  }
-  embed_administer:
-    display_plugin: embed
-    id: embed_administer
-    display_title: 'Embed: Administer'
-    position: 2
-    display_options:
-      display_extenders: {  }
-      display_description: 'Administer submissions.'
       style:
         type: table
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
           columns:
             webform_submission_bulk_form: webform_submission_bulk_form
             sid: sid
@@ -623,6 +479,7 @@ display:
             remote_addr: remote_addr
             view_webform_submission: view_webform_submission
             edit_webform_submission: view_webform_submission
+          default: created
           info:
             webform_submission_bulk_form:
               align: ''
@@ -692,26 +549,56 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-          default: created
+          override: true
+          sticky: false
+          summary: ''
           empty_table: false
-      defaults:
-        style: false
-        row: false
-        access: false
-        fields: false
-        filters: false
-        filter_groups: false
+          caption: ''
+          description: ''
       row:
         type: fields
         options:
+          default_field_elements: true
           inline: {  }
           separator: ''
           hide_empty: false
-          default_field_elements: true
-      access:
-        type: perm
+      query:
+        type: views_query
         options:
-          perm: 'administer webform submission'
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+      tags: {  }
+  embed_administer:
+    id: embed_administer
+    display_title: 'Embed: Administer'
+    display_plugin: embed
+    position: 2
+    display_options:
       fields:
         webform_submission_bulk_form:
           id: webform_submission_bulk_form
@@ -720,6 +607,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: webform_submission_bulk_form
           label: 'Webform submission operations bulk form'
           exclude: false
           alter:
@@ -764,8 +653,6 @@ display:
           action_title: Action
           include_exclude: exclude
           selected_actions: {  }
-          entity_type: webform_submission
-          plugin_id: webform_submission_bulk_form
         sid:
           id: sid
           table: webform_submission
@@ -773,6 +660,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sid
+          plugin_id: field
           label: '#'
           exclude: false
           alter:
@@ -829,9 +719,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sid
-          plugin_id: field
         in_draft:
           id: in_draft
           table: webform_submission
@@ -839,6 +726,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: field
           label: Draft
           exclude: false
           alter:
@@ -884,8 +774,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -896,9 +786,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: field
         sticky:
           id: sticky
           table: webform_submission
@@ -906,6 +793,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: field
           label: Sticky
           exclude: false
           alter:
@@ -951,8 +841,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -963,9 +853,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: field
         locked:
           id: locked
           table: webform_submission
@@ -973,6 +860,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: field
           label: Locked
           exclude: false
           alter:
@@ -1018,8 +908,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1030,9 +920,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: field
         created:
           id: created
           table: webform_submission
@@ -1040,6 +927,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: created
+          plugin_id: field
           label: Created
           exclude: false
           alter:
@@ -1097,9 +987,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: created
-          plugin_id: field
         completed:
           id: completed
           table: webform_submission
@@ -1107,6 +994,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: completed
+          plugin_id: field
           label: Completed
           exclude: false
           alter:
@@ -1164,9 +1054,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: completed
-          plugin_id: field
         remote_addr:
           id: remote_addr
           table: webform_submission
@@ -1174,6 +1061,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: remote_addr
+          plugin_id: field
           label: 'IP address'
           exclude: false
           alter:
@@ -1229,9 +1119,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: remote_addr
-          plugin_id: field
         operations:
           id: operations
           table: webform_submission
@@ -1239,6 +1126,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: null
+          plugin_id: entity_operations
           label: Operations
           exclude: false
           alter:
@@ -1281,9 +1171,10 @@ display:
           empty_zero: false
           hide_alter_empty: true
           destination: true
-          entity_type: null
-          entity_field: null
-          plugin_id: entity_operations
+      access:
+        type: perm
+        options:
+          perm: 'administer webform submission'
       filters:
         in_draft:
           id: in_draft
@@ -1292,6 +1183,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: boolean
           operator: '='
           value: All
           group: 1
@@ -1302,6 +1196,8 @@ display:
             description: ''
             use_operator: false
             operator: in_draft_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: in_draft
             required: false
             remember: false
@@ -1310,8 +1206,6 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1324,9 +1218,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: boolean
         sticky:
           id: sticky
           table: webform_submission
@@ -1334,6 +1225,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: boolean
           operator: '='
           value: All
           group: 1
@@ -1344,6 +1238,8 @@ display:
             description: ''
             use_operator: false
             operator: sticky_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: sticky
             required: false
             remember: false
@@ -1352,8 +1248,6 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1366,9 +1260,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: boolean
         locked:
           id: locked
           table: webform_submission
@@ -1376,6 +1267,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: boolean
           operator: '='
           value: All
           group: 1
@@ -1386,6 +1280,8 @@ display:
             description: ''
             use_operator: false
             operator: locked_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: locked
             required: false
             remember: false
@@ -1395,8 +1291,6 @@ display:
               anonymous: '0'
               administrator: '0'
               demo_region: '0'
-            operator_limit_selection: false
-            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -1409,13 +1303,119 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: boolean
       filter_groups:
         operator: AND
         groups:
           1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            webform_submission_bulk_form: webform_submission_bulk_form
+            sid: sid
+            in_draft: in_draft
+            sticky: sticky
+            locked: locked
+            created: created
+            completed: completed
+            remote_addr: remote_addr
+            view_webform_submission: view_webform_submission
+            edit_webform_submission: view_webform_submission
+          default: created
+          info:
+            webform_submission_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            sid:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            in_draft:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            sticky:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            locked:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            created:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            completed:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            remote_addr:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            view_webform_submission:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ' '
+              empty_column: false
+              responsive: ''
+            edit_webform_submission:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      defaults:
+        access: false
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+      display_description: 'Administer submissions.'
+      display_extenders: {  }
     cache_metadata:
       max-age: 0
       contexts:
@@ -1427,36 +1427,24 @@ display:
         - user.permissions
       tags: {  }
   embed_default:
-    display_plugin: embed
     id: embed_default
     display_title: 'Embed: Default'
+    display_plugin: embed
     position: 1
     display_options:
-      display_extenders: {  }
-      display_description: 'Display submissions.'
-      defaults:
-        fields: true
-        style: false
-        row: false
-        filters: true
-        filter_groups: true
       style:
         type: table
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
           columns:
             sid: sid
             in_draft: in_draft
             created: created
             remote_addr: remote_addr
             view_webform_submission: view_webform_submission
+          default: created
           info:
             sid:
               sortable: true
@@ -1493,15 +1481,27 @@ display:
               separator: ' '
               empty_column: false
               responsive: ''
-          default: created
+          override: true
+          sticky: false
+          summary: ''
           empty_table: false
+          caption: ''
+          description: ''
       row:
         type: fields
         options:
+          default_field_elements: true
           inline: {  }
           separator: ''
           hide_empty: false
-          default_field_elements: true
+      defaults:
+        style: false
+        row: false
+        fields: true
+        filters: true
+        filter_groups: true
+      display_description: 'Display submissions.'
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:
@@ -1512,13 +1512,11 @@ display:
         - user
       tags: {  }
   embed_manage:
-    display_plugin: embed
     id: embed_manage
     display_title: 'Embed: Manage'
+    display_plugin: embed
     position: 3
     display_options:
-      display_extenders: {  }
-      display_description: 'Manage submissions.'
       fields:
         webform_submission_bulk_form:
           id: webform_submission_bulk_form
@@ -1527,6 +1525,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: webform_submission_bulk_form
           label: 'Webform submission operations bulk form'
           exclude: false
           alter:
@@ -1575,8 +1575,6 @@ display:
             - webform_submission_make_sticky_action
             - webform_submission_make_unlock_action
             - webform_submission_make_unsticky_action
-          entity_type: webform_submission
-          plugin_id: webform_submission_bulk_form
         sid:
           id: sid
           table: webform_submission
@@ -1584,6 +1582,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sid
+          plugin_id: field
           label: '#'
           exclude: false
           alter:
@@ -1640,9 +1641,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sid
-          plugin_id: field
         in_draft:
           id: in_draft
           table: webform_submission
@@ -1650,6 +1648,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: field
           label: Draft
           exclude: false
           alter:
@@ -1695,8 +1696,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1707,9 +1708,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: field
         sticky:
           id: sticky
           table: webform_submission
@@ -1717,6 +1715,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: field
           label: Sticky
           exclude: false
           alter:
@@ -1762,8 +1763,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1774,9 +1775,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: field
         locked:
           id: locked
           table: webform_submission
@@ -1784,6 +1782,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: field
           label: Locked
           exclude: false
           alter:
@@ -1829,8 +1830,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1841,9 +1842,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: field
         created:
           id: created
           table: webform_submission
@@ -1851,6 +1849,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: created
+          plugin_id: field
           label: Created
           exclude: false
           alter:
@@ -1908,9 +1909,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: created
-          plugin_id: field
         completed:
           id: completed
           table: webform_submission
@@ -1918,6 +1916,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: completed
+          plugin_id: field
           label: Completed
           exclude: false
           alter:
@@ -1975,9 +1976,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: completed
-          plugin_id: field
         remote_addr:
           id: remote_addr
           table: webform_submission
@@ -1985,6 +1983,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: remote_addr
+          plugin_id: field
           label: 'IP address'
           exclude: false
           alter:
@@ -2040,9 +2041,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: remote_addr
-          plugin_id: field
         view_webform_submission:
           id: view_webform_submission
           table: webform_submission
@@ -2050,6 +2048,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: entity_link
           label: Operations
           exclude: false
           alter:
@@ -2094,8 +2094,6 @@ display:
           text: view
           output_url_as_text: false
           absolute: false
-          entity_type: webform_submission
-          plugin_id: entity_link
         edit_webform_submission:
           id: edit_webform_submission
           table: webform_submission
@@ -2103,6 +2101,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: entity_link_edit
           label: Operations
           exclude: false
           alter:
@@ -2147,26 +2147,148 @@ display:
           text: edit
           output_url_as_text: false
           absolute: false
+      access:
+        type: perm
+        options:
+          perm: 'edit any webform submission'
+      filters:
+        in_draft:
+          id: in_draft
+          table: webform_submission
+          field: in_draft
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: webform_submission
-          plugin_id: entity_link_edit
-      defaults:
-        fields: false
-        style: false
-        row: false
-        access: false
-        filters: false
-        filter_groups: false
+          entity_field: in_draft
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Is draft'
+            description: ''
+            use_operator: false
+            operator: in_draft_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: in_draft
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        sticky:
+          id: sticky
+          table: webform_submission
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Sticky
+            description: ''
+            use_operator: false
+            operator: sticky_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: sticky
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        locked:
+          id: locked
+          table: webform_submission
+          field: locked
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Locked
+            description: ''
+            use_operator: false
+            operator: locked_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: locked
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              demo_region: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: table
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
           columns:
             webform_submission_bulk_form: webform_submission_bulk_form
             sid: sid
@@ -2178,6 +2300,7 @@ display:
             remote_addr: remote_addr
             view_webform_submission: view_webform_submission
             edit_webform_submission: view_webform_submission
+          default: created
           info:
             webform_submission_bulk_form:
               align: ''
@@ -2247,151 +2370,28 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-          default: created
+          override: true
+          sticky: false
+          summary: ''
           empty_table: false
+          caption: ''
+          description: ''
       row:
         type: fields
         options:
+          default_field_elements: true
           inline: {  }
           separator: ''
           hide_empty: false
-          default_field_elements: true
-      access:
-        type: perm
-        options:
-          perm: 'edit any webform submission'
-      filters:
-        in_draft:
-          id: in_draft
-          table: webform_submission
-          field: in_draft
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: 'Is draft'
-            description: ''
-            use_operator: false
-            operator: in_draft_op
-            identifier: in_draft
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: boolean
-        sticky:
-          id: sticky
-          table: webform_submission
-          field: sticky
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: Sticky
-            description: ''
-            use_operator: false
-            operator: sticky_op
-            identifier: sticky
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: boolean
-        locked:
-          id: locked
-          table: webform_submission
-          field: locked
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: Locked
-            description: ''
-            use_operator: false
-            operator: locked_op
-            identifier: locked
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              demo_region: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: boolean
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
+      defaults:
+        access: false
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+      display_description: 'Manage submissions.'
+      display_extenders: {  }
     cache_metadata:
       max-age: 0
       contexts:
@@ -2403,13 +2403,11 @@ display:
         - user.permissions
       tags: {  }
   embed_review:
-    display_plugin: embed
     id: embed_review
     display_title: 'Embed: Review'
+    display_plugin: embed
     position: 4
     display_options:
-      display_extenders: {  }
-      display_description: 'Review submissions.'
       fields:
         sid:
           id: sid
@@ -2418,6 +2416,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sid
+          plugin_id: field
           label: '#'
           exclude: false
           alter:
@@ -2474,9 +2475,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sid
-          plugin_id: field
         in_draft:
           id: in_draft
           table: webform_submission
@@ -2484,6 +2482,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: in_draft
+          plugin_id: field
           label: Draft
           exclude: false
           alter:
@@ -2529,8 +2530,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -2541,9 +2542,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: field
         sticky:
           id: sticky
           table: webform_submission
@@ -2551,6 +2549,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: field
           label: Sticky
           exclude: false
           alter:
@@ -2596,8 +2597,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -2608,9 +2609,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: field
         locked:
           id: locked
           table: webform_submission
@@ -2618,6 +2616,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: field
           label: Locked
           exclude: false
           alter:
@@ -2663,8 +2664,8 @@ display:
           type: boolean
           settings:
             format: yes-no
-            format_custom_true: ''
             format_custom_false: ''
+            format_custom_true: ''
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -2675,9 +2676,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: field
         created:
           id: created
           table: webform_submission
@@ -2685,6 +2683,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: created
+          plugin_id: field
           label: Created
           exclude: false
           alter:
@@ -2742,9 +2743,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: created
-          plugin_id: field
         completed:
           id: completed
           table: webform_submission
@@ -2752,6 +2750,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: completed
+          plugin_id: field
           label: Completed
           exclude: false
           alter:
@@ -2809,9 +2810,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: completed
-          plugin_id: field
         remote_addr:
           id: remote_addr
           table: webform_submission
@@ -2819,6 +2817,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          entity_field: remote_addr
+          plugin_id: field
           label: 'IP address'
           exclude: false
           alter:
@@ -2874,9 +2875,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: webform_submission
-          entity_field: remote_addr
-          plugin_id: field
         view_webform_submission:
           id: view_webform_submission
           table: webform_submission
@@ -2884,6 +2882,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: webform_submission
+          plugin_id: entity_link
           label: Operations
           exclude: false
           alter:
@@ -2928,26 +2928,148 @@ display:
           text: view
           output_url_as_text: false
           absolute: false
+      access:
+        type: perm
+        options:
+          perm: 'view any webform submission'
+      filters:
+        in_draft:
+          id: in_draft
+          table: webform_submission
+          field: in_draft
+          relationship: none
+          group_type: group
+          admin_label: ''
           entity_type: webform_submission
-          plugin_id: entity_link
-      defaults:
-        fields: false
-        style: false
-        row: false
-        access: false
-        filters: false
-        filter_groups: false
+          entity_field: in_draft
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Is draft'
+            description: ''
+            use_operator: false
+            operator: in_draft_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: in_draft
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        sticky:
+          id: sticky
+          table: webform_submission
+          field: sticky
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: webform_submission
+          entity_field: sticky
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Sticky
+            description: ''
+            use_operator: false
+            operator: sticky_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: sticky
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        locked:
+          id: locked
+          table: webform_submission
+          field: locked
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: webform_submission
+          entity_field: locked
+          plugin_id: boolean
+          operator: '='
+          value: All
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: Locked
+            description: ''
+            use_operator: false
+            operator: locked_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: locked
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              demo_region: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: table
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
           columns:
             webform_submission_bulk_form: webform_submission_bulk_form
             sid: sid
@@ -2959,6 +3081,7 @@ display:
             remote_addr: remote_addr
             view_webform_submission: view_webform_submission
             edit_webform_submission: view_webform_submission
+          default: created
           info:
             webform_submission_bulk_form:
               align: ''
@@ -3028,151 +3151,28 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-          default: created
+          override: true
+          sticky: false
+          summary: ''
           empty_table: false
+          caption: ''
+          description: ''
       row:
         type: fields
         options:
+          default_field_elements: true
           inline: {  }
           separator: ''
           hide_empty: false
-          default_field_elements: true
-      access:
-        type: perm
-        options:
-          perm: 'view any webform submission'
-      filters:
-        in_draft:
-          id: in_draft
-          table: webform_submission
-          field: in_draft
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: 'Is draft'
-            description: ''
-            use_operator: false
-            operator: in_draft_op
-            identifier: in_draft
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: in_draft
-          plugin_id: boolean
-        sticky:
-          id: sticky
-          table: webform_submission
-          field: sticky
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: Sticky
-            description: ''
-            use_operator: false
-            operator: sticky_op
-            identifier: sticky
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: sticky
-          plugin_id: boolean
-        locked:
-          id: locked
-          table: webform_submission
-          field: locked
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: All
-          group: 1
-          exposed: true
-          expose:
-            operator_id: ''
-            label: Locked
-            description: ''
-            use_operator: false
-            operator: locked_op
-            identifier: locked
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-              demo_region: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: webform_submission
-          entity_field: locked
-          plugin_id: boolean
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
+      defaults:
+        access: false
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+      display_description: 'Review submissions.'
+      display_extenders: {  }
     cache_metadata:
       max-age: -1
       contexts:

--- a/conf/drupal/config/views.view.who_s_new.yml
+++ b/conf/drupal/config/views.view.who_s_new.yml
@@ -15,26 +15,52 @@ base_table: users_field_data
 base_field: uid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
+      title: 'Who''s new'
+      fields:
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: user_name
+      pager:
+        type: some
         options:
-          perm: 'access content'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
+          offset: 0
+          items_per_page: 5
       exposed_form:
         type: basic
         options:
@@ -45,64 +71,46 @@ display:
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
-      pager:
-        type: some
+      access:
+        type: perm
         options:
-          items_per_page: 5
-          offset: 0
-      style:
-        type: html_list
-      row:
-        type: fields
-      fields:
-        name:
-          id: name
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        created:
+          id: created
           table: users_field_data
-          field: name
-          label: ''
-          plugin_id: field
-          type: user_name
-          alter:
-            alter_text: false
-            make_link: false
-            absolute: false
-            trim: false
-            word_boundary: false
-            ellipsis: false
-            strip_tags: false
-            html: false
-          hide_empty: false
-          empty_zero: false
+          field: created
           relationship: none
           group_type: group
           admin_label: ''
-          exclude: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_alter_empty: true
           entity_type: user
-          entity_field: name
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments: {  }
       filters:
         status:
-          value: '1'
+          id: status
           table: users_field_data
           field: status
-          id: status
+          entity_type: user
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
           expose:
             operator: '0'
             operator_limit_selection: false
             operator_list: {  }
-          group: 1
-          plugin_id: boolean
-          entity_type: user
-          entity_field: status
         access:
           id: access
           table: users_field_data
@@ -110,6 +118,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: access
+          plugin_id: date
           operator: '>'
           value:
             min: ''
@@ -124,17 +135,17 @@ display:
             description: ''
             use_operator: false
             operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: ''
             required: false
             remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -147,53 +158,43 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: date
-          entity_type: user
-          entity_field: access
-      sorts:
-        created:
-          id: created
-          table: users_field_data
-          field: created
-          relationship: none
-          group_type: group
-          admin_label: ''
-          order: DESC
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-          plugin_id: date
-          entity_type: user
-          entity_field: created
-      title: 'Who''s new'
+      style:
+        type: html_list
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header: {  }
       footer: {  }
-      empty: {  }
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - user.permissions
-      max-age: -1
       tags: {  }
   block_1:
-    display_plugin: block
     id: block_1
     display_title: 'Who''s new'
+    display_plugin: block
     position: 1
     display_options:
       display_description: 'A list of new users'
+      display_extenders: {  }
       block_description: 'Who''s new'
       block_category: User
-      display_extenders: {  }
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - user.permissions
-      max-age: -1
       tags: {  }

--- a/conf/drupal/config/views.view.who_s_online.yml
+++ b/conf/drupal/config/views.view.who_s_online.yml
@@ -15,26 +15,52 @@ base_table: users_field_data
 base_field: uid
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
+      title: 'Who''s online'
+      fields:
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: user_name
+      pager:
+        type: some
         options:
-          perm: 'access user profiles'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
+          offset: 0
+          items_per_page: 10
       exposed_form:
         type: basic
         options:
@@ -45,71 +71,26 @@ display:
           expose_sort_order: true
           sort_asc_label: Asc
           sort_desc_label: Desc
-      pager:
-        type: some
+      access:
+        type: perm
         options:
-          items_per_page: 10
-          offset: 0
-      style:
-        type: html_list
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          type: ul
-          wrapper_class: item-list
-          class: ''
-      row:
-        type: fields
-      fields:
-        name:
-          id: name
-          table: users_field_data
-          field: name
-          label: ''
-          plugin_id: field
-          type: user_name
-          alter:
-            alter_text: false
-            make_link: false
-            absolute: false
-            trim: false
-            word_boundary: false
-            ellipsis: false
-            strip_tags: false
-            html: false
-          hide_empty: false
-          empty_zero: false
+          perm: 'access user profiles'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
           relationship: none
           group_type: group
           admin_label: ''
-          exclude: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_alter_empty: true
-          entity_type: user
-          entity_field: name
-      filters:
-        status:
-          value: '1'
-          table: users_field_data
-          field: status
-          id: status
-          expose:
-            operator: '0'
-            operator_limit_selection: false
-            operator_list: {  }
-          group: 1
-          plugin_id: boolean
-          entity_type: user
-          entity_field: status
+          plugin_id: text_custom
+          empty: true
+          content: 'There are currently 0 users online.'
+          tokenize: false
+      sorts:
         access:
           id: access
           table: users_field_data
@@ -117,6 +98,40 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: user
+          entity_field: access
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: access
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: users_field_data
+          field: status
+          entity_type: user
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
+        access:
+          id: access
+          table: users_field_data
+          field: access
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: access
+          plugin_id: date
           operator: '>='
           value:
             min: ''
@@ -131,6 +146,8 @@ display:
             description: 'A user is considered online for this long after they have last viewed a page.'
             use_operator: false
             operator: access_op
+            operator_limit_selection: false
+            operator_list: {  }
             identifier: access
             required: false
             remember: false
@@ -139,11 +156,9 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
-            placeholder: ''
             min_placeholder: ''
             max_placeholder: ''
-            operator_limit_selection: false
-            operator_list: {  }
+            placeholder: ''
           is_grouped: false
           group_info:
             label: ''
@@ -156,26 +171,26 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          plugin_id: date
-          entity_type: user
-          entity_field: access
-      sorts:
-        access:
-          id: access
-          table: users_field_data
-          field: access
-          order: DESC
-          relationship: none
-          group_type: group
-          admin_label: ''
-          exposed: false
-          expose:
-            label: ''
-          granularity: second
-          plugin_id: date
-          entity_type: user
-          entity_field: access
-      title: 'Who''s online'
+      style:
+        type: html_list
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          type: ul
+          wrapper_class: item-list
+          class: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
       header:
         result:
           id: result
@@ -184,45 +199,31 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          plugin_id: result
           empty: false
           content: 'There are currently @total users online.'
-          plugin_id: result
       footer: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'There are currently 0 users online.'
-          plugin_id: text_custom
-      relationships: {  }
-      arguments: {  }
       display_extenders: {  }
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - user.permissions
-      max-age: -1
       tags: {  }
   who_s_online_block:
-    display_plugin: block
     id: who_s_online_block
     display_title: 'Who''s online'
+    display_plugin: block
     position: 1
     display_options:
-      block_description: 'Who''s online'
       display_description: 'A list of users that are currently logged in.'
       display_extenders: {  }
+      block_description: 'Who''s online'
     cache_metadata:
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - user.permissions
-      max-age: -1
       tags: {  }

--- a/conf/drupal/config/webform.settings.yml
+++ b/conf/drupal/config/webform.settings.yml
@@ -1,31 +1,32 @@
+_core:
+  default_config_hash: pCVedUicnZwcaPYXHSEnGjAGPbKqhTUmtHKTi4nfI-M
+langcode: en
 settings:
   default_status: open
   default_page_base_path: /form
   default_ajax: false
+  default_ajax_progress_type: throbber
   default_ajax_effect: fade
   default_ajax_speed: 500
-  default_ajax_progress_type: throbber
-  default_form_open_message: 'This form has not yet been opened to submissions.'
-  default_form_close_message: 'Sorry...This form is closed to new submissions.'
-  default_form_exception_message: 'Unable to display this webform. Please contact the site administrator.'
   default_submit_button_label: Submit
   default_reset_button_label: Reset
   default_delete_button_label: Delete
   default_form_submit_once: false
+  default_form_open_message: 'This form has not yet been opened to submissions.'
+  default_form_close_message: 'Sorry...This form is closed to new submissions.'
+  default_form_exception_message: 'Unable to display this webform. Please contact the site administrator.'
   default_form_confidential_message: 'This form is confidential. You must <a href="[site:login-url]/logout?destination=[current-page:url:relative]">Log out</a> to submit it.'
   default_form_access_denied_message: 'Please login to access this form.'
-  default_form_disable_back: false
-  default_form_submit_back: false
-  default_form_unsaved: false
   default_form_disable_remote_addr: false
   default_form_novalidate: false
   default_form_disable_inline_errors: false
   default_form_required: false
   default_form_required_label: 'Indicates required field'
+  default_form_unsaved: false
+  default_form_disable_back: false
+  default_form_submit_back: false
   default_form_details_toggle: true
   default_form_file_limit: ''
-  form_classes: "container-inline clearfix\nform--inline clearfix\nmessages messages--error\nmessages messages--warning\nmessages messages--status\n"
-  button_classes: ''
   default_wizard_prev_button_label: '< Previous Page'
   default_wizard_next_button_label: 'Next Page >'
   default_wizard_start_label: Start
@@ -44,10 +45,9 @@ settings:
   default_draft_pending_multiple_message: 'You have pending drafts for this webform. <a href="#">View your pending drafts</a>.'
   default_confirmation_message: 'New submission added to [webform:title].'
   default_confirmation_back_label: 'Back to form'
+  default_limit_total_message: 'No more submissions are permitted.'
+  default_limit_user_message: 'No more submissions are permitted.'
   default_submission_label: '[webform_submission:submitted-to]: Submission #[webform_submission:serial]'
-  default_submission_access_denied_message: 'Please login to access this submission.'
-  default_submission_exception_message: 'Unable to process this submission. Please contact the site administrator.'
-  default_submission_locked_message: 'This submission has been locked.'
   default_submission_log: false
   default_submission_views: {  }
   default_submission_views_replace:
@@ -63,28 +63,32 @@ settings:
       - entity.node.webform.user.drafts
       - entity.node.webform.user.submissions
   default_results_customize: false
+  default_submission_access_denied_message: 'Please login to access this submission.'
+  default_submission_exception_message: 'Unable to process this submission. Please contact the site administrator.'
+  default_submission_locked_message: 'This submission has been locked.'
   default_previous_submission_message: 'You have already submitted this webform. <a href="#">View your previous submission</a>.'
   default_previous_submissions_message: 'You have already submitted this webform. <a href="#">View your previous submissions</a>.'
   default_autofill_message: 'This submission has been autofilled with your previous submission.'
-  preview_classes: "messages messages--error\nmessages messages--warning\nmessages messages--status\n"
-  confirmation_classes: "messages messages--error\nmessages messages--warning\nmessages messages--status\n"
-  confirmation_back_classes: "button\n"
-  default_limit_total_message: 'No more submissions are permitted.'
-  default_limit_user_message: 'No more submissions are permitted.'
+  form_classes: |
+    container-inline clearfix
+    form--inline clearfix
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  button_classes: ''
+  preview_classes: |
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  confirmation_classes: |
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  confirmation_back_classes: |
+    button
   default_share: false
   default_share_node: false
   default_share_theme_name: ''
-  dialog: false
-  dialog_options:
-    narrow:
-      title: Narrow
-      width: 600
-    normal:
-      title: Normal
-      width: 800
-    wide:
-      title: Wide
-      width: 1000
   webform_bulk_form: true
   webform_bulk_form_actions:
     - webform_open_action
@@ -99,44 +103,21 @@ settings:
     - webform_submission_make_lock_action
     - webform_submission_make_unlock_action
     - webform_submission_delete_action
+  dialog: false
+  dialog_options:
+    narrow:
+      title: Narrow
+      width: 600
+    normal:
+      title: Normal
+      width: 800
+    wide:
+      title: Wide
+      width: 1000
   default_submission_login_message: 'Please login to access this submission.'
 assets:
   css: ''
   javascript: ''
-handler:
-  excluded_handlers: {  }
-variant:
-  excluded_variants: {  }
-export:
-  temp_directory: ''
-  exporter: delimited
-  multiple_delimiter: ;
-  header_format: label
-  header_prefix: true
-  header_prefix_label_delimiter: ': '
-  header_prefix_key_delimiter: __
-  composite_element_item_format: label
-  options_single_format: compact
-  options_multiple_format: compact
-  options_item_format: label
-  entity_reference_items:
-    - id
-    - title
-    - url
-  likert_answers_format: label
-  signature_format: status
-  delimiter: ','
-  excel: false
-  archive_type: tar
-  excluded_exporters: {  }
-batch:
-  default_batch_export_size: 500
-  default_batch_import_size: 100
-  default_batch_update_size: 500
-  default_batch_delete_size: 500
-  default_batch_email_size: 500
-purge:
-  cron_size: 100
 form:
   limit: 50
   filter_category: ''
@@ -145,9 +126,28 @@ element:
   machine_name_pattern: a-z0-9_
   empty_message: '{Empty}'
   allowed_tags: admin
-  wrapper_classes: "container-inline clearfix\nform--inline clearfix\nmessages messages--error\nmessages messages--warning\nmessages messages--status\n"
-  classes: "container-inline clearfix\nform--inline clearfix\nmessages messages--error\nmessages messages--warning\nmessages messages--status\n"
-  horizontal_rule_classes: "webform-horizontal-rule--solid\nwebform-horizontal-rule--dashed\nwebform-horizontal-rule--dotted\nwebform-horizontal-rule--gradient\nwebform-horizontal-rule--thin\nwebform-horizontal-rule--medium\nwebform-horizontal-rule--thick\nwebform-horizontal-rule--flaired\nwebform-horizontal-rule--glyph\n"
+  wrapper_classes: |
+    container-inline clearfix
+    form--inline clearfix
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  classes: |
+    container-inline clearfix
+    form--inline clearfix
+    messages messages--error
+    messages messages--warning
+    messages messages--status
+  horizontal_rule_classes: |
+    webform-horizontal-rule--solid
+    webform-horizontal-rule--dashed
+    webform-horizontal-rule--dotted
+    webform-horizontal-rule--gradient
+    webform-horizontal-rule--thin
+    webform-horizontal-rule--medium
+    webform-horizontal-rule--thick
+    webform-horizontal-rule--flaired
+    webform-horizontal-rule--glyph
   default_description_display: ''
   default_more_title: More
   default_section_title_tag: h2
@@ -173,10 +173,10 @@ file:
   file_private_redirect_message: 'Please login to access the uploaded file.'
   default_max_filesize: ''
   default_managed_file_extensions: 'gif jpg png bmp eps tif pict psd txt rtf html odf pdf doc docx ppt pptx xls xlsx xml avi mov mp3 ogg wav bz2 dmg gz jar rar sit svg tar zip'
-  default_audio_file_extensions: 'mp3 ogg wav'
-  default_document_file_extensions: 'txt rtf pdf doc docx odt ppt pptx odp xls xlsx ods'
   default_image_file_extensions: 'gif jpg png svg'
   default_video_file_extensions: 'avi mov mp4 ogg wav webm'
+  default_audio_file_extensions: 'mp3 ogg wav'
+  default_document_file_extensions: 'txt rtf pdf doc docx odt ppt pptx odp xls xlsx ods'
   make_unused_managed_files_temporary: true
   delete_temporary_managed_files: true
 format: {  }
@@ -189,20 +189,146 @@ mail:
   default_sender_mail: ''
   default_sender_name: ''
   default_subject: 'Webform submission from: [webform_submission:source-title]'
-  default_body_text: "Submitted on [webform_submission:created]\nSubmitted by: [webform_submission:user]\n\nSubmitted values are:\n[webform_submission:values]\n"
-  default_body_html: "<p>Submitted on [webform_submission:created]</p>\n<p>Submitted by: [webform_submission:user]</p>\n<p>Submitted values are:</p>\n[webform_submission:values]\n"
+  default_body_text: |
+    Submitted on [webform_submission:created]
+    Submitted by: [webform_submission:user]
+
+    Submitted values are:
+    [webform_submission:values]
+  default_body_html: |
+    <p>Submitted on [webform_submission:created]</p>
+    <p>Submitted by: [webform_submission:user]</p>
+    <p>Submitted values are:</p>
+    [webform_submission:values]
   roles: {  }
+export:
+  temp_directory: ''
+  exporter: delimited
+  delimiter: ','
+  multiple_delimiter: ;
+  excel: false
+  archive_type: tar
+  header_format: label
+  header_prefix: true
+  header_prefix_key_delimiter: __
+  header_prefix_label_delimiter: ': '
+  entity_reference_items:
+    - id
+    - title
+    - url
+  options_single_format: compact
+  options_multiple_format: compact
+  options_item_format: label
+  likert_answers_format: label
+  signature_format: status
+  composite_element_item_format: label
+  excluded_exporters: {  }
+handler:
+  excluded_handlers: {  }
+variant:
+  excluded_variants: {  }
+batch:
+  default_batch_export_size: 500
+  default_batch_import_size: 100
+  default_batch_update_size: 500
+  default_batch_delete_size: 500
+  default_batch_email_size: 500
+purge:
+  cron_size: 100
 test:
-  types: "checkbox:\n  - true\ncolor:\n  - '#ffffcc'\n  - '#ffffcc'\n  - '#ccffff'\nemail:\n  - 'example@example.com'\n  - 'test@test.com'\n  - 'random@random.com'\nlanguage_select:\n  - en\nmachine_name:\n  - 'loremipsum'\n  - 'oratione'\n  - 'dixisset'\ntel:\n  - '123-456-7890'\n  - '098-765-4321'\ntextarea:\n  - 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Negat esse eam, inquit, propter se expetendam. Primum Theophrasti, Strato, physicum se voluit; Id mihi magnum videtur. Itaque mihi non satis videmini considerare quod iter sit naturae quaeque progressio. Quare hoc videndum est, possitne nobis hoc ratio philosophorum dare. Est enim tanti philosophi tamque nobilis audacter sua decreta defendere.'\n  - 'Huius, Lyco, oratione locuples, rebus ipsis ielunior. Duo Reges: constructio interrete. Sed haec in pueris; Sed utrum hortandus es nobis, Luci, inquit, an etiam tua sponte propensus es? Sapiens autem semper beatus est et est aliquando in dolore; Immo videri fortasse. Paulum, cum regem Persem captum adduceret, eodem flumine invectio? Et ille ridens: Video, inquit, quid agas;'\n  - 'Quae cum dixisset, finem ille. Quamquam non negatis nos intellegere quid sit voluptas, sed quid ille dicat. Progredientibus autem aetatibus sensim tardeve potius quasi nosmet ipsos cognoscimus. Gloriosa ostentatio in constituendo summo bono. Qui-vere falsone, quaerere mittimus-dicitur oculis se privasse; Duarum enim vitarum nobis erunt instituta capienda. Comprehensum, quod cognitum non habet? Qui enim existimabit posse se miserum esse beatus non erit. Causa autem fuit huc veniendi ut quosdam hinc libros promerem. Nunc omni virtuti vitium contrario nomine opponitur.'\ntext_format:\n  - value: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Negat esse eam, inquit, propter se expetendam. Primum Theophrasti, Strato, physicum se voluit; Id mihi magnum videtur. Itaque mihi non satis videmini considerare quod iter sit naturae quaeque progressio. Quare hoc videndum est, possitne nobis hoc ratio philosophorum dare. Est enim tanti philosophi tamque nobilis audacter sua decreta defendere.</p>'\n  - value: '<p>Huius, Lyco, oratione locuples, rebus ipsis ielunior. Duo Reges: constructio interrete. Sed haec in pueris; Sed utrum hortandus es nobis, Luci, inquit, an etiam tua sponte propensus es? Sapiens autem semper beatus est et est aliquando in dolore; Immo videri fortasse. Paulum, cum regem Persem captum adduceret, eodem flumine invectio? Et ille ridens: Video, inquit, quid agas;</p>'\n  - value: '<p>Quae cum dixisset, finem ille. Quamquam non negatis nos intellegere quid sit voluptas, sed quid ille dicat. Progredientibus autem aetatibus sensim tardeve potius quasi nosmet ipsos cognoscimus. Gloriosa ostentatio in constituendo summo bono. Qui-vere falsone, quaerere mittimus-dicitur oculis se privasse; Duarum enim vitarum nobis erunt instituta capienda. Comprehensum, quod cognitum non habet? Qui enim existimabit posse se miserum esse beatus non erit. Causa autem fuit huc veniendi ut quosdam hinc libros promerem. Nunc omni virtuti vitium contrario nomine opponitur.</p>'\nurl:\n  - 'http://example.com'\n  - 'http://test.com'\nwebform_creditcard_number:\n  - '4111111111111111'\nwebform_email_confirm:\n  - 'example@example.com'\n  - 'test@test.com'\n  - 'random@random.com'\nwebform_email_multiple:\n  - 'example@example.com, test@test.com, random@random.com'\nwebform_location:\n  - value: 'The White House, 1600 Pennsylvania Ave NW, Washington, DC 20500, USA'\n  - value: 'London SW1A 1AA, United Kingdom'\n  - value: 'Moscow, Russia, 10307'\nwebform_time:\n  - '09:00'\n  - '17:00'\n"
-  names: "first_name:\n  - John\n  - Paul\n  - Ringo\n  - George\nlast_name:\n  - Lennon\n  - McCartney\n  - Starr\n  - Harrison\naddress:\n  - '10 Main Street'\n  - '11 Brook Alley Road. APT 1'\nzip:\n  - '11111'\n  - '12345'\n  - 12345-6789\nphone:\n  - 123-456-7890\n  - 098-765-4321\nfax:\n  - 123-456-7890\n  - 098-765-4321\ncity:\n  - Springfield\n  - Pleasantville\n  - 'Hill Valley'\nurl:\n  - 'http://example.com'\n  - 'http://test.com'\ndefault:\n  - Loremipsum\n  - Oratione\n  - Dixisset\npostal_code:\n  - '11111'\n  - '12345'\n  - 12345-6789"
+  types: |
+    checkbox:
+      - true
+    color:
+      - '#ffffcc'
+      - '#ffffcc'
+      - '#ccffff'
+    email:
+      - 'example@example.com'
+      - 'test@test.com'
+      - 'random@random.com'
+    language_select:
+      - en
+    machine_name:
+      - 'loremipsum'
+      - 'oratione'
+      - 'dixisset'
+    tel:
+      - '123-456-7890'
+      - '098-765-4321'
+    textarea:
+      - 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Negat esse eam, inquit, propter se expetendam. Primum Theophrasti, Strato, physicum se voluit; Id mihi magnum videtur. Itaque mihi non satis videmini considerare quod iter sit naturae quaeque progressio. Quare hoc videndum est, possitne nobis hoc ratio philosophorum dare. Est enim tanti philosophi tamque nobilis audacter sua decreta defendere.'
+      - 'Huius, Lyco, oratione locuples, rebus ipsis ielunior. Duo Reges: constructio interrete. Sed haec in pueris; Sed utrum hortandus es nobis, Luci, inquit, an etiam tua sponte propensus es? Sapiens autem semper beatus est et est aliquando in dolore; Immo videri fortasse. Paulum, cum regem Persem captum adduceret, eodem flumine invectio? Et ille ridens: Video, inquit, quid agas;'
+      - 'Quae cum dixisset, finem ille. Quamquam non negatis nos intellegere quid sit voluptas, sed quid ille dicat. Progredientibus autem aetatibus sensim tardeve potius quasi nosmet ipsos cognoscimus. Gloriosa ostentatio in constituendo summo bono. Qui-vere falsone, quaerere mittimus-dicitur oculis se privasse; Duarum enim vitarum nobis erunt instituta capienda. Comprehensum, quod cognitum non habet? Qui enim existimabit posse se miserum esse beatus non erit. Causa autem fuit huc veniendi ut quosdam hinc libros promerem. Nunc omni virtuti vitium contrario nomine opponitur.'
+    text_format:
+      - value: '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Negat esse eam, inquit, propter se expetendam. Primum Theophrasti, Strato, physicum se voluit; Id mihi magnum videtur. Itaque mihi non satis videmini considerare quod iter sit naturae quaeque progressio. Quare hoc videndum est, possitne nobis hoc ratio philosophorum dare. Est enim tanti philosophi tamque nobilis audacter sua decreta defendere.</p>'
+      - value: '<p>Huius, Lyco, oratione locuples, rebus ipsis ielunior. Duo Reges: constructio interrete. Sed haec in pueris; Sed utrum hortandus es nobis, Luci, inquit, an etiam tua sponte propensus es? Sapiens autem semper beatus est et est aliquando in dolore; Immo videri fortasse. Paulum, cum regem Persem captum adduceret, eodem flumine invectio? Et ille ridens: Video, inquit, quid agas;</p>'
+      - value: '<p>Quae cum dixisset, finem ille. Quamquam non negatis nos intellegere quid sit voluptas, sed quid ille dicat. Progredientibus autem aetatibus sensim tardeve potius quasi nosmet ipsos cognoscimus. Gloriosa ostentatio in constituendo summo bono. Qui-vere falsone, quaerere mittimus-dicitur oculis se privasse; Duarum enim vitarum nobis erunt instituta capienda. Comprehensum, quod cognitum non habet? Qui enim existimabit posse se miserum esse beatus non erit. Causa autem fuit huc veniendi ut quosdam hinc libros promerem. Nunc omni virtuti vitium contrario nomine opponitur.</p>'
+    url:
+      - 'http://example.com'
+      - 'http://test.com'
+    webform_creditcard_number:
+      - '4111111111111111'
+    webform_email_confirm:
+      - 'example@example.com'
+      - 'test@test.com'
+      - 'random@random.com'
+    webform_email_multiple:
+      - 'example@example.com, test@test.com, random@random.com'
+    webform_location:
+      - value: 'The White House, 1600 Pennsylvania Ave NW, Washington, DC 20500, USA'
+      - value: 'London SW1A 1AA, United Kingdom'
+      - value: 'Moscow, Russia, 10307'
+    webform_time:
+      - '09:00'
+      - '17:00'
+  names: |-
+    first_name:
+      - John
+      - Paul
+      - Ringo
+      - George
+    last_name:
+      - Lennon
+      - McCartney
+      - Starr
+      - Harrison
+    address:
+      - '10 Main Street'
+      - '11 Brook Alley Road. APT 1'
+    zip:
+      - '11111'
+      - '12345'
+      - 12345-6789
+    phone:
+      - 123-456-7890
+      - 098-765-4321
+    fax:
+      - 123-456-7890
+      - 098-765-4321
+    city:
+      - Springfield
+      - Pleasantville
+      - 'Hill Valley'
+    url:
+      - 'http://example.com'
+      - 'http://test.com'
+    default:
+      - Loremipsum
+      - Oratione
+      - Dixisset
+    postal_code:
+      - '11111'
+      - '12345'
+      - 12345-6789
 ui:
   video_display: dialog
-  details_save: true
   help_disabled: false
   dialog_disabled: false
   offcanvas_disabled: false
   promotions_disabled: false
   support_disabled: false
+  details_save: true
   description_help: true
   toolbar_item: false
   about_disabled: false
@@ -213,12 +339,9 @@ libraries:
     - jquery.toggles
 requirements:
   cdn: true
-  bootstrap: true
   clientside_validation: true
+  bootstrap: true
   spam: true
-langcode: en
 third_party_settings:
   captcha:
     replace_administration_mode: true
-_core:
-  default_config_hash: pCVedUicnZwcaPYXHSEnGjAGPbKqhTUmtHKTi4nfI-M

--- a/conf/drupal/config/webform.webform.contact.yml
+++ b/conf/drupal/config/webform.webform.contact.yml
@@ -5,9 +5,11 @@ dependencies:
   enforced:
     module:
       - webform
+_core:
+  default_config_hash: W8LHFRO51r0rBKzjUCRv8qxnRs6aTKBTxa8jwn7tBP8
+weight: 0
 open: null
 close: null
-weight: 0
 uid: null
 template: false
 archive: false
@@ -15,7 +17,31 @@ id: contact
 title: Contact
 description: 'Basic email contact webform.'
 category: ''
-elements: "name:\n  '#title': 'Your Name'\n  '#type': textfield\n  '#required': true\n  '#default_value': '[current-user:display-name]'\nemail:\n  '#title': 'Your Email'\n  '#type': email\n  '#required': true\n  '#default_value': '[current-user:mail]'\nsubject:\n  '#title': Subject\n  '#type': textfield\n  '#required': true\n  '#test': 'Testing contact webform from [site:name]'\nmessage:\n  '#title': Message\n  '#type': textarea\n  '#required': true\n  '#test': 'Please ignore this email.'\nactions:\n  '#type': webform_actions\n  '#title': 'Submit button(s)'\n  '#submit__label': 'Send message'\n"
+elements: |
+  name:
+    '#title': 'Your Name'
+    '#type': textfield
+    '#required': true
+    '#default_value': '[current-user:display-name]'
+  email:
+    '#title': 'Your Email'
+    '#type': email
+    '#required': true
+    '#default_value': '[current-user:mail]'
+  subject:
+    '#title': Subject
+    '#type': textfield
+    '#required': true
+    '#test': 'Testing contact webform from [site:name]'
+  message:
+    '#title': Message
+    '#type': textarea
+    '#required': true
+    '#test': 'Please ignore this email.'
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': 'Send message'
 css: ''
 javascript: ''
 settings:
@@ -30,9 +56,9 @@ settings:
   page_theme_name: ''
   form_title: both
   form_submit_once: false
-  form_exception_message: ''
   form_open_message: ''
   form_close_message: ''
+  form_exception_message: ''
   form_previous_submissions: true
   form_confidential: false
   form_confidential_message: ''
@@ -42,31 +68,36 @@ settings:
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
   form_prepopulate_source_entity_type: ''
-  form_reset: false
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
   form_disable_autocomplete: false
   form_novalidate: false
   form_disable_inline_errors: false
   form_required: false
-  form_unsaved: false
-  form_disable_back: false
-  form_submit_back: false
   form_autofocus: false
   form_details_toggle: false
+  form_reset: false
   form_access_denied: default
   form_access_denied_title: ''
   form_access_denied_message: ''
   form_access_denied_attributes: {  }
   form_file_limit: ''
+  form_attributes: {  }
   form_method: ''
   form_action: ''
-  form_attributes: {  }
   share: false
   share_node: false
   share_theme_name: ''
   share_title: true
   share_page_body_attributes: {  }
   submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
   submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
   submission_views: {  }
   submission_views_replace: {  }
   submission_user_columns: {  }
@@ -75,11 +106,6 @@ settings:
   submission_access_denied_title: ''
   submission_access_denied_message: ''
   submission_access_denied_attributes: {  }
-  submission_exception_message: ''
-  submission_locked_message: ''
-  submission_excluded_elements: {  }
-  submission_exclude_empty: false
-  submission_exclude_empty_checkbox: false
   previous_submission_message: ''
   previous_submissions_message: ''
   autofill: false
@@ -90,13 +116,13 @@ settings:
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_auto_forward: true
-  wizard_auto_forward_hide_next_button: false
-  wizard_keyboard: true
   wizard_start_label: ''
   wizard_preview_link: false
   wizard_confirmation: true
   wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
   wizard_track: ''
   wizard_prev_button_label: ''
   wizard_next_button_label: ''
@@ -119,9 +145,9 @@ settings:
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
   confirmation_type: url_message
+  confirmation_url: '<front>'
   confirmation_title: ''
   confirmation_message: 'Your message has been sent.'
-  confirmation_url: '<front>'
   confirmation_attributes: {  }
   confirmation_back: true
   confirmation_back_label: ''
@@ -200,9 +226,9 @@ access:
 handlers:
   email_confirmation:
     id: email
+    handler_id: email_confirmation
     label: 'Email confirmation'
     notes: ''
-    handler_id: email_confirmation
     status: true
     conditions: {  }
     weight: 1
@@ -211,13 +237,17 @@ handlers:
         - completed
       to_mail: '[current-user:mail]'
       to_options: {  }
-      cc_mail: ''
-      cc_options: {  }
       bcc_mail: ''
       bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
       from_mail: _default
       from_options: {  }
       from_name: _default
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
       subject: '[webform_submission:values:subject:raw]'
       body: '[webform_submission:values:message:value]'
       excluded_elements: {  }
@@ -228,18 +258,14 @@ handlers:
       html: true
       attachments: false
       twig: false
-      debug: false
-      reply_to: ''
-      return_path: ''
-      sender_mail: ''
-      sender_name: ''
       theme_name: ''
       parameters: {  }
+      debug: false
   email_notification:
     id: email
+    handler_id: email_notification
     label: 'Email notification'
     notes: ''
-    handler_id: email_notification
     status: true
     conditions: {  }
     weight: 1
@@ -248,13 +274,17 @@ handlers:
         - completed
       to_mail: _default
       to_options: {  }
-      cc_mail: ''
-      cc_options: {  }
       bcc_mail: ''
       bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
       from_mail: '[webform_submission:values:email:raw]'
       from_options: {  }
       from_name: '[webform_submission:values:name:raw]'
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
       subject: '[webform_submission:values:subject:raw]'
       body: '[webform_submission:values:message:value]'
       excluded_elements: {  }
@@ -265,13 +295,7 @@ handlers:
       html: true
       attachments: false
       twig: false
-      debug: false
-      reply_to: ''
-      return_path: ''
-      sender_mail: ''
-      sender_name: ''
       theme_name: ''
       parameters: {  }
+      debug: false
 variants: {  }
-_core:
-  default_config_hash: W8LHFRO51r0rBKzjUCRv8qxnRs6aTKBTxa8jwn7tBP8

--- a/conf/drupal/config/webform.webform.lightning_talk_sign_up.yml
+++ b/conf/drupal/config/webform.webform.lightning_talk_sign_up.yml
@@ -2,9 +2,9 @@ uuid: b5dd1627-f0fc-4710-84fe-f0026d6954f9
 langcode: en
 status: open
 dependencies: {  }
+weight: 0
 open: null
 close: null
-weight: 0
 uid: 1
 template: false
 archive: false
@@ -12,7 +12,39 @@ id: lightning_talk_sign_up
 title: 'Lightning Talk Sign Up'
 description: ''
 category: ''
-elements: "present_lightning_talk:\n  '#type': radios\n  '#title': 'Would you like to present a Lightning Talk?'\n  '#options': yes_no\n  '#required': true\nwhat_is_your_name_:\n  '#type': webform_name\n  '#title': 'What is your name?'\n  '#title_display': before\n  '#required': true\n  '#states':\n    invisible:\n      ':input[name=\"present_lightning_talk\"]':\n        '!value': 'Yes'\n  '#title__access': false\n  '#middle__access': false\n  '#suffix__access': false\n  '#degree__access': false\nemail_address:\n  '#type': webform_email_confirm\n  '#title': 'Email address'\n  '#states':\n    invisible:\n      ':input[name=\"present_lightning_talk\"]':\n        '!value': 'Yes'\nwhat_would_you_like_to_present_:\n  '#type': textarea\n  '#title': 'What would you like to present?'\n  '#states':\n    invisible:\n      ':input[name=\"present_lightning_talk\"]':\n        '!value': 'Yes'\n"
+elements: |
+  present_lightning_talk:
+    '#type': radios
+    '#title': 'Would you like to present a Lightning Talk?'
+    '#options': yes_no
+    '#required': true
+  what_is_your_name_:
+    '#type': webform_name
+    '#title': 'What is your name?'
+    '#title_display': before
+    '#required': true
+    '#states':
+      invisible:
+        ':input[name="present_lightning_talk"]':
+          '!value': 'Yes'
+    '#title__access': false
+    '#middle__access': false
+    '#suffix__access': false
+    '#degree__access': false
+  email_address:
+    '#type': webform_email_confirm
+    '#title': 'Email address'
+    '#states':
+      invisible:
+        ':input[name="present_lightning_talk"]':
+          '!value': 'Yes'
+  what_would_you_like_to_present_:
+    '#type': textarea
+    '#title': 'What would you like to present?'
+    '#states':
+      invisible:
+        ':input[name="present_lightning_talk"]':
+          '!value': 'Yes'
 css: ''
 javascript: ''
 settings:
@@ -27,9 +59,9 @@ settings:
   page_theme_name: ''
   form_title: both
   form_submit_once: false
-  form_exception_message: ''
   form_open_message: ''
   form_close_message: ''
+  form_exception_message: ''
   form_previous_submissions: true
   form_confidential: false
   form_confidential_message: ''
@@ -39,31 +71,36 @@ settings:
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
   form_prepopulate_source_entity_type: ''
-  form_reset: false
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
   form_disable_autocomplete: false
   form_novalidate: false
   form_disable_inline_errors: false
   form_required: false
-  form_unsaved: false
-  form_disable_back: false
-  form_submit_back: false
   form_autofocus: false
   form_details_toggle: false
+  form_reset: false
   form_access_denied: default
   form_access_denied_title: ''
   form_access_denied_message: ''
   form_access_denied_attributes: {  }
   form_file_limit: ''
+  form_attributes: {  }
   form_method: ''
   form_action: ''
-  form_attributes: {  }
   share: false
   share_node: false
   share_theme_name: ''
   share_title: true
   share_page_body_attributes: {  }
   submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
   submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
   submission_views: {  }
   submission_views_replace: {  }
   submission_user_columns: {  }
@@ -72,11 +109,6 @@ settings:
   submission_access_denied_title: ''
   submission_access_denied_message: ''
   submission_access_denied_attributes: {  }
-  submission_exception_message: ''
-  submission_locked_message: ''
-  submission_excluded_elements: {  }
-  submission_exclude_empty: false
-  submission_exclude_empty_checkbox: false
   previous_submission_message: ''
   previous_submissions_message: ''
   autofill: false
@@ -87,13 +119,13 @@ settings:
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_auto_forward: true
-  wizard_auto_forward_hide_next_button: false
-  wizard_keyboard: true
   wizard_start_label: ''
   wizard_preview_link: false
   wizard_confirmation: true
   wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
   wizard_track: ''
   wizard_prev_button_label: ''
   wizard_next_button_label: ''
@@ -116,9 +148,9 @@ settings:
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
   confirmation_type: page
+  confirmation_url: ''
   confirmation_title: ''
   confirmation_message: ''
-  confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: true
   confirmation_back_label: ''

--- a/conf/drupal/config/webform.webform.midcamp_2018_survey.yml
+++ b/conf/drupal/config/webform.webform.midcamp_2018_survey.yml
@@ -2,9 +2,9 @@ uuid: 0825e1bf-8303-49b7-9c98-4c3b5e410505
 langcode: en
 status: open
 dependencies: {  }
+weight: 0
 open: null
 close: null
-weight: 0
 uid: 1
 template: false
 archive: false
@@ -12,7 +12,202 @@ id: midcamp_2018_survey
 title: 'Midcamp 2018 Survey'
 description: ''
 category: ''
-elements: "1:\n  '#type': webform_wizard_page\n  '#title': '1'\n  '#open': true\n  markup_intro:\n    '#type': webform_markup\n    '#markup': 'Thank you for taking this survey. It has 20 questions. We want to make next year&#39;s MidCamp even better and your responses will help inform our strategy for 2018.'\n  first_time_midcamp:\n    '#type': radios\n    '#title': 'First time at Midcamp?'\n    '#options': yes_no\n    '#required': true\n2:\n  '#type': webform_wizard_page\n  '#title': '2'\n  '#open': true\n  how_did_you_find_out_about_midcamp_:\n    '#type': webform_checkboxes_other\n    '#title': 'How did you find out about MidCamp?'\n    '#description': \"<p tabindex=\\\"-1\\\">Welcome! Congrats! We&rsquo;re think you&rsquo;re the greatest!!</p>\\nHow did you find out about MidCamp? (pick all that apply)\\n\"\n    '#title_display': before\n    '#description_display': before\n    '#options':\n      Colleague: Colleague\n      'Local drupal org/meetup group': 'Local drupal org/meetup group'\n      Friend: Friend\n      'Drupal.org website': 'Drupal.org website'\n      'Twitter/other social media': 'Twitter/other social media'\n    '#states':\n      invisible:\n        ':input[name=\"first_time_midcamp\"]':\n          '!value': 'Yes'\n  what_is_your_job_:\n    '#type': webform_checkboxes_other\n    '#title': 'What is your job?'\n    '#title_display': before\n    '#options':\n      'Drupal developer': 'Drupal developer'\n      'Developer (other)': 'Developer (other)'\n      'Site Builder': 'Site Builder'\n      'Website Manager': 'Website Manager'\n      'Drupal Project Manager': 'Drupal Project Manager'\n      Designer: Designer\n      Recruiter: Recruiter\n      UXer: UXer\n      'Business Owner': 'Business Owner'\n      Student: Student\n  primary_reason_for_coming:\n    '#type': webform_checkboxes_other\n    '#title': 'Which of the following best describes your primary reason for coming to MidCamp'\n    '#options':\n      'Learn about Drupal 8': 'Learn about Drupal 8'\n      'Meeting clients': 'Meeting clients'\n      'Meeting employers': 'Meeting employers'\n      'Recruiting employees': 'Recruiting employees'\n      'Meeting community members': 'Meeting community members'\n      'Want to build knowledge/learning': 'Want to build knowledge/learning'\n      'Make connections in Drupal Community': 'Make connections in Drupal Community'\n      Training: Training\n      Sprints: Sprints\n      BOFs: BOFs\n  where_did_you_stay_during_camp_:\n    '#type': radios\n    '#title': 'Where did you stay during camp?'\n    '#options':\n      'At my home. I’m local.': 'At my home. I’m local.'\n      'A camp-recommended hotel': 'A camp-recommended hotel'\n      'A rental or hotel elsewhere in the city': 'A rental or hotel elsewhere in the city'\n      'With friends/any free bed': 'With friends/any free bed'\n3:\n  '#type': webform_wizard_page\n  '#title': '3'\n  '#open': true\n  did_you_attend_any_sessions_:\n    '#type': radios\n    '#title': 'Did you attend any sessions?'\n    '#options': yes_no\n  sessions_worthwhile:\n    '#type': webform_entity_select\n    '#title': 'Which MidCamp sessions did you find most worthwhile?'\n    '#multiple': 5\n    '#multiple_error': 'Please choose no more than 5 favorite sessions!'\n    '#description': 'Please select up to 5 sessions.'\n    '#states':\n      invisible:\n        ':input[name=\"did_you_attend_any_sessions_\"]':\n          '!value': 'Yes'\n    '#target_type': node\n    '#selection_handler': views\n    '#selection_settings':\n      view:\n        view_name: survey_filters\n        display_name: entity_reference_1\n        arguments: {  }\n  speakers_enjoy:\n    '#type': webform_entity_select\n    '#title': 'Which MidCamp speakers did you most enjoy?'\n    '#multiple': 5\n    '#multiple_error': 'Please choose no more than 5 favorite speakers!'\n    '#description': 'Please select up to 5 speakers.'\n    '#options_randomize': true\n    '#states':\n      invisible:\n        ':input[name=\"did_you_attend_any_sessions_\"]':\n          '!value': 'Yes'\n    '#target_type': user\n    '#selection_handler': views\n    '#selection_settings':\n      view:\n        view_name: user_entityreference\n        display_name: entity_reference_1\n        arguments: {  }\n  recommend_midcamp_0_10:\n    '#type': webform_rating\n    '#title': 'On a scale from 0-10, how likely are you to recommend Midcamp to a friend or colleague?'\n    '#max': 10\n    '#reset': true\n  do_you_have_anything_to_say_about_the_food_or_drink_:\n    '#type': radios\n    '#title': 'Do you have anything to say about the food or drink?'\n    '#options': yes_no\n4:\n  '#type': webform_wizard_page\n  '#title': '4'\n  '#open': true\n  food_satisfaction:\n    '#type': webform_likert\n    '#title': 'Please rate the following on a scale of 1-5 for your satisfaction with the following'\n    '#states':\n      invisible:\n        ':input[name=\"do_you_have_anything_to_say_about_the_food_or_drink_\"]':\n          '!value': 'Yes'\n    '#questions':\n      'Quantity of food': 'Quantity of food'\n      'Quality of food': 'Quality of food'\n      \"Variety of food (dietary requirements)\\t\": \"Variety of food (dietary requirements)\\t\"\n      'Quantity of drinks/coffee': 'Quantity of drinks/coffee'\n    '#answers':\n      \"Extremely dissatisfied\\t\": \"Extremely dissatisfied\\t\"\n      'Somewhat dissatisfied': 'Somewhat dissatisfied'\n      'Neither satisfied nor dissatisfied': 'Neither satisfied nor dissatisfied'\n      'Somewhat satisfied': 'Somewhat satisfied'\n      'Extremely satisfied': 'Extremely satisfied'\n    '#na_answer_text': ''\n  other_comments_food_or_drink:\n    '#type': textarea\n    '#title': 'Any other comments about the food or drink?'\n    '#states':\n      invisible:\n        ':input[name=\"do_you_have_anything_to_say_about_the_food_or_drink_\"]':\n          '!value': 'Yes'\n  rate_experience_at_midcamp_scale_1_5:\n    '#type': webform_likert\n    '#title': 'Please rate your experience at MidCamp on a scale of 1-5, where 1 is very negative and 5 is very positive.'\n    '#questions':\n      'How satisfied were you with the large meeting space?': 'How satisfied were you with the large meeting space?'\n      \"How satisfied were you with the set-ups?\\t\": \"How satisfied were you with the set-ups?\\t\"\n      \"How useful were the walking lanes?\\t\": \"How useful were the walking lanes?\\t\"\n      \"How likely are you to come back to MidCamp next year?\\t\": \"How likely are you to come back to MidCamp next year?\\t\"\n      \"How satisfied are you with your experience at MidCamp?\\t\": \"How satisfied are you with your experience at MidCamp?\\t\"\n    '#answers': likert_satisfaction\n    '#na_answer_text': ''\n  highlight_of_camp:\n    '#type': textarea\n    '#title': 'What was the highlight of camp for you?'\n  improve_next_year:\n    '#type': textarea\n    '#title': 'What could we improve for next year?'\n  suggestions_grow_midcamp:\n    '#type': textarea\n    '#title': 'We are always looking for ways to broaden our reach: if you have any suggestions on how to grow MidCamp we’d love to hear them.'\n  other_comments:\n    '#type': textarea\n    '#title': 'Any other comments that you want to share with the organizers of this year''s camp?'\n  email:\n    '#type': email\n    '#title': 'What is your email?'\n  what_is_your_drupal_org_username:\n    '#type': textfield\n    '#title': 'What is your Drupal.org Username?'\n  postal_code_or_zipcode_for_primary_residence:\n    '#type': webform_address\n    '#title': 'Postal Code or Zipcode (for primary residence)'\n    '#address__access': false\n    '#address_2__access': false\n    '#city__access': false\n    '#state_province__access': false\n    '#country__access': false\n  interested_in_helping_organize_midcamp:\n    '#type': radios\n    '#title': 'Are you interested in being a volunteer or helping organize MidCamp next year?'\n    '#options':\n      'Yes': 'Yes'\n      Maybe: Maybe\n      'No': 'No'\n"
+elements: |
+  1:
+    '#type': webform_wizard_page
+    '#title': '1'
+    '#open': true
+    markup_intro:
+      '#type': webform_markup
+      '#markup': 'Thank you for taking this survey. It has 20 questions. We want to make next year&#39;s MidCamp even better and your responses will help inform our strategy for 2018.'
+    first_time_midcamp:
+      '#type': radios
+      '#title': 'First time at Midcamp?'
+      '#options': yes_no
+      '#required': true
+  2:
+    '#type': webform_wizard_page
+    '#title': '2'
+    '#open': true
+    how_did_you_find_out_about_midcamp_:
+      '#type': webform_checkboxes_other
+      '#title': 'How did you find out about MidCamp?'
+      '#description': "<p tabindex=\"-1\">Welcome! Congrats! We&rsquo;re think you&rsquo;re the greatest!!</p>\nHow did you find out about MidCamp? (pick all that apply)\n"
+      '#title_display': before
+      '#description_display': before
+      '#options':
+        Colleague: Colleague
+        'Local drupal org/meetup group': 'Local drupal org/meetup group'
+        Friend: Friend
+        'Drupal.org website': 'Drupal.org website'
+        'Twitter/other social media': 'Twitter/other social media'
+      '#states':
+        invisible:
+          ':input[name="first_time_midcamp"]':
+            '!value': 'Yes'
+    what_is_your_job_:
+      '#type': webform_checkboxes_other
+      '#title': 'What is your job?'
+      '#title_display': before
+      '#options':
+        'Drupal developer': 'Drupal developer'
+        'Developer (other)': 'Developer (other)'
+        'Site Builder': 'Site Builder'
+        'Website Manager': 'Website Manager'
+        'Drupal Project Manager': 'Drupal Project Manager'
+        Designer: Designer
+        Recruiter: Recruiter
+        UXer: UXer
+        'Business Owner': 'Business Owner'
+        Student: Student
+    primary_reason_for_coming:
+      '#type': webform_checkboxes_other
+      '#title': 'Which of the following best describes your primary reason for coming to MidCamp'
+      '#options':
+        'Learn about Drupal 8': 'Learn about Drupal 8'
+        'Meeting clients': 'Meeting clients'
+        'Meeting employers': 'Meeting employers'
+        'Recruiting employees': 'Recruiting employees'
+        'Meeting community members': 'Meeting community members'
+        'Want to build knowledge/learning': 'Want to build knowledge/learning'
+        'Make connections in Drupal Community': 'Make connections in Drupal Community'
+        Training: Training
+        Sprints: Sprints
+        BOFs: BOFs
+    where_did_you_stay_during_camp_:
+      '#type': radios
+      '#title': 'Where did you stay during camp?'
+      '#options':
+        'At my home. I’m local.': 'At my home. I’m local.'
+        'A camp-recommended hotel': 'A camp-recommended hotel'
+        'A rental or hotel elsewhere in the city': 'A rental or hotel elsewhere in the city'
+        'With friends/any free bed': 'With friends/any free bed'
+  3:
+    '#type': webform_wizard_page
+    '#title': '3'
+    '#open': true
+    did_you_attend_any_sessions_:
+      '#type': radios
+      '#title': 'Did you attend any sessions?'
+      '#options': yes_no
+    sessions_worthwhile:
+      '#type': webform_entity_select
+      '#title': 'Which MidCamp sessions did you find most worthwhile?'
+      '#multiple': 5
+      '#multiple_error': 'Please choose no more than 5 favorite sessions!'
+      '#description': 'Please select up to 5 sessions.'
+      '#states':
+        invisible:
+          ':input[name="did_you_attend_any_sessions_"]':
+            '!value': 'Yes'
+      '#target_type': node
+      '#selection_handler': views
+      '#selection_settings':
+        view:
+          view_name: survey_filters
+          display_name: entity_reference_1
+          arguments: {  }
+    speakers_enjoy:
+      '#type': webform_entity_select
+      '#title': 'Which MidCamp speakers did you most enjoy?'
+      '#multiple': 5
+      '#multiple_error': 'Please choose no more than 5 favorite speakers!'
+      '#description': 'Please select up to 5 speakers.'
+      '#options_randomize': true
+      '#states':
+        invisible:
+          ':input[name="did_you_attend_any_sessions_"]':
+            '!value': 'Yes'
+      '#target_type': user
+      '#selection_handler': views
+      '#selection_settings':
+        view:
+          view_name: user_entityreference
+          display_name: entity_reference_1
+          arguments: {  }
+    recommend_midcamp_0_10:
+      '#type': webform_rating
+      '#title': 'On a scale from 0-10, how likely are you to recommend Midcamp to a friend or colleague?'
+      '#max': 10
+      '#reset': true
+    do_you_have_anything_to_say_about_the_food_or_drink_:
+      '#type': radios
+      '#title': 'Do you have anything to say about the food or drink?'
+      '#options': yes_no
+  4:
+    '#type': webform_wizard_page
+    '#title': '4'
+    '#open': true
+    food_satisfaction:
+      '#type': webform_likert
+      '#title': 'Please rate the following on a scale of 1-5 for your satisfaction with the following'
+      '#states':
+        invisible:
+          ':input[name="do_you_have_anything_to_say_about_the_food_or_drink_"]':
+            '!value': 'Yes'
+      '#questions':
+        'Quantity of food': 'Quantity of food'
+        'Quality of food': 'Quality of food'
+        "Variety of food (dietary requirements)\t": "Variety of food (dietary requirements)\t"
+        'Quantity of drinks/coffee': 'Quantity of drinks/coffee'
+      '#answers':
+        "Extremely dissatisfied\t": "Extremely dissatisfied\t"
+        'Somewhat dissatisfied': 'Somewhat dissatisfied'
+        'Neither satisfied nor dissatisfied': 'Neither satisfied nor dissatisfied'
+        'Somewhat satisfied': 'Somewhat satisfied'
+        'Extremely satisfied': 'Extremely satisfied'
+      '#na_answer_text': ''
+    other_comments_food_or_drink:
+      '#type': textarea
+      '#title': 'Any other comments about the food or drink?'
+      '#states':
+        invisible:
+          ':input[name="do_you_have_anything_to_say_about_the_food_or_drink_"]':
+            '!value': 'Yes'
+    rate_experience_at_midcamp_scale_1_5:
+      '#type': webform_likert
+      '#title': 'Please rate your experience at MidCamp on a scale of 1-5, where 1 is very negative and 5 is very positive.'
+      '#questions':
+        'How satisfied were you with the large meeting space?': 'How satisfied were you with the large meeting space?'
+        "How satisfied were you with the set-ups?\t": "How satisfied were you with the set-ups?\t"
+        "How useful were the walking lanes?\t": "How useful were the walking lanes?\t"
+        "How likely are you to come back to MidCamp next year?\t": "How likely are you to come back to MidCamp next year?\t"
+        "How satisfied are you with your experience at MidCamp?\t": "How satisfied are you with your experience at MidCamp?\t"
+      '#answers': likert_satisfaction
+      '#na_answer_text': ''
+    highlight_of_camp:
+      '#type': textarea
+      '#title': 'What was the highlight of camp for you?'
+    improve_next_year:
+      '#type': textarea
+      '#title': 'What could we improve for next year?'
+    suggestions_grow_midcamp:
+      '#type': textarea
+      '#title': 'We are always looking for ways to broaden our reach: if you have any suggestions on how to grow MidCamp we’d love to hear them.'
+    other_comments:
+      '#type': textarea
+      '#title': 'Any other comments that you want to share with the organizers of this year''s camp?'
+    email:
+      '#type': email
+      '#title': 'What is your email?'
+    what_is_your_drupal_org_username:
+      '#type': textfield
+      '#title': 'What is your Drupal.org Username?'
+    postal_code_or_zipcode_for_primary_residence:
+      '#type': webform_address
+      '#title': 'Postal Code or Zipcode (for primary residence)'
+      '#address__access': false
+      '#address_2__access': false
+      '#city__access': false
+      '#state_province__access': false
+      '#country__access': false
+    interested_in_helping_organize_midcamp:
+      '#type': radios
+      '#title': 'Are you interested in being a volunteer or helping organize MidCamp next year?'
+      '#options':
+        'Yes': 'Yes'
+        Maybe: Maybe
+        'No': 'No'
 css: ''
 javascript: ''
 settings:
@@ -27,9 +222,9 @@ settings:
   page_theme_name: ''
   form_title: both
   form_submit_once: true
-  form_exception_message: ''
   form_open_message: ''
   form_close_message: ''
+  form_exception_message: ''
   form_previous_submissions: true
   form_confidential: false
   form_confidential_message: ''
@@ -39,31 +234,36 @@ settings:
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
   form_prepopulate_source_entity_type: ''
-  form_reset: false
+  form_unsaved: true
+  form_disable_back: false
+  form_submit_back: false
   form_disable_autocomplete: false
   form_novalidate: false
   form_disable_inline_errors: false
   form_required: false
-  form_unsaved: true
-  form_disable_back: false
-  form_submit_back: false
   form_autofocus: false
   form_details_toggle: false
+  form_reset: false
   form_access_denied: default
   form_access_denied_title: ''
   form_access_denied_message: ''
   form_access_denied_attributes: {  }
   form_file_limit: ''
+  form_attributes: {  }
   form_method: ''
   form_action: ''
-  form_attributes: {  }
   share: false
   share_node: false
   share_theme_name: ''
   share_title: true
   share_page_body_attributes: {  }
   submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
   submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
   submission_views: {  }
   submission_views_replace: {  }
   submission_user_columns: {  }
@@ -72,11 +272,6 @@ settings:
   submission_access_denied_title: ''
   submission_access_denied_message: ''
   submission_access_denied_attributes: {  }
-  submission_exception_message: ''
-  submission_locked_message: ''
-  submission_excluded_elements: {  }
-  submission_exclude_empty: false
-  submission_exclude_empty_checkbox: false
   previous_submission_message: ''
   previous_submissions_message: ''
   autofill: false
@@ -87,13 +282,13 @@ settings:
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_auto_forward: true
-  wizard_auto_forward_hide_next_button: false
-  wizard_keyboard: true
   wizard_start_label: ''
   wizard_preview_link: false
   wizard_confirmation: true
   wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
   wizard_track: ''
   wizard_prev_button_label: ''
   wizard_next_button_label: ''
@@ -116,9 +311,9 @@ settings:
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
   confirmation_type: page
+  confirmation_url: ''
   confirmation_title: 'Thank you!'
   confirmation_message: 'Thank you for filling out this survey!'
-  confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: true
   confirmation_back_label: ''

--- a/conf/drupal/config/webform.webform.midcamp_2019_survey.yml
+++ b/conf/drupal/config/webform.webform.midcamp_2019_survey.yml
@@ -2,9 +2,9 @@ uuid: 69260f08-31d0-4c28-b6a5-00c5a1fc3c1d
 langcode: en
 status: open
 dependencies: {  }
+weight: 0
 open: null
 close: null
-weight: 0
 uid: 101
 template: false
 archive: false
@@ -12,7 +12,252 @@ id: midcamp_2019_survey
 title: 'Midcamp 2019 Survey'
 description: ''
 category: ''
-elements: "1:\n  '#type': webform_wizard_page\n  '#title': '1'\n  '#open': true\n  markup_intro:\n    '#type': webform_markup\n    '#markup': 'Thank you for taking this survey. It has 25 questions. We want to make next year&#39;s MidCamp even better and your responses will help inform our strategy for 2019.'\n  first_time_midcamp:\n    '#type': radios\n    '#title': 'First time at Midcamp?'\n    '#options': yes_no\n    '#required': true\n2:\n  '#type': webform_wizard_page\n  '#title': '2'\n  '#open': true\n  how_did_you_find_out_about_midcamp_:\n    '#type': webform_checkboxes_other\n    '#title': 'How did you find out about MidCamp?'\n    '#description': \"<p tabindex=\\\"-1\\\">Welcome! Congrats! We&rsquo;re think you&rsquo;re the greatest!!</p>\\nHow did you find out about MidCamp? (pick all that apply)\\n\"\n    '#title_display': before\n    '#description_display': before\n    '#options':\n      Colleague: Colleague\n      'Local drupal org/meetup group': 'Local drupal org/meetup group'\n      Friend: Friend\n      'Drupal.org website': 'Drupal.org website'\n      'Twitter/other social media': 'Twitter/other social media'\n    '#states':\n      invisible:\n        ':input[name=\"first_time_midcamp\"]':\n          '!value': 'Yes'\n  primary_reason_for_coming:\n    '#type': webform_checkboxes_other\n    '#title': 'Which of the following best describes your primary reason for coming to MidCamp?'\n    '#options':\n      'Learn about Drupal 8': 'Learn about Drupal 8'\n      'Meeting clients': 'Meeting clients'\n      'Meeting employers': 'Meeting employers'\n      'Recruiting employees': 'Recruiting employees'\n      'Meeting community members': 'Meeting community members'\n      'Want to build knowledge/learning': 'Want to build knowledge/learning'\n      'Make connections in Drupal Community': 'Make connections in Drupal Community'\n      Training: Training\n      Sprints: Sprints\n      BOFs: BOFs\n  where_did_you_stay_during_camp_:\n    '#type': radios\n    '#title': 'Where did you stay during camp?'\n    '#options':\n      'At my home. I’m local.': 'At my home. I’m local.'\n      'A camp-recommended hotel': 'A camp-recommended hotel'\n      'A rental or hotel elsewhere in the city': 'A rental or hotel elsewhere in the city'\n      'With friends/any free bed': 'With friends/any free bed'\n  what_is_your_job_:\n    '#type': webform_checkboxes_other\n    '#title': 'What is your job?'\n    '#title_display': before\n    '#options':\n      'Drupal developer': 'Drupal developer'\n      'Developer (other)': 'Developer (other)'\n      'Site Builder': 'Site Builder'\n      'Website Manager': 'Website Manager'\n      'Drupal Project Manager': 'Drupal Project Manager'\n      Designer: Designer\n      Recruiter: Recruiter\n      UXer: UXer\n      'Business Owner': 'Business Owner'\n      Student: Student\n  did_you_purchase_your_ticket_personally_or_was_it_purchased_by_a:\n    '#type': radios\n    '#title': 'Did you purchase your ticket personally or was it purchased by a company?'\n    '#options':\n      'I purchased my ticket personally': 'I purchased my ticket personally'\n      'My employer purchased my ticket': 'My employer purchased my ticket'\n      'I used a sponsor or speaker code': 'I used a sponsor or speaker code'\n  do_you_feel_the_ticket_price_is:\n    '#type': radios\n    '#title': 'Do you feel the ticket price is'\n    '#options':\n      'To high': 'To high'\n      'To low': 'To low'\n      'Just right': 'Just right'\n  for_the_price_do_you_feel_like_the_value_of_midcamp_was:\n    '#type': radios\n    '#title': 'For the price, do you feel like the value of MidCamp was'\n    '#options':\n      'MidCamp was more valuable than the cost': 'MidCamp was more valuable than the cost'\n      'MidCamp was less valuable than the cost': 'MidCamp was less valuable than the cost'\n      'MidCamp was equal in value for the cost': 'MidCamp was equal in value for the cost'\n3:\n  '#type': webform_wizard_page\n  '#title': '3'\n  '#open': true\n  did_you_attend_any_sessions_:\n    '#type': radios\n    '#title': 'Did you attend any sessions?'\n    '#options': yes_no\n  sessions_worthwhile:\n    '#type': webform_entity_select\n    '#title': 'Which MidCamp sessions did you find most worthwhile?'\n    '#multiple': 5\n    '#multiple_error': 'Please choose no more than 5 favorite sessions!'\n    '#description': 'Please select up to 5 sessions.'\n    '#states':\n      invisible:\n        ':input[name=\"did_you_attend_any_sessions_\"]':\n          '!value': 'Yes'\n    '#target_type': node\n    '#selection_handler': views\n    '#selection_settings':\n      view:\n        view_name: survey_filters\n        display_name: entity_reference_1\n        arguments: {  }\n  speakers_enjoy:\n    '#type': webform_entity_select\n    '#title': 'Which MidCamp speakers did you most enjoy?'\n    '#multiple': 5\n    '#multiple_error': 'Please choose no more than 5 favorite speakers!'\n    '#description': 'Please select up to 5 speakers.'\n    '#options_randomize': true\n    '#states':\n      invisible:\n        ':input[name=\"did_you_attend_any_sessions_\"]':\n          '!value': 'Yes'\n    '#target_type': user\n    '#selection_handler': views\n    '#selection_settings':\n      view:\n        view_name: speakers\n        display_name: entity_reference_2\n        arguments: {  }\n  recommend_midcamp_0_10:\n    '#type': webform_rating\n    '#title': 'On a scale from 0-10, how likely are you to recommend Midcamp to a friend or colleague?'\n    '#max': 10\n    '#reset': true\n  food_satisfaction:\n    '#type': webform_likert\n    '#title': 'Please rate the following on a scale of 1-5 for your satisfaction with the following.  1 is highly dissatisfied, 5 is highly satisfied.'\n    '#states':\n      invisible:\n        ':input[name=\"do_you_have_anything_to_say_about_the_food_or_drink_\"]':\n          '!value': 'Yes'\n    '#questions':\n      'Quantity of food': 'Quantity of food'\n      'Quality of food': 'Quality of food'\n      \"Variety of food (dietary requirements)\\t\": \"Variety of food (dietary requirements)\\t\"\n      'Quantity of drinks/coffee': 'Quantity of drinks/coffee'\n    '#answers':\n      \"Extremely dissatisfied\\t\": \"Extremely dissatisfied\\t\"\n      'Somewhat dissatisfied': 'Somewhat dissatisfied'\n      'Neither satisfied nor dissatisfied': 'Neither satisfied nor dissatisfied'\n      'Somewhat satisfied': 'Somewhat satisfied'\n      'Extremely satisfied': 'Extremely satisfied'\n    '#na_answer_text': ''\n  other_comments_food_or_drink:\n    '#type': textarea\n    '#title': 'Any other comments about the food or drink?'\n    '#states':\n      invisible:\n        ':input[name=\"do_you_have_anything_to_say_about_the_food_or_drink_\"]':\n          '!value': 'Yes'\n  please_rate_the_following_on_a_scale_of_1_5_for_your_satisfactio:\n    '#type': webform_likert\n    '#title': 'Please rate the following on a scale of 1-5 for your satisfaction with the following'\n    '#states':\n      invisible:\n        ':input[name=\"do_you_have_anything_to_say_about_the_food_or_drink_\"]':\n          '!value': 'Yes'\n    '#questions':\n      Sessions: Sessions\n      'Birds of a Feather (BoFs)': 'Birds of a Feather (BoFs)'\n      'Welcome Party': 'Welcome Party'\n      'Game Night': 'Game Night'\n      'Closing Party': 'Closing Party'\n      'Contrib Day Training': 'Contrib Day Training'\n      'Contribution Day': 'Contribution Day'\n    '#answers': likert_five_scale\n    '#na_answer_text': ''\n  any_other_comments_about_sessions_bofs_socials_keynote_or_contri:\n    '#type': textarea\n    '#title': 'Any other comments about sessions, BoFs, socials, Keynote, or Contribution Day?'\n    '#states':\n      invisible:\n        ':input[name=\"do_you_have_anything_to_say_about_the_food_or_drink_\"]':\n          '!value': 'Yes'\n4:\n  '#type': webform_wizard_page\n  '#title': '4'\n  '#open': true\n  rate_experience_at_midcamp_scale_1_5:\n    '#type': webform_likert\n    '#title': 'Please rate your experience at MidCamp on a scale of 1-5, where 1 is very negative and 5 is very positive.'\n    '#questions':\n      'How satisfied were you with the large meeting space?': 'How satisfied were you with the large meeting space?'\n      \"How satisfied were you with the set-ups?\\t\": \"How satisfied were you with the set-ups?\\t\"\n      \"How useful were the walking lanes?\\t\": \"How useful were the walking lanes?\\t\"\n      \"How likely are you to come back to MidCamp next year?\\t\": \"How likely are you to come back to MidCamp next year?\\t\"\n      \"How satisfied are you with your experience at MidCamp?\\t\": \"How satisfied are you with your experience at MidCamp?\\t\"\n    '#answers': likert_five_scale\n    '#na_answer_text': ''\n  highlight_of_camp:\n    '#type': textarea\n    '#title': 'What was the highlight of camp for you?'\n  improve_next_year:\n    '#type': textarea\n    '#title': 'What could we improve for next year?'\n  suggestions_grow_midcamp:\n    '#type': textarea\n    '#title': 'We are always looking for ways to broaden our reach: if you have any suggestions on how to grow MidCamp we’d love to hear them.'\n  other_comments:\n    '#type': textarea\n    '#title': 'Any other comments that you want to share with the organizers of this year''s camp?'\n  was_the_booklet_in_your_name_badge_useful_:\n    '#type': select\n    '#title': 'Was the booklet in your name badge useful?'\n    '#options':\n      'Yes. The booklet was important.': 'Yes. The booklet was important.'\n      'I don''t mind if we get rid of the booklet.': 'I don''t mind if we get rid of the booklet.'\n6:\n  '#type': webform_wizard_page\n  '#title': '5'\n  email:\n    '#type': email\n    '#title': 'What is your email?'\n  what_is_your_drupal_org_username:\n    '#type': textfield\n    '#title': 'What is your Drupal.org Username?'\n  postal_code_or_zipcode_for_primary_residence:\n    '#type': webform_address\n    '#title': 'Postal Code or Zipcode (for primary residence)'\n    '#address__access': false\n    '#address_2__access': false\n    '#city__access': false\n    '#state_province__access': false\n    '#country__access': false\n  interested_in_helping_organize_midcamp:\n    '#type': radios\n    '#title': 'Are you interested in being a volunteer or helping organize MidCamp next year?'\n    '#options':\n      'Yes': 'Yes'\n      Maybe: Maybe\n      'No': 'No'\n"
+elements: |
+  1:
+    '#type': webform_wizard_page
+    '#title': '1'
+    '#open': true
+    markup_intro:
+      '#type': webform_markup
+      '#markup': 'Thank you for taking this survey. It has 25 questions. We want to make next year&#39;s MidCamp even better and your responses will help inform our strategy for 2019.'
+    first_time_midcamp:
+      '#type': radios
+      '#title': 'First time at Midcamp?'
+      '#options': yes_no
+      '#required': true
+  2:
+    '#type': webform_wizard_page
+    '#title': '2'
+    '#open': true
+    how_did_you_find_out_about_midcamp_:
+      '#type': webform_checkboxes_other
+      '#title': 'How did you find out about MidCamp?'
+      '#description': "<p tabindex=\"-1\">Welcome! Congrats! We&rsquo;re think you&rsquo;re the greatest!!</p>\nHow did you find out about MidCamp? (pick all that apply)\n"
+      '#title_display': before
+      '#description_display': before
+      '#options':
+        Colleague: Colleague
+        'Local drupal org/meetup group': 'Local drupal org/meetup group'
+        Friend: Friend
+        'Drupal.org website': 'Drupal.org website'
+        'Twitter/other social media': 'Twitter/other social media'
+      '#states':
+        invisible:
+          ':input[name="first_time_midcamp"]':
+            '!value': 'Yes'
+    primary_reason_for_coming:
+      '#type': webform_checkboxes_other
+      '#title': 'Which of the following best describes your primary reason for coming to MidCamp?'
+      '#options':
+        'Learn about Drupal 8': 'Learn about Drupal 8'
+        'Meeting clients': 'Meeting clients'
+        'Meeting employers': 'Meeting employers'
+        'Recruiting employees': 'Recruiting employees'
+        'Meeting community members': 'Meeting community members'
+        'Want to build knowledge/learning': 'Want to build knowledge/learning'
+        'Make connections in Drupal Community': 'Make connections in Drupal Community'
+        Training: Training
+        Sprints: Sprints
+        BOFs: BOFs
+    where_did_you_stay_during_camp_:
+      '#type': radios
+      '#title': 'Where did you stay during camp?'
+      '#options':
+        'At my home. I’m local.': 'At my home. I’m local.'
+        'A camp-recommended hotel': 'A camp-recommended hotel'
+        'A rental or hotel elsewhere in the city': 'A rental or hotel elsewhere in the city'
+        'With friends/any free bed': 'With friends/any free bed'
+    what_is_your_job_:
+      '#type': webform_checkboxes_other
+      '#title': 'What is your job?'
+      '#title_display': before
+      '#options':
+        'Drupal developer': 'Drupal developer'
+        'Developer (other)': 'Developer (other)'
+        'Site Builder': 'Site Builder'
+        'Website Manager': 'Website Manager'
+        'Drupal Project Manager': 'Drupal Project Manager'
+        Designer: Designer
+        Recruiter: Recruiter
+        UXer: UXer
+        'Business Owner': 'Business Owner'
+        Student: Student
+    did_you_purchase_your_ticket_personally_or_was_it_purchased_by_a:
+      '#type': radios
+      '#title': 'Did you purchase your ticket personally or was it purchased by a company?'
+      '#options':
+        'I purchased my ticket personally': 'I purchased my ticket personally'
+        'My employer purchased my ticket': 'My employer purchased my ticket'
+        'I used a sponsor or speaker code': 'I used a sponsor or speaker code'
+    do_you_feel_the_ticket_price_is:
+      '#type': radios
+      '#title': 'Do you feel the ticket price is'
+      '#options':
+        'To high': 'To high'
+        'To low': 'To low'
+        'Just right': 'Just right'
+    for_the_price_do_you_feel_like_the_value_of_midcamp_was:
+      '#type': radios
+      '#title': 'For the price, do you feel like the value of MidCamp was'
+      '#options':
+        'MidCamp was more valuable than the cost': 'MidCamp was more valuable than the cost'
+        'MidCamp was less valuable than the cost': 'MidCamp was less valuable than the cost'
+        'MidCamp was equal in value for the cost': 'MidCamp was equal in value for the cost'
+  3:
+    '#type': webform_wizard_page
+    '#title': '3'
+    '#open': true
+    did_you_attend_any_sessions_:
+      '#type': radios
+      '#title': 'Did you attend any sessions?'
+      '#options': yes_no
+    sessions_worthwhile:
+      '#type': webform_entity_select
+      '#title': 'Which MidCamp sessions did you find most worthwhile?'
+      '#multiple': 5
+      '#multiple_error': 'Please choose no more than 5 favorite sessions!'
+      '#description': 'Please select up to 5 sessions.'
+      '#states':
+        invisible:
+          ':input[name="did_you_attend_any_sessions_"]':
+            '!value': 'Yes'
+      '#target_type': node
+      '#selection_handler': views
+      '#selection_settings':
+        view:
+          view_name: survey_filters
+          display_name: entity_reference_1
+          arguments: {  }
+    speakers_enjoy:
+      '#type': webform_entity_select
+      '#title': 'Which MidCamp speakers did you most enjoy?'
+      '#multiple': 5
+      '#multiple_error': 'Please choose no more than 5 favorite speakers!'
+      '#description': 'Please select up to 5 speakers.'
+      '#options_randomize': true
+      '#states':
+        invisible:
+          ':input[name="did_you_attend_any_sessions_"]':
+            '!value': 'Yes'
+      '#target_type': user
+      '#selection_handler': views
+      '#selection_settings':
+        view:
+          view_name: speakers
+          display_name: entity_reference_2
+          arguments: {  }
+    recommend_midcamp_0_10:
+      '#type': webform_rating
+      '#title': 'On a scale from 0-10, how likely are you to recommend Midcamp to a friend or colleague?'
+      '#max': 10
+      '#reset': true
+    food_satisfaction:
+      '#type': webform_likert
+      '#title': 'Please rate the following on a scale of 1-5 for your satisfaction with the following.  1 is highly dissatisfied, 5 is highly satisfied.'
+      '#states':
+        invisible:
+          ':input[name="do_you_have_anything_to_say_about_the_food_or_drink_"]':
+            '!value': 'Yes'
+      '#questions':
+        'Quantity of food': 'Quantity of food'
+        'Quality of food': 'Quality of food'
+        "Variety of food (dietary requirements)\t": "Variety of food (dietary requirements)\t"
+        'Quantity of drinks/coffee': 'Quantity of drinks/coffee'
+      '#answers':
+        "Extremely dissatisfied\t": "Extremely dissatisfied\t"
+        'Somewhat dissatisfied': 'Somewhat dissatisfied'
+        'Neither satisfied nor dissatisfied': 'Neither satisfied nor dissatisfied'
+        'Somewhat satisfied': 'Somewhat satisfied'
+        'Extremely satisfied': 'Extremely satisfied'
+      '#na_answer_text': ''
+    other_comments_food_or_drink:
+      '#type': textarea
+      '#title': 'Any other comments about the food or drink?'
+      '#states':
+        invisible:
+          ':input[name="do_you_have_anything_to_say_about_the_food_or_drink_"]':
+            '!value': 'Yes'
+    please_rate_the_following_on_a_scale_of_1_5_for_your_satisfactio:
+      '#type': webform_likert
+      '#title': 'Please rate the following on a scale of 1-5 for your satisfaction with the following'
+      '#states':
+        invisible:
+          ':input[name="do_you_have_anything_to_say_about_the_food_or_drink_"]':
+            '!value': 'Yes'
+      '#questions':
+        Sessions: Sessions
+        'Birds of a Feather (BoFs)': 'Birds of a Feather (BoFs)'
+        'Welcome Party': 'Welcome Party'
+        'Game Night': 'Game Night'
+        'Closing Party': 'Closing Party'
+        'Contrib Day Training': 'Contrib Day Training'
+        'Contribution Day': 'Contribution Day'
+      '#answers': likert_five_scale
+      '#na_answer_text': ''
+    any_other_comments_about_sessions_bofs_socials_keynote_or_contri:
+      '#type': textarea
+      '#title': 'Any other comments about sessions, BoFs, socials, Keynote, or Contribution Day?'
+      '#states':
+        invisible:
+          ':input[name="do_you_have_anything_to_say_about_the_food_or_drink_"]':
+            '!value': 'Yes'
+  4:
+    '#type': webform_wizard_page
+    '#title': '4'
+    '#open': true
+    rate_experience_at_midcamp_scale_1_5:
+      '#type': webform_likert
+      '#title': 'Please rate your experience at MidCamp on a scale of 1-5, where 1 is very negative and 5 is very positive.'
+      '#questions':
+        'How satisfied were you with the large meeting space?': 'How satisfied were you with the large meeting space?'
+        "How satisfied were you with the set-ups?\t": "How satisfied were you with the set-ups?\t"
+        "How useful were the walking lanes?\t": "How useful were the walking lanes?\t"
+        "How likely are you to come back to MidCamp next year?\t": "How likely are you to come back to MidCamp next year?\t"
+        "How satisfied are you with your experience at MidCamp?\t": "How satisfied are you with your experience at MidCamp?\t"
+      '#answers': likert_five_scale
+      '#na_answer_text': ''
+    highlight_of_camp:
+      '#type': textarea
+      '#title': 'What was the highlight of camp for you?'
+    improve_next_year:
+      '#type': textarea
+      '#title': 'What could we improve for next year?'
+    suggestions_grow_midcamp:
+      '#type': textarea
+      '#title': 'We are always looking for ways to broaden our reach: if you have any suggestions on how to grow MidCamp we’d love to hear them.'
+    other_comments:
+      '#type': textarea
+      '#title': 'Any other comments that you want to share with the organizers of this year''s camp?'
+    was_the_booklet_in_your_name_badge_useful_:
+      '#type': select
+      '#title': 'Was the booklet in your name badge useful?'
+      '#options':
+        'Yes. The booklet was important.': 'Yes. The booklet was important.'
+        'I don''t mind if we get rid of the booklet.': 'I don''t mind if we get rid of the booklet.'
+  6:
+    '#type': webform_wizard_page
+    '#title': '5'
+    email:
+      '#type': email
+      '#title': 'What is your email?'
+    what_is_your_drupal_org_username:
+      '#type': textfield
+      '#title': 'What is your Drupal.org Username?'
+    postal_code_or_zipcode_for_primary_residence:
+      '#type': webform_address
+      '#title': 'Postal Code or Zipcode (for primary residence)'
+      '#address__access': false
+      '#address_2__access': false
+      '#city__access': false
+      '#state_province__access': false
+      '#country__access': false
+    interested_in_helping_organize_midcamp:
+      '#type': radios
+      '#title': 'Are you interested in being a volunteer or helping organize MidCamp next year?'
+      '#options':
+        'Yes': 'Yes'
+        Maybe: Maybe
+        'No': 'No'
 css: ''
 javascript: ''
 settings:
@@ -27,9 +272,9 @@ settings:
   page_theme_name: ''
   form_title: both
   form_submit_once: true
-  form_exception_message: ''
   form_open_message: ''
   form_close_message: ''
+  form_exception_message: ''
   form_previous_submissions: true
   form_confidential: false
   form_confidential_message: ''
@@ -39,31 +284,36 @@ settings:
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
   form_prepopulate_source_entity_type: ''
-  form_reset: false
+  form_unsaved: true
+  form_disable_back: false
+  form_submit_back: false
   form_disable_autocomplete: false
   form_novalidate: false
   form_disable_inline_errors: false
   form_required: false
-  form_unsaved: true
-  form_disable_back: false
-  form_submit_back: false
   form_autofocus: false
   form_details_toggle: false
+  form_reset: false
   form_access_denied: default
   form_access_denied_title: ''
   form_access_denied_message: ''
   form_access_denied_attributes: {  }
   form_file_limit: ''
+  form_attributes: {  }
   form_method: ''
   form_action: ''
-  form_attributes: {  }
   share: false
   share_node: false
   share_theme_name: ''
   share_title: true
   share_page_body_attributes: {  }
   submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
   submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
   submission_views: {  }
   submission_views_replace: {  }
   submission_user_columns: {  }
@@ -72,11 +322,6 @@ settings:
   submission_access_denied_title: ''
   submission_access_denied_message: ''
   submission_access_denied_attributes: {  }
-  submission_exception_message: ''
-  submission_locked_message: ''
-  submission_excluded_elements: {  }
-  submission_exclude_empty: false
-  submission_exclude_empty_checkbox: false
   previous_submission_message: ''
   previous_submissions_message: ''
   autofill: false
@@ -87,13 +332,13 @@ settings:
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_auto_forward: true
-  wizard_auto_forward_hide_next_button: false
-  wizard_keyboard: true
   wizard_start_label: ''
   wizard_preview_link: false
   wizard_confirmation: true
   wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
   wizard_track: ''
   wizard_prev_button_label: ''
   wizard_next_button_label: ''
@@ -116,9 +361,9 @@ settings:
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
   confirmation_type: page
+  confirmation_url: ''
   confirmation_title: 'Thank you!'
   confirmation_message: 'Thank you for filling out this survey!'
-  confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: true
   confirmation_back_label: ''

--- a/conf/drupal/config/webform.webform.midcamp_2020_survey.yml
+++ b/conf/drupal/config/webform.webform.midcamp_2020_survey.yml
@@ -2,9 +2,9 @@ uuid: c0162bd0-1af1-460d-a3c0-44a2047c7349
 langcode: en
 status: closed
 dependencies: {  }
+weight: 0
 open: null
 close: null
-weight: 0
 uid: 13
 template: false
 archive: false
@@ -12,7 +12,237 @@ id: midcamp_2020_survey
 title: 'Midcamp 2020 Survey'
 description: ''
 category: ''
-elements: "1:\n  '#type': webform_wizard_page\n  '#title': '1'\n  '#open': true\n  markup_intro:\n    '#type': webform_markup\n    '#markup': 'Thank you for taking this survey. It will take about 5 minutes to complete. We want to make next year&#39;s MidCamp even better and your responses will help inform our strategy for 2021.'\n  first_time_midcamp:\n    '#type': radios\n    '#title': 'First time at Midcamp?'\n    '#options': yes_no\n    '#required': true\n2:\n  '#type': webform_wizard_page\n  '#title': '2'\n  '#open': true\n  how_did_you_find_out_about_midcamp_:\n    '#type': webform_checkboxes_other\n    '#title': 'How did you find out about MidCamp?'\n    '#title_display': before\n    '#description_display': before\n    '#options':\n      Colleague: Colleague\n      'Local drupal org/meetup group': 'Local drupal org/meetup group'\n      Friend: Friend\n      'Drupal.org website': 'Drupal.org website'\n      'Twitter/other social media': 'Twitter/other social media'\n    '#states':\n      invisible:\n        ':input[name=\"first_time_midcamp\"]':\n          '!value': 'Yes'\n  primary_reason_for_coming:\n    '#type': webform_checkboxes_other\n    '#title': 'Which of the following best describes your primary reason for coming to MidCamp?'\n    '#options':\n      'Learn about Drupal 8': 'Learn about Drupal 8'\n      'Meeting clients': 'Meeting clients'\n      'Meeting employers': 'Meeting employers'\n      'Recruiting employees': 'Recruiting employees'\n      'Meeting community members': 'Meeting community members'\n      'Want to build knowledge/learning': 'Want to build knowledge/learning'\n      'Make connections in Drupal Community': 'Make connections in Drupal Community'\n      Training: Training\n      Sprints: Sprints\n      BOFs: BOFs\n  what_is_your_job_:\n    '#type': webform_checkboxes_other\n    '#title': 'What is your job?'\n    '#title_display': before\n    '#options':\n      'Drupal developer': 'Drupal developer'\n      'Developer (other)': 'Developer (other)'\n      'Site Builder': 'Site Builder'\n      'Website Manager': 'Website Manager'\n      'Drupal Project Manager': 'Drupal Project Manager'\n      Designer: Designer\n      Recruiter: Recruiter\n      UXer: UXer\n      'Business Owner': 'Business Owner'\n      Student: Student\n3:\n  '#type': webform_wizard_page\n  '#title': '3'\n  '#open': true\n  did_you_attend_any_sessions_:\n    '#type': radios\n    '#title': 'Did you attend any sessions?'\n    '#options': yes_no\n  sessions_worthwhile:\n    '#type': webform_entity_select\n    '#title': 'Which MidCamp sessions did you find most worthwhile?'\n    '#multiple': 5\n    '#multiple_error': 'Please choose no more than 5 favorite sessions!'\n    '#description': 'Please select up to 5 sessions.'\n    '#states':\n      invisible:\n        ':input[name=\"did_you_attend_any_sessions_\"]':\n          '!value': 'Yes'\n    '#target_type': node\n    '#selection_handler': views\n    '#selection_settings':\n      view:\n        view_name: survey_filters\n        display_name: entity_reference_1\n        arguments: {  }\n  speakers_enjoy:\n    '#type': webform_entity_select\n    '#title': 'Which MidCamp speakers did you most enjoy?'\n    '#multiple': 5\n    '#multiple_error': 'Please choose no more than 5 favorite speakers!'\n    '#description': 'Please select up to 5 speakers.'\n    '#options_randomize': true\n    '#states':\n      invisible:\n        ':input[name=\"did_you_attend_any_sessions_\"]':\n          '!value': 'Yes'\n    '#target_type': user\n    '#selection_handler': views\n    '#selection_settings':\n      view:\n        view_name: speakers\n        display_name: entity_reference_3\n        arguments: {  }\n  recommend_midcamp_0_10:\n    '#type': webform_rating\n    '#title': 'On a scale from 0-10, how likely are you to recommend Midcamp to a friend or colleague?'\n    '#max': 10\n    '#reset': true\n  please_rate_the_following_on_a_scale_of_1_5_for_your_satisfactio:\n    '#type': webform_likert\n    '#title': 'Please rate your satisfaction of the following on a scale of 1-5 (where 1 is very negative and 5 is very positive)'\n    '#states':\n      invisible:\n        ':input[name=\"do_you_have_anything_to_say_about_the_food_or_drink_\"]':\n          '!value': 'Yes'\n    '#questions':\n      Sessions: Sessions\n      '\"Hallway\"': '\"Hallway\"'\n      'Virtual Game Night': 'Virtual Game Night'\n      'Virtual Movie Night': 'Virtual Movie Night'\n      'Contrib Day Training': 'Contrib Day Training'\n      'Contribution Day': 'Contribution Day'\n    '#answers': likert_five_scale\n    '#na_answer_text': ''\n  any_other_comments_about_sessions_bofs_socials_keynote_or_contri:\n    '#type': textarea\n    '#title': 'Any other comments about sessions, hallway, socials, or Contribution Day?'\n    '#states':\n      invisible:\n        ':input[name=\"do_you_have_anything_to_say_about_the_food_or_drink_\"]':\n          '!value': 'Yes'\n4:\n  '#type': webform_wizard_page\n  '#title': '4'\n  '#open': true\n  rate_experience_at_midcamp_scale_1_5:\n    '#type': webform_likert\n    '#title': 'Please rate your experience at MidCamp on a scale of 1-5, where 1 is very negative and 5 is very positive.'\n    '#questions':\n      'How satisfied are you with our communication?': 'How satisfied are you with our communication? -- Emails, website, socials, etc.'\n      'How satisfied are you with the virtual tools?': 'How satisfied are you with the virtual tools? -- Zoom, Slack, Discord.'\n      'How likely are you to come back to MidCamp next year?': 'How likely are you to come back to MidCamp next year?'\n      'How satisfied are you with your experience at MidCamp?': 'How satisfied are you with your experience at MidCamp?'\n    '#answers': likert_five_scale\n    '#na_answer_text': ''\n  highlight_of_camp:\n    '#type': textarea\n    '#title': 'What was the highlight of camp for you?'\n  improve_next_year:\n    '#type': textarea\n    '#title': 'What could we improve for next year?'\n  suggestions_grow_midcamp:\n    '#type': textarea\n    '#title': 'We are always looking for ways to broaden our reach: if you have any suggestions on how to grow MidCamp we’d love to hear them.'\n  other_comments:\n    '#type': textarea\n    '#title': 'Any other comments that you want to share with the organizers of this year''s camp?'\n5:\n  '#type': webform_wizard_page\n  '#title': '5'\n  were_you_previously_planning_on_attending_midcamp_in_person_this:\n    '#type': radios\n    '#title': 'Were you planning on attending MidCamp in person this year?'\n    '#options': yes_no\n  what_did_you_think_of_the_virtual_event_overall_:\n    '#type': radios\n    '#title': 'What did you think of the virtual event overall?'\n    '#options': likert_quality\n  what_could_we_do_to_improve_the_virtual_experience_:\n    '#type': textarea\n    '#title': 'What could we do to improve the virtual experience?'\n  would_you_attend_a_hybrid_event_both_in_person_and_digital_:\n    '#type': radios\n    '#title': 'Would you attend a hybrid event (both in-person and digital)?'\n    '#options': likert_would_you\n  if_you_purchased_a_ticket_for_the_live_event_which_did_you_purch:\n    '#type': radios\n    '#title': 'Thinking about an in-person event (as previously planned), which ticket would you be most likely to purchase?'\n    '#options':\n      'The Worm (Early Bird, $50)': 'The Worm (Early Bird, $50)'\n      'Alice (Regular, $100)': 'Alice (Regular, $100)'\n      'The Rabbit (Last-minute, $200)': 'The Rabbit (Last-minute, $200)'\n      'Student ($25)': 'Student ($25)'\n      'Sponsored ($0)': 'Sponsored ($0)'\n  thinking_about_a_virtual_event_as_happened_which_ticket_would_yo:\n    '#type': radios\n    '#title': 'Thinking about a virtual event (as happened), which ticket would you be most likely to purchase?'\n    '#options':\n      'The Worm (Early Bird, $50)': 'The Worm (Early Bird, $50)'\n      'Alice (Regular, $100)': 'Alice (Regular, $100)'\n      'The Rabbit (Last-minute, $200)': 'The Rabbit (Last-minute, $200)'\n      'Student ($25)': 'Student ($25)'\n      'Sponsored ($0)': 'Sponsored ($0)'\n  please_let_us_know_what_you_thought_of_our_new_pricing_structure:\n    '#type': textarea\n    '#title': 'Please let us know what you thought of our new pricing structure for the in-person event.'\n    '#description': |\n      The structure was:\n      <ul>\n      \t<li>Early Bird - $50 - through Dec 31</li>\n      \t<li>Regular - $100 - Jan 1 - Feb 29</li>\n      \t<li>Last-minute - $200 - March 1 - event</li>\n      \t<li>Student - $25 - always</li>\n      \t<li>Sponsored - $0 - always</li>\n      </ul>\n      \n6:\n  '#type': webform_wizard_page\n  '#title': '6'\n  email:\n    '#type': email\n    '#title': 'What is your email?'\n  what_is_your_drupal_org_username:\n    '#type': textfield\n    '#title': 'What is your Drupal.org Username?'\n  postal_code_or_zipcode_for_primary_residence:\n    '#type': webform_address\n    '#title': 'Postal Code or Zipcode (for primary residence)'\n    '#address__access': false\n    '#address_2__access': false\n    '#city__access': false\n    '#state_province__access': false\n    '#country__access': false\n  interested_in_helping_organize_midcamp:\n    '#type': radios\n    '#title': 'Are you interested in being a volunteer or helping organize MidCamp next year?'\n    '#options':\n      'Yes': 'Yes'\n      Maybe: Maybe\n      'No': 'No'"
+elements: |-
+  1:
+    '#type': webform_wizard_page
+    '#title': '1'
+    '#open': true
+    markup_intro:
+      '#type': webform_markup
+      '#markup': 'Thank you for taking this survey. It will take about 5 minutes to complete. We want to make next year&#39;s MidCamp even better and your responses will help inform our strategy for 2021.'
+    first_time_midcamp:
+      '#type': radios
+      '#title': 'First time at Midcamp?'
+      '#options': yes_no
+      '#required': true
+  2:
+    '#type': webform_wizard_page
+    '#title': '2'
+    '#open': true
+    how_did_you_find_out_about_midcamp_:
+      '#type': webform_checkboxes_other
+      '#title': 'How did you find out about MidCamp?'
+      '#title_display': before
+      '#description_display': before
+      '#options':
+        Colleague: Colleague
+        'Local drupal org/meetup group': 'Local drupal org/meetup group'
+        Friend: Friend
+        'Drupal.org website': 'Drupal.org website'
+        'Twitter/other social media': 'Twitter/other social media'
+      '#states':
+        invisible:
+          ':input[name="first_time_midcamp"]':
+            '!value': 'Yes'
+    primary_reason_for_coming:
+      '#type': webform_checkboxes_other
+      '#title': 'Which of the following best describes your primary reason for coming to MidCamp?'
+      '#options':
+        'Learn about Drupal 8': 'Learn about Drupal 8'
+        'Meeting clients': 'Meeting clients'
+        'Meeting employers': 'Meeting employers'
+        'Recruiting employees': 'Recruiting employees'
+        'Meeting community members': 'Meeting community members'
+        'Want to build knowledge/learning': 'Want to build knowledge/learning'
+        'Make connections in Drupal Community': 'Make connections in Drupal Community'
+        Training: Training
+        Sprints: Sprints
+        BOFs: BOFs
+    what_is_your_job_:
+      '#type': webform_checkboxes_other
+      '#title': 'What is your job?'
+      '#title_display': before
+      '#options':
+        'Drupal developer': 'Drupal developer'
+        'Developer (other)': 'Developer (other)'
+        'Site Builder': 'Site Builder'
+        'Website Manager': 'Website Manager'
+        'Drupal Project Manager': 'Drupal Project Manager'
+        Designer: Designer
+        Recruiter: Recruiter
+        UXer: UXer
+        'Business Owner': 'Business Owner'
+        Student: Student
+  3:
+    '#type': webform_wizard_page
+    '#title': '3'
+    '#open': true
+    did_you_attend_any_sessions_:
+      '#type': radios
+      '#title': 'Did you attend any sessions?'
+      '#options': yes_no
+    sessions_worthwhile:
+      '#type': webform_entity_select
+      '#title': 'Which MidCamp sessions did you find most worthwhile?'
+      '#multiple': 5
+      '#multiple_error': 'Please choose no more than 5 favorite sessions!'
+      '#description': 'Please select up to 5 sessions.'
+      '#states':
+        invisible:
+          ':input[name="did_you_attend_any_sessions_"]':
+            '!value': 'Yes'
+      '#target_type': node
+      '#selection_handler': views
+      '#selection_settings':
+        view:
+          view_name: survey_filters
+          display_name: entity_reference_1
+          arguments: {  }
+    speakers_enjoy:
+      '#type': webform_entity_select
+      '#title': 'Which MidCamp speakers did you most enjoy?'
+      '#multiple': 5
+      '#multiple_error': 'Please choose no more than 5 favorite speakers!'
+      '#description': 'Please select up to 5 speakers.'
+      '#options_randomize': true
+      '#states':
+        invisible:
+          ':input[name="did_you_attend_any_sessions_"]':
+            '!value': 'Yes'
+      '#target_type': user
+      '#selection_handler': views
+      '#selection_settings':
+        view:
+          view_name: speakers
+          display_name: entity_reference_3
+          arguments: {  }
+    recommend_midcamp_0_10:
+      '#type': webform_rating
+      '#title': 'On a scale from 0-10, how likely are you to recommend Midcamp to a friend or colleague?'
+      '#max': 10
+      '#reset': true
+    please_rate_the_following_on_a_scale_of_1_5_for_your_satisfactio:
+      '#type': webform_likert
+      '#title': 'Please rate your satisfaction of the following on a scale of 1-5 (where 1 is very negative and 5 is very positive)'
+      '#states':
+        invisible:
+          ':input[name="do_you_have_anything_to_say_about_the_food_or_drink_"]':
+            '!value': 'Yes'
+      '#questions':
+        Sessions: Sessions
+        '"Hallway"': '"Hallway"'
+        'Virtual Game Night': 'Virtual Game Night'
+        'Virtual Movie Night': 'Virtual Movie Night'
+        'Contrib Day Training': 'Contrib Day Training'
+        'Contribution Day': 'Contribution Day'
+      '#answers': likert_five_scale
+      '#na_answer_text': ''
+    any_other_comments_about_sessions_bofs_socials_keynote_or_contri:
+      '#type': textarea
+      '#title': 'Any other comments about sessions, hallway, socials, or Contribution Day?'
+      '#states':
+        invisible:
+          ':input[name="do_you_have_anything_to_say_about_the_food_or_drink_"]':
+            '!value': 'Yes'
+  4:
+    '#type': webform_wizard_page
+    '#title': '4'
+    '#open': true
+    rate_experience_at_midcamp_scale_1_5:
+      '#type': webform_likert
+      '#title': 'Please rate your experience at MidCamp on a scale of 1-5, where 1 is very negative and 5 is very positive.'
+      '#questions':
+        'How satisfied are you with our communication?': 'How satisfied are you with our communication? -- Emails, website, socials, etc.'
+        'How satisfied are you with the virtual tools?': 'How satisfied are you with the virtual tools? -- Zoom, Slack, Discord.'
+        'How likely are you to come back to MidCamp next year?': 'How likely are you to come back to MidCamp next year?'
+        'How satisfied are you with your experience at MidCamp?': 'How satisfied are you with your experience at MidCamp?'
+      '#answers': likert_five_scale
+      '#na_answer_text': ''
+    highlight_of_camp:
+      '#type': textarea
+      '#title': 'What was the highlight of camp for you?'
+    improve_next_year:
+      '#type': textarea
+      '#title': 'What could we improve for next year?'
+    suggestions_grow_midcamp:
+      '#type': textarea
+      '#title': 'We are always looking for ways to broaden our reach: if you have any suggestions on how to grow MidCamp we’d love to hear them.'
+    other_comments:
+      '#type': textarea
+      '#title': 'Any other comments that you want to share with the organizers of this year''s camp?'
+  5:
+    '#type': webform_wizard_page
+    '#title': '5'
+    were_you_previously_planning_on_attending_midcamp_in_person_this:
+      '#type': radios
+      '#title': 'Were you planning on attending MidCamp in person this year?'
+      '#options': yes_no
+    what_did_you_think_of_the_virtual_event_overall_:
+      '#type': radios
+      '#title': 'What did you think of the virtual event overall?'
+      '#options': likert_quality
+    what_could_we_do_to_improve_the_virtual_experience_:
+      '#type': textarea
+      '#title': 'What could we do to improve the virtual experience?'
+    would_you_attend_a_hybrid_event_both_in_person_and_digital_:
+      '#type': radios
+      '#title': 'Would you attend a hybrid event (both in-person and digital)?'
+      '#options': likert_would_you
+    if_you_purchased_a_ticket_for_the_live_event_which_did_you_purch:
+      '#type': radios
+      '#title': 'Thinking about an in-person event (as previously planned), which ticket would you be most likely to purchase?'
+      '#options':
+        'The Worm (Early Bird, $50)': 'The Worm (Early Bird, $50)'
+        'Alice (Regular, $100)': 'Alice (Regular, $100)'
+        'The Rabbit (Last-minute, $200)': 'The Rabbit (Last-minute, $200)'
+        'Student ($25)': 'Student ($25)'
+        'Sponsored ($0)': 'Sponsored ($0)'
+    thinking_about_a_virtual_event_as_happened_which_ticket_would_yo:
+      '#type': radios
+      '#title': 'Thinking about a virtual event (as happened), which ticket would you be most likely to purchase?'
+      '#options':
+        'The Worm (Early Bird, $50)': 'The Worm (Early Bird, $50)'
+        'Alice (Regular, $100)': 'Alice (Regular, $100)'
+        'The Rabbit (Last-minute, $200)': 'The Rabbit (Last-minute, $200)'
+        'Student ($25)': 'Student ($25)'
+        'Sponsored ($0)': 'Sponsored ($0)'
+    please_let_us_know_what_you_thought_of_our_new_pricing_structure:
+      '#type': textarea
+      '#title': 'Please let us know what you thought of our new pricing structure for the in-person event.'
+      '#description': |
+        The structure was:
+        <ul>
+        	<li>Early Bird - $50 - through Dec 31</li>
+        	<li>Regular - $100 - Jan 1 - Feb 29</li>
+        	<li>Last-minute - $200 - March 1 - event</li>
+        	<li>Student - $25 - always</li>
+        	<li>Sponsored - $0 - always</li>
+        </ul>
+        
+  6:
+    '#type': webform_wizard_page
+    '#title': '6'
+    email:
+      '#type': email
+      '#title': 'What is your email?'
+    what_is_your_drupal_org_username:
+      '#type': textfield
+      '#title': 'What is your Drupal.org Username?'
+    postal_code_or_zipcode_for_primary_residence:
+      '#type': webform_address
+      '#title': 'Postal Code or Zipcode (for primary residence)'
+      '#address__access': false
+      '#address_2__access': false
+      '#city__access': false
+      '#state_province__access': false
+      '#country__access': false
+    interested_in_helping_organize_midcamp:
+      '#type': radios
+      '#title': 'Are you interested in being a volunteer or helping organize MidCamp next year?'
+      '#options':
+        'Yes': 'Yes'
+        Maybe: Maybe
+        'No': 'No'
 css: ''
 javascript: ''
 settings:
@@ -27,9 +257,9 @@ settings:
   page_theme_name: ''
   form_title: source_entity_webform
   form_submit_once: true
-  form_exception_message: ''
   form_open_message: ''
   form_close_message: ''
+  form_exception_message: ''
   form_previous_submissions: true
   form_confidential: false
   form_confidential_message: ''
@@ -39,31 +269,36 @@ settings:
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
   form_prepopulate_source_entity_type: ''
-  form_reset: false
+  form_unsaved: true
+  form_disable_back: false
+  form_submit_back: false
   form_disable_autocomplete: false
   form_novalidate: false
   form_disable_inline_errors: false
   form_required: false
-  form_unsaved: true
-  form_disable_back: false
-  form_submit_back: false
   form_autofocus: false
   form_details_toggle: false
+  form_reset: false
   form_access_denied: default
   form_access_denied_title: ''
   form_access_denied_message: ''
   form_access_denied_attributes: {  }
   form_file_limit: ''
+  form_attributes: {  }
   form_method: ''
   form_action: ''
-  form_attributes: {  }
   share: false
   share_node: false
   share_theme_name: ''
   share_title: true
   share_page_body_attributes: {  }
   submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
   submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
   submission_views: {  }
   submission_views_replace: {  }
   submission_user_columns: {  }
@@ -72,11 +307,6 @@ settings:
   submission_access_denied_title: ''
   submission_access_denied_message: ''
   submission_access_denied_attributes: {  }
-  submission_exception_message: ''
-  submission_locked_message: ''
-  submission_excluded_elements: {  }
-  submission_exclude_empty: false
-  submission_exclude_empty_checkbox: false
   previous_submission_message: ''
   previous_submissions_message: ''
   autofill: false
@@ -87,13 +317,13 @@ settings:
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_auto_forward: true
-  wizard_auto_forward_hide_next_button: false
-  wizard_keyboard: true
   wizard_start_label: ''
   wizard_preview_link: false
   wizard_confirmation: true
   wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
   wizard_track: ''
   wizard_prev_button_label: ''
   wizard_next_button_label: ''
@@ -116,9 +346,9 @@ settings:
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
   confirmation_type: page
+  confirmation_url: ''
   confirmation_title: 'Thank you!'
   confirmation_message: 'Thank you for filling out this survey!'
-  confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: true
   confirmation_back_label: ''

--- a/conf/drupal/config/webform.webform.midcamp_2021_feedback_survey.yml
+++ b/conf/drupal/config/webform.webform.midcamp_2021_feedback_survey.yml
@@ -2,9 +2,9 @@ uuid: c01e46ea-4353-4919-8018-0e843f9c1ab6
 langcode: en
 status: closed
 dependencies: {  }
+weight: 0
 open: null
 close: null
-weight: 0
 uid: 40
 template: false
 archive: false
@@ -12,7 +12,35 @@ id: midcamp_2021_feedback_survey
 title: 'MidCamp 2021 Feedback Survey'
 description: ''
 category: ''
-elements: "markup:\n  '#type': webform_markup\n  '#markup': |\n    Thank you for attending MidCamp 2021!<br />\n    <br />\n    We have a few questions about your experience and how we can improve for MidCamp 2022.&nbsp; Thanks so much for giving us your feedback,&nbsp;&nbsp;\n    \nis_this_feedback_for_a_session_or_for_the_whole_camp_:\n  '#type': radios\n  '#title': 'Is this feedback for a session or for the whole camp?'\n  '#options':\n    'For a single session': 'For a single session'\n    'For the camp overall': 'For the camp overall'\nif_for_a_session_which_session_:\n  '#type': textarea\n  '#title': 'If for a session, which session?'\nwhat_was_your_favorite_part_:\n  '#type': textarea\n  '#title': 'What was your favorite part?'\nwhat_might_be_tried_for_improvement_:\n  '#type': textarea\n  '#title': 'What might be tried for improvement?'\nany_other_notes_:\n  '#type': textarea\n  '#title': 'Any other notes?'\nwhat_was_your_least_favorite_part_midcamp2021:\n  '#type': textarea\n  '#title': 'What was your least favorite part?'"
+elements: |-
+  markup:
+    '#type': webform_markup
+    '#markup': |
+      Thank you for attending MidCamp 2021!<br />
+      <br />
+      We have a few questions about your experience and how we can improve for MidCamp 2022.&nbsp; Thanks so much for giving us your feedback,&nbsp;&nbsp;
+      
+  is_this_feedback_for_a_session_or_for_the_whole_camp_:
+    '#type': radios
+    '#title': 'Is this feedback for a session or for the whole camp?'
+    '#options':
+      'For a single session': 'For a single session'
+      'For the camp overall': 'For the camp overall'
+  if_for_a_session_which_session_:
+    '#type': textarea
+    '#title': 'If for a session, which session?'
+  what_was_your_favorite_part_:
+    '#type': textarea
+    '#title': 'What was your favorite part?'
+  what_might_be_tried_for_improvement_:
+    '#type': textarea
+    '#title': 'What might be tried for improvement?'
+  any_other_notes_:
+    '#type': textarea
+    '#title': 'Any other notes?'
+  what_was_your_least_favorite_part_midcamp2021:
+    '#type': textarea
+    '#title': 'What was your least favorite part?'
 css: ''
 javascript: ''
 settings:
@@ -27,9 +55,9 @@ settings:
   page_theme_name: ''
   form_title: source_entity_webform
   form_submit_once: false
-  form_exception_message: ''
   form_open_message: ''
   form_close_message: ''
+  form_exception_message: ''
   form_previous_submissions: true
   form_confidential: false
   form_confidential_message: ''
@@ -39,31 +67,36 @@ settings:
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
   form_prepopulate_source_entity_type: ''
-  form_reset: false
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
   form_disable_autocomplete: false
   form_novalidate: false
   form_disable_inline_errors: false
   form_required: false
-  form_unsaved: false
-  form_disable_back: false
-  form_submit_back: false
   form_autofocus: false
   form_details_toggle: false
+  form_reset: false
   form_access_denied: default
   form_access_denied_title: ''
   form_access_denied_message: ''
   form_access_denied_attributes: {  }
   form_file_limit: ''
+  form_attributes: {  }
   form_method: ''
   form_action: ''
-  form_attributes: {  }
   share: false
   share_node: false
   share_theme_name: ''
   share_title: true
   share_page_body_attributes: {  }
   submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
   submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
   submission_views: {  }
   submission_views_replace: {  }
   submission_user_columns: {  }
@@ -72,11 +105,6 @@ settings:
   submission_access_denied_title: ''
   submission_access_denied_message: ''
   submission_access_denied_attributes: {  }
-  submission_exception_message: ''
-  submission_locked_message: ''
-  submission_excluded_elements: {  }
-  submission_exclude_empty: false
-  submission_exclude_empty_checkbox: false
   previous_submission_message: ''
   previous_submissions_message: ''
   autofill: false
@@ -87,13 +115,13 @@ settings:
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_auto_forward: true
-  wizard_auto_forward_hide_next_button: false
-  wizard_keyboard: true
   wizard_start_label: ''
   wizard_preview_link: false
   wizard_confirmation: true
   wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
   wizard_track: ''
   wizard_prev_button_label: ''
   wizard_next_button_label: ''
@@ -116,9 +144,9 @@ settings:
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
   confirmation_type: page
+  confirmation_url: ''
   confirmation_title: ''
   confirmation_message: ''
-  confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: true
   confirmation_back_label: ''

--- a/conf/drupal/config/webform.webform.midcamp_2021_survey.yml
+++ b/conf/drupal/config/webform.webform.midcamp_2021_survey.yml
@@ -2,9 +2,9 @@ uuid: 2370644e-3cc9-4315-a115-920912bbbb0b
 langcode: en
 status: open
 dependencies: {  }
+weight: 0
 open: null
 close: null
-weight: 0
 uid: 13
 template: false
 archive: false
@@ -12,7 +12,35 @@ id: midcamp_2021_survey
 title: 'MidCamp 2021 Survey'
 description: ''
 category: ''
-elements: "markup:\n  '#type': webform_markup\n  '#markup': |\n    <p style=\"line-height:1.38\"><span style=\"font-size:11pt; font-variant:normal; white-space:pre-wrap\"><span style=\"font-family:Arial\"><span style=\"color:#000000\"><span style=\"font-weight:400\"><span style=\"font-style:normal\"><span style=\"text-decoration:none\">These questions are intentionally broad. If you&rsquo;d like, we encourage you to sit down with a coworker or Drupal-buddy and discuss together, and take notes in this form for each other.&nbsp;Read more <a href=\"https://www.midcamp.org/2020/article/who-world-am-i-ah-thats-great-puzzle\">about why we are asking these questions</a>.<br />\n    <br />\n    Aggregate or summarized responses may be shared with Event Organizers and in blog posts in the future.</span></span></span></span></span></span></p>\ndescribe_yourself_:\n  '#type': textfield\n  '#title': 'Describe yourself...'\n  '#description': 'What kind of Drupal Event-goer are you?&nbsp;<span style=\"font-size:11pt; font-variant:normal; white-space:pre-wrap\"><span style=\"font-family:Arial\"><span style=\"color:#000000\"><span style=\"font-weight:400\"><span style=\"font-style:normal\"><span style=\"text-decoration:none\">Are you a serial speaker? A long-time listener? An occasional visitor?</span></span></span></span></span></span>'\nmidcamp_valued:\n  '#type': textarea\n  '#title': 'If you’ve attended an in-person MidCamp, what did you value most about your experience?'\nmidcamp_frustrated:\n  '#type': textarea\n  '#title': 'What frustrated you about in-person MidCamp?'\nvirtual_valued:\n  '#type': textarea\n  '#title': 'Of all the virtual conferences (including MidCamp 2020), what did you value most?'\nvirtual_frustrated:\n  '#type': textarea\n  '#title': 'What have been the most frustrating things about virtual conferences?'\nmidcamp_2021_value:\n  '#type': textarea\n  '#title': 'What value could MidCamp bring to the virtual event space in early 2021… or would our best contribution be not contributing?'\nwhat_else:\n  '#type': textarea\n  '#title': 'What else do you want to tell us?'"
+elements: |-
+  markup:
+    '#type': webform_markup
+    '#markup': |
+      <p style="line-height:1.38"><span style="font-size:11pt; font-variant:normal; white-space:pre-wrap"><span style="font-family:Arial"><span style="color:#000000"><span style="font-weight:400"><span style="font-style:normal"><span style="text-decoration:none">These questions are intentionally broad. If you&rsquo;d like, we encourage you to sit down with a coworker or Drupal-buddy and discuss together, and take notes in this form for each other.&nbsp;Read more <a href="https://www.midcamp.org/2020/article/who-world-am-i-ah-thats-great-puzzle">about why we are asking these questions</a>.<br />
+      <br />
+      Aggregate or summarized responses may be shared with Event Organizers and in blog posts in the future.</span></span></span></span></span></span></p>
+  describe_yourself_:
+    '#type': textfield
+    '#title': 'Describe yourself...'
+    '#description': 'What kind of Drupal Event-goer are you?&nbsp;<span style="font-size:11pt; font-variant:normal; white-space:pre-wrap"><span style="font-family:Arial"><span style="color:#000000"><span style="font-weight:400"><span style="font-style:normal"><span style="text-decoration:none">Are you a serial speaker? A long-time listener? An occasional visitor?</span></span></span></span></span></span>'
+  midcamp_valued:
+    '#type': textarea
+    '#title': 'If you’ve attended an in-person MidCamp, what did you value most about your experience?'
+  midcamp_frustrated:
+    '#type': textarea
+    '#title': 'What frustrated you about in-person MidCamp?'
+  virtual_valued:
+    '#type': textarea
+    '#title': 'Of all the virtual conferences (including MidCamp 2020), what did you value most?'
+  virtual_frustrated:
+    '#type': textarea
+    '#title': 'What have been the most frustrating things about virtual conferences?'
+  midcamp_2021_value:
+    '#type': textarea
+    '#title': 'What value could MidCamp bring to the virtual event space in early 2021… or would our best contribution be not contributing?'
+  what_else:
+    '#type': textarea
+    '#title': 'What else do you want to tell us?'
 css: ''
 javascript: ''
 settings:
@@ -27,9 +55,9 @@ settings:
   page_theme_name: ''
   form_title: both
   form_submit_once: false
-  form_exception_message: ''
   form_open_message: ''
   form_close_message: ''
+  form_exception_message: ''
   form_previous_submissions: true
   form_confidential: false
   form_confidential_message: ''
@@ -39,31 +67,36 @@ settings:
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
   form_prepopulate_source_entity_type: ''
-  form_reset: false
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
   form_disable_autocomplete: false
   form_novalidate: false
   form_disable_inline_errors: false
   form_required: false
-  form_unsaved: false
-  form_disable_back: false
-  form_submit_back: false
   form_autofocus: false
   form_details_toggle: false
+  form_reset: false
   form_access_denied: default
   form_access_denied_title: ''
   form_access_denied_message: ''
   form_access_denied_attributes: {  }
   form_file_limit: ''
+  form_attributes: {  }
   form_method: ''
   form_action: ''
-  form_attributes: {  }
   share: false
   share_node: false
   share_theme_name: ''
   share_title: true
   share_page_body_attributes: {  }
   submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
   submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
   submission_views: {  }
   submission_views_replace: {  }
   submission_user_columns: {  }
@@ -72,11 +105,6 @@ settings:
   submission_access_denied_title: ''
   submission_access_denied_message: ''
   submission_access_denied_attributes: {  }
-  submission_exception_message: ''
-  submission_locked_message: ''
-  submission_excluded_elements: {  }
-  submission_exclude_empty: false
-  submission_exclude_empty_checkbox: false
   previous_submission_message: ''
   previous_submissions_message: ''
   autofill: false
@@ -87,13 +115,13 @@ settings:
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_auto_forward: true
-  wizard_auto_forward_hide_next_button: false
-  wizard_keyboard: true
   wizard_start_label: ''
   wizard_preview_link: false
   wizard_confirmation: true
   wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
   wizard_track: ''
   wizard_prev_button_label: ''
   wizard_next_button_label: ''
@@ -116,9 +144,9 @@ settings:
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
   confirmation_type: page
+  confirmation_url: ''
   confirmation_title: ''
   confirmation_message: ''
-  confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: true
   confirmation_back_label: ''

--- a/conf/drupal/config/webform.webform.movie_suggestions.yml
+++ b/conf/drupal/config/webform.webform.movie_suggestions.yml
@@ -2,9 +2,9 @@ uuid: 190bbf19-6d86-4344-93d0-9414f2e96e58
 langcode: en
 status: open
 dependencies: {  }
+weight: 0
 open: null
 close: null
-weight: 0
 uid: 67
 template: false
 archive: false
@@ -12,7 +12,12 @@ id: movie_suggestions
 title: 'Movie Suggestions'
 description: 'A virtual &quot;submit a suggestion&quot; box for which movie to watch on movie night.'
 category: ''
-elements: "movie_titles:\n  '#type': textarea\n  '#title': 'Movie Title(s)'\n  '#description': 'Please enter one movie title per line. Movie must be available on Netflix or in the <a href=\"https://en.wikipedia.org/wiki/List_of_films_in_the_public_domain_in_the_United_States\">public domain</a>.'\n  '#required': true"
+elements: |-
+  movie_titles:
+    '#type': textarea
+    '#title': 'Movie Title(s)'
+    '#description': 'Please enter one movie title per line. Movie must be available on Netflix or in the <a href="https://en.wikipedia.org/wiki/List_of_films_in_the_public_domain_in_the_United_States">public domain</a>.'
+    '#required': true
 css: ''
 javascript: ''
 settings:
@@ -27,9 +32,9 @@ settings:
   page_theme_name: ''
   form_title: both
   form_submit_once: false
-  form_exception_message: ''
   form_open_message: ''
   form_close_message: ''
+  form_exception_message: ''
   form_previous_submissions: true
   form_confidential: false
   form_confidential_message: ''
@@ -39,31 +44,36 @@ settings:
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
   form_prepopulate_source_entity_type: ''
-  form_reset: false
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
   form_disable_autocomplete: false
   form_novalidate: false
   form_disable_inline_errors: false
   form_required: false
-  form_unsaved: false
-  form_disable_back: false
-  form_submit_back: false
   form_autofocus: false
   form_details_toggle: false
+  form_reset: false
   form_access_denied: default
   form_access_denied_title: ''
   form_access_denied_message: ''
   form_access_denied_attributes: {  }
   form_file_limit: ''
+  form_attributes: {  }
   form_method: ''
   form_action: ''
-  form_attributes: {  }
   share: false
   share_node: false
   share_theme_name: ''
   share_title: true
   share_page_body_attributes: {  }
   submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
   submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
   submission_views: {  }
   submission_views_replace: {  }
   submission_user_columns: {  }
@@ -72,11 +82,6 @@ settings:
   submission_access_denied_title: ''
   submission_access_denied_message: ''
   submission_access_denied_attributes: {  }
-  submission_exception_message: ''
-  submission_locked_message: ''
-  submission_excluded_elements: {  }
-  submission_exclude_empty: false
-  submission_exclude_empty_checkbox: false
   previous_submission_message: ''
   previous_submissions_message: ''
   autofill: false
@@ -87,13 +92,13 @@ settings:
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_auto_forward: true
-  wizard_auto_forward_hide_next_button: false
-  wizard_keyboard: true
   wizard_start_label: ''
   wizard_preview_link: false
   wizard_confirmation: true
   wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
   wizard_track: ''
   wizard_prev_button_label: ''
   wizard_next_button_label: ''
@@ -116,9 +121,9 @@ settings:
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
   confirmation_type: page
+  confirmation_url: ''
   confirmation_title: ''
   confirmation_message: ''
-  confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: true
   confirmation_back_label: ''

--- a/conf/drupal/config/webform.webform.room_monitor_checklist.yml
+++ b/conf/drupal/config/webform.webform.room_monitor_checklist.yml
@@ -2,9 +2,9 @@ uuid: 14089955-e024-4f64-af62-9ebebd80ba97
 langcode: en
 status: open
 dependencies: {  }
+weight: 0
 open: null
 close: null
-weight: 0
 uid: 16
 template: false
 archive: false
@@ -12,7 +12,29 @@ id: room_monitor_checklist
 title: 'Room Monitor Checklist'
 description: ''
 category: ''
-elements: "markup:\n  '#type': webform_markup\n  '#markup': \"Thank you for being a room monitor.&nbsp; Please fill out the form below and if there are any immediate needs, please contact JD Flynn or any of the organizer teams via Slack or Twitter or yelling really loudly (please don&#39;t yell really loudly).&nbsp;&nbsp;<br />\\n<br />\\nIn addition to filling out this form, there are a few things we need checked out for every session:\\n<ul>\\n\\t<li>Please be in the room at least 5 minutes before the session starts to help make sure that any issues are hopefully handled before the session starts.</li>\\n\\t<li>Make sure that the speaker(s) press the BIG RED BUTTON on the recording kit.&nbsp; If the light strip is red, it&#39;s recording.</li>\\n\\t<li>If there are any issues during recording with the projector flickering or other strangeness, ping Kevin Thull on Slack or email JD Flynn</li>\\n\\t<li>Learn something!</li>\\n</ul>\"\nsession:\n  '#type': webform_entity_select\n  '#title': Session\n  '#target_type': node\n  '#selection_handler': views\n  '#selection_settings':\n    view:\n      view_name: survey_filters\n      display_name: entity_reference_1\n      arguments: {  }\nmonitor_name:\n  '#type': textfield\n  '#title': 'Monitor Name'\nnumber_of_attendees:\n  '#type': textfield\n  '#title': 'Number of Attendees (including yourself)'\nany_concerns_:\n  '#type': textarea\n  '#title': 'Any Concerns?'\n"
+elements: |
+  markup:
+    '#type': webform_markup
+    '#markup': "Thank you for being a room monitor.&nbsp; Please fill out the form below and if there are any immediate needs, please contact JD Flynn or any of the organizer teams via Slack or Twitter or yelling really loudly (please don&#39;t yell really loudly).&nbsp;&nbsp;<br />\n<br />\nIn addition to filling out this form, there are a few things we need checked out for every session:\n<ul>\n\t<li>Please be in the room at least 5 minutes before the session starts to help make sure that any issues are hopefully handled before the session starts.</li>\n\t<li>Make sure that the speaker(s) press the BIG RED BUTTON on the recording kit.&nbsp; If the light strip is red, it&#39;s recording.</li>\n\t<li>If there are any issues during recording with the projector flickering or other strangeness, ping Kevin Thull on Slack or email JD Flynn</li>\n\t<li>Learn something!</li>\n</ul>"
+  session:
+    '#type': webform_entity_select
+    '#title': Session
+    '#target_type': node
+    '#selection_handler': views
+    '#selection_settings':
+      view:
+        view_name: survey_filters
+        display_name: entity_reference_1
+        arguments: {  }
+  monitor_name:
+    '#type': textfield
+    '#title': 'Monitor Name'
+  number_of_attendees:
+    '#type': textfield
+    '#title': 'Number of Attendees (including yourself)'
+  any_concerns_:
+    '#type': textarea
+    '#title': 'Any Concerns?'
 css: ''
 javascript: ''
 settings:
@@ -27,9 +49,9 @@ settings:
   page_theme_name: ''
   form_title: both
   form_submit_once: false
-  form_exception_message: ''
   form_open_message: ''
   form_close_message: ''
+  form_exception_message: ''
   form_previous_submissions: true
   form_confidential: false
   form_confidential_message: ''
@@ -39,31 +61,36 @@ settings:
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
   form_prepopulate_source_entity_type: ''
-  form_reset: false
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
   form_disable_autocomplete: false
   form_novalidate: false
   form_disable_inline_errors: false
   form_required: false
-  form_unsaved: false
-  form_disable_back: false
-  form_submit_back: false
   form_autofocus: false
   form_details_toggle: false
+  form_reset: false
   form_access_denied: default
   form_access_denied_title: ''
   form_access_denied_message: ''
   form_access_denied_attributes: {  }
   form_file_limit: ''
+  form_attributes: {  }
   form_method: ''
   form_action: ''
-  form_attributes: {  }
   share: false
   share_node: false
   share_theme_name: ''
   share_title: true
   share_page_body_attributes: {  }
   submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
   submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
   submission_views: {  }
   submission_views_replace: {  }
   submission_user_columns: {  }
@@ -72,11 +99,6 @@ settings:
   submission_access_denied_title: ''
   submission_access_denied_message: ''
   submission_access_denied_attributes: {  }
-  submission_exception_message: ''
-  submission_locked_message: ''
-  submission_excluded_elements: {  }
-  submission_exclude_empty: false
-  submission_exclude_empty_checkbox: false
   previous_submission_message: ''
   previous_submissions_message: ''
   autofill: false
@@ -87,13 +109,13 @@ settings:
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_auto_forward: true
-  wizard_auto_forward_hide_next_button: false
-  wizard_keyboard: true
   wizard_start_label: ''
   wizard_preview_link: false
   wizard_confirmation: true
   wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
   wizard_track: ''
   wizard_prev_button_label: ''
   wizard_next_button_label: ''
@@ -116,9 +138,9 @@ settings:
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
   confirmation_type: page
+  confirmation_url: ''
   confirmation_title: ''
   confirmation_message: ''
-  confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: true
   confirmation_back_label: ''
@@ -197,9 +219,9 @@ access:
 handlers:
   email:
     id: email
+    handler_id: email
     label: Email
     notes: ''
-    handler_id: email
     status: true
     conditions: {  }
     weight: 0
@@ -208,13 +230,17 @@ handlers:
         - completed
       to_mail: jflynn8@gmail.com
       to_options: {  }
-      cc_mail: ''
-      cc_options: {  }
       bcc_mail: ''
       bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
       from_mail: _default
       from_options: {  }
       from_name: _default
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
       subject: _default
       body: _default
       excluded_elements: {  }
@@ -225,11 +251,7 @@ handlers:
       html: true
       attachments: false
       twig: false
-      debug: false
-      reply_to: ''
-      return_path: ''
-      sender_mail: ''
-      sender_name: ''
       theme_name: ''
       parameters: {  }
+      debug: false
 variants: {  }

--- a/conf/drupal/config/webform.webform.session_feedback.yml
+++ b/conf/drupal/config/webform.webform.session_feedback.yml
@@ -2,9 +2,9 @@ uuid: 351cbc2c-6753-45ea-bb08-e9d6f85e7db8
 langcode: en
 status: open
 dependencies: {  }
+weight: 0
 open: null
 close: null
-weight: 0
 uid: 6
 template: false
 archive: false
@@ -12,7 +12,29 @@ id: session_feedback
 title: 'Session Feedback'
 description: 'A survey for attendees to tell us what they thought of a session.'
 category: ''
-elements: "mastery_of_topic:\n  '#type': radios\n  '#title': 'Please rate the speaker''s mastery of this topic.'\n  '#options': likert_five_scale\n  '#options_display': side_by_side\npresentation_skills:\n  '#type': radios\n  '#title': 'Please rate the speaker''s presentation skills.'\n  '#options': likert_five_scale\n  '#options_display': side_by_side\nquality_of_slides:\n  '#type': radios\n  '#title': 'Please rate the quality of speaker''s slides and visual aids.'\n  '#options': likert_five_scale\n  '#options_display': side_by_side\nlearn_something:\n  '#type': radios\n  '#title': 'Did you learn something?'\n  '#options': yes_no\ncomments:\n  '#type': textarea\n  '#title': Comments"
+elements: |-
+  mastery_of_topic:
+    '#type': radios
+    '#title': 'Please rate the speaker''s mastery of this topic.'
+    '#options': likert_five_scale
+    '#options_display': side_by_side
+  presentation_skills:
+    '#type': radios
+    '#title': 'Please rate the speaker''s presentation skills.'
+    '#options': likert_five_scale
+    '#options_display': side_by_side
+  quality_of_slides:
+    '#type': radios
+    '#title': 'Please rate the quality of speaker''s slides and visual aids.'
+    '#options': likert_five_scale
+    '#options_display': side_by_side
+  learn_something:
+    '#type': radios
+    '#title': 'Did you learn something?'
+    '#options': yes_no
+  comments:
+    '#type': textarea
+    '#title': Comments
 css: ''
 javascript: ''
 settings:
@@ -27,9 +49,9 @@ settings:
   page_theme_name: ''
   form_title: both
   form_submit_once: false
-  form_exception_message: ''
   form_open_message: ''
   form_close_message: ''
+  form_exception_message: ''
   form_previous_submissions: true
   form_confidential: false
   form_confidential_message: ''
@@ -39,31 +61,36 @@ settings:
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
   form_prepopulate_source_entity_type: ''
-  form_reset: false
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
   form_disable_autocomplete: false
   form_novalidate: false
   form_disable_inline_errors: false
   form_required: false
-  form_unsaved: false
-  form_disable_back: false
-  form_submit_back: false
   form_autofocus: false
   form_details_toggle: false
+  form_reset: false
   form_access_denied: default
   form_access_denied_title: ''
   form_access_denied_message: ''
   form_access_denied_attributes: {  }
   form_file_limit: ''
+  form_attributes: {  }
   form_method: ''
   form_action: ''
-  form_attributes: {  }
   share: false
   share_node: false
   share_theme_name: ''
   share_title: true
   share_page_body_attributes: {  }
   submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
   submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
   submission_views: {  }
   submission_views_replace:
     webform_routes: {  }
@@ -74,11 +101,6 @@ settings:
   submission_access_denied_title: ''
   submission_access_denied_message: ''
   submission_access_denied_attributes: {  }
-  submission_exception_message: ''
-  submission_locked_message: ''
-  submission_excluded_elements: {  }
-  submission_exclude_empty: false
-  submission_exclude_empty_checkbox: false
   previous_submission_message: ''
   previous_submissions_message: ''
   autofill: false
@@ -89,13 +111,13 @@ settings:
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_auto_forward: true
-  wizard_auto_forward_hide_next_button: false
-  wizard_keyboard: true
   wizard_start_label: ''
   wizard_preview_link: false
   wizard_confirmation: true
   wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
   wizard_track: ''
   wizard_prev_button_label: ''
   wizard_next_button_label: ''
@@ -118,9 +140,9 @@ settings:
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
   confirmation_type: inline
+  confirmation_url: ''
   confirmation_title: ''
   confirmation_message: 'Thanks for your feedback!'
-  confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: true
   confirmation_back_label: ''

--- a/conf/drupal/config/webform.webform.tourism_quote.yml
+++ b/conf/drupal/config/webform.webform.tourism_quote.yml
@@ -2,9 +2,9 @@ uuid: 4f9b189f-599e-4cb9-8642-ca6df4be6c68
 langcode: en
 status: open
 dependencies: {  }
+weight: 0
 open: null
 close: null
-weight: 0
 uid: 67
 template: false
 archive: false
@@ -12,7 +12,49 @@ id: tourism_quote
 title: 'Submit a Tourism Quote'
 description: ''
 category: ''
-elements: "markup:\n  '#type': webform_markup\n  '#display_on': both\n  '#markup': 'Want to be featured on our <a href=\"/2019/tourism\">tourism page</a>? Let us know your favorite spots and things to do as well as any tips for visitors!'\nname:\n  '#type': textfield\n  '#title': 'Your Name'\n  '#required': true\nemail:\n  '#type': email\n  '#title': 'Your Email'\n  '#required': true\n  '#unique': true\nquote:\n  '#type': textarea\n  '#title': 'Your Blurb'\n  '#required': true\npicture_option:\n  '#type': select\n  '#title': 'Your Picture Option'\n  '#options':\n    user_image: 'Use the image from my user.'\n    generic_image: 'Use the generic Mad Hatter image.'\n    upload_image: 'Use the image uploaded here.'\n  '#required': true\npicture_image:\n  '#type': webform_image_file\n  '#title': 'Your Picture'\n  '#help': \"Your virtual face or picture.<br />\\r\\nImage should be at least 250 pixels wide.\"\n  '#states':\n    enabled:\n      ':input[name=\"picture_option\"]':\n        value: upload_image\n    visible:\n      ':input[name=\"picture_option\"]':\n        value: upload_image\n    required:\n      ':input[name=\"picture_option\"]':\n        value: upload_image\n  '#max_filesize': '2'\n  '#file_extensions': 'gif jpg png jpeg'\n  '#sanitize': true\n"
+elements: |
+  markup:
+    '#type': webform_markup
+    '#display_on': both
+    '#markup': 'Want to be featured on our <a href="/2019/tourism">tourism page</a>? Let us know your favorite spots and things to do as well as any tips for visitors!'
+  name:
+    '#type': textfield
+    '#title': 'Your Name'
+    '#required': true
+  email:
+    '#type': email
+    '#title': 'Your Email'
+    '#required': true
+    '#unique': true
+  quote:
+    '#type': textarea
+    '#title': 'Your Blurb'
+    '#required': true
+  picture_option:
+    '#type': select
+    '#title': 'Your Picture Option'
+    '#options':
+      user_image: 'Use the image from my user.'
+      generic_image: 'Use the generic Mad Hatter image.'
+      upload_image: 'Use the image uploaded here.'
+    '#required': true
+  picture_image:
+    '#type': webform_image_file
+    '#title': 'Your Picture'
+    '#help': "Your virtual face or picture.<br />\r\nImage should be at least 250 pixels wide."
+    '#states':
+      enabled:
+        ':input[name="picture_option"]':
+          value: upload_image
+      visible:
+        ':input[name="picture_option"]':
+          value: upload_image
+      required:
+        ':input[name="picture_option"]':
+          value: upload_image
+    '#max_filesize': '2'
+    '#file_extensions': 'gif jpg png jpeg'
+    '#sanitize': true
 css: ''
 javascript: ''
 settings:
@@ -27,9 +69,9 @@ settings:
   page_theme_name: ''
   form_title: both
   form_submit_once: true
-  form_exception_message: ''
   form_open_message: ''
   form_close_message: ''
+  form_exception_message: ''
   form_previous_submissions: true
   form_confidential: false
   form_confidential_message: ''
@@ -39,31 +81,36 @@ settings:
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
   form_prepopulate_source_entity_type: ''
-  form_reset: false
+  form_unsaved: true
+  form_disable_back: false
+  form_submit_back: false
   form_disable_autocomplete: false
   form_novalidate: false
   form_disable_inline_errors: false
   form_required: false
-  form_unsaved: true
-  form_disable_back: false
-  form_submit_back: false
   form_autofocus: true
   form_details_toggle: false
+  form_reset: false
   form_access_denied: default
   form_access_denied_title: ''
   form_access_denied_message: ''
   form_access_denied_attributes: {  }
   form_file_limit: ''
+  form_attributes: {  }
   form_method: ''
   form_action: ''
-  form_attributes: {  }
   share: false
   share_node: false
   share_theme_name: ''
   share_title: true
   share_page_body_attributes: {  }
   submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
   submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
   submission_views: {  }
   submission_views_replace: {  }
   submission_user_columns: {  }
@@ -72,11 +119,6 @@ settings:
   submission_access_denied_title: ''
   submission_access_denied_message: ''
   submission_access_denied_attributes: {  }
-  submission_exception_message: ''
-  submission_locked_message: ''
-  submission_excluded_elements: {  }
-  submission_exclude_empty: false
-  submission_exclude_empty_checkbox: false
   previous_submission_message: ''
   previous_submissions_message: ''
   autofill: false
@@ -87,13 +129,13 @@ settings:
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_auto_forward: true
-  wizard_auto_forward_hide_next_button: false
-  wizard_keyboard: true
   wizard_start_label: ''
   wizard_preview_link: false
   wizard_confirmation: true
   wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
   wizard_track: ''
   wizard_prev_button_label: ''
   wizard_next_button_label: ''
@@ -116,9 +158,9 @@ settings:
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
   confirmation_type: inline
+  confirmation_url: ''
   confirmation_title: ''
   confirmation_message: ''
-  confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: true
   confirmation_back_label: ''
@@ -197,9 +239,9 @@ access:
 handlers:
   email:
     id: email
+    handler_id: email
     label: Email
     notes: ''
-    handler_id: email
     status: true
     conditions: {  }
     weight: 0
@@ -208,13 +250,17 @@ handlers:
         - completed
       to_mail: 'dsdobrzynski@gmail.com,info@midcamp.org'
       to_options: {  }
-      cc_mail: ''
-      cc_options: {  }
       bcc_mail: ''
       bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
       from_mail: _default
       from_options: {  }
       from_name: _default
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
       subject: _default
       body: _default
       excluded_elements: {  }
@@ -225,11 +271,7 @@ handlers:
       html: true
       attachments: false
       twig: false
-      debug: false
-      reply_to: ''
-      return_path: ''
-      sender_mail: ''
-      sender_name: ''
       theme_name: ''
       parameters: {  }
+      debug: false
 variants: {  }

--- a/conf/drupal/config/webform.webform.training_feedback.yml
+++ b/conf/drupal/config/webform.webform.training_feedback.yml
@@ -2,9 +2,9 @@ uuid: 8149bcc2-9834-48dd-b8e1-6d06775bfe86
 langcode: en
 status: open
 dependencies: {  }
+weight: 0
 open: null
 close: null
-weight: 0
 uid: 26
 template: false
 archive: false
@@ -12,7 +12,85 @@ id: training_feedback
 title: 'Training Feedback'
 description: 'A survey for students to tell us what they thought of a training.'
 category: ''
-elements: "markup:\n  '#type': webform_markup\n  '#markup': 'Thank you for helping your trainers and the MidCamp organizers improve the training experience!&nbsp;'\nwhat_training_did_you_attend_:\n  '#type': select\n  '#title': 'What training did you attend?'\n  '#options':\n    'Git Ur Pro Dev Workflow and Go From Continuous Integration Zero to Hero': 'Git Ur Pro Dev Workflow and Go From Continuous Integration Zero to Hero'\n    'Introduction to Drupal 8 Module Development': 'Introduction to Drupal 8 Module Development'\n    'What Am I Getting Myself Into? A Drupal Crash Course for Non-Developers': 'What Am I Getting Myself Into? A Drupal Crash Course for Non-Developers'\n  '#options_randomize': true\n  '#required': true\ndid_this_workshop_meet_your_expectations_:\n  '#type': webform_radios_other\n  '#title': 'Did this training meet your expectations?'\n  '#options':\n    'Yes': 'Yes'\n  '#other__type': textarea\n  '#other__option_label': 'No'\n  '#other__title': 'Please tell us why (optional)'\n  '#other__placeholder': 'Enter feedback...'\n  '#required': true\ndo_you_recommend_this_class_:\n  '#type': webform_radios_other\n  '#title': 'Should this training be offered next year?'\n  '#help': 'Would you recommend this training to someone else in your role?'\n  '#options':\n    'Yes': 'Yes'\n  '#other__type': textarea\n  '#other__option_label': 'No'\n  '#other__title': 'Please tell us why (optional)'\n  '#other__placeholder': 'Enter your feedback...'\n  '#required': true\ndid_the_instructor_s_communicate_the_subject_matter_clearly_:\n  '#type': webform_radios_other\n  '#title': 'Did the instructor(s) communicate the subject-matter clearly?'\n  '#options':\n    'Yes': 'Yes'\n  '#other__type': textarea\n  '#other__option_label': 'No'\n  '#other__title': 'Please tell us why (optional)'\n  '#other__placeholder': 'Enter your feedback...'\n  '#required': true\nwas_the_depth_of_content_appropriate_for_the_subject_matter_:\n  '#type': radios\n  '#title': 'Was the depth of content appropriate for the subject-matter?'\n  '#options':\n    'It was too deep; there was too much material': 'It was too deep; there was too much material'\n    'It was just right': 'It was just right'\n    'It wasn''t deep enough; I still have questions': 'It wasn''t deep enough; I still have questions'\n  '#required': true\nwas_the_pace_of_instruction_appropriate_for_the_subject_matter_:\n  '#type': radios\n  '#title': 'Was the pace of instruction appropriate for the subject-matter?'\n  '#options':\n    'No, it was too fast': 'No, it was too fast'\n    'Yes, it was just right': 'Yes, it was just right'\n    'No, it was too slow': 'No, it was too slow'\n  '#required': true\nwhy_did_you_sign_up_for_this_workshop_:\n  '#type': textarea\n  '#title': 'Why did you sign up for this training?'\nif_the_trainer_can_only_improve_this_workshop_in_one_area_where_:\n  '#type': textarea\n  '#title': 'If the trainer can only improve this training in one area, where should they focus?'\n  '#help': 'e.g., logistics, content, speakers, etc.'\nanything_else_:\n  '#type': textarea\n  '#title': 'Any other feedback about this specific training?'\nwhat_training_topics_do_you_want_to_attend_:\n  '#type': textarea\n  '#title': 'What training topics would you attend next year?'\n  '#help': 'If applicable, please&nbsp;include the experience level for each topic (beginner, intermediate, advanced).'\n  '#description': 'Intro to Drupal 8, Module Development, Theming, Project Mangement, etc.'\nany_feedback_about_training_for_the_midcamp_organizers_:\n  '#type': textarea\n  '#title': 'Any other feedback about training for the MidCamp organizers?'\n  '#description': 'If you want to be contacted in response to your feedback, please leave your name and email address in this field along with any other notes.'\n"
+elements: |
+  markup:
+    '#type': webform_markup
+    '#markup': 'Thank you for helping your trainers and the MidCamp organizers improve the training experience!&nbsp;'
+  what_training_did_you_attend_:
+    '#type': select
+    '#title': 'What training did you attend?'
+    '#options':
+      'Git Ur Pro Dev Workflow and Go From Continuous Integration Zero to Hero': 'Git Ur Pro Dev Workflow and Go From Continuous Integration Zero to Hero'
+      'Introduction to Drupal 8 Module Development': 'Introduction to Drupal 8 Module Development'
+      'What Am I Getting Myself Into? A Drupal Crash Course for Non-Developers': 'What Am I Getting Myself Into? A Drupal Crash Course for Non-Developers'
+    '#options_randomize': true
+    '#required': true
+  did_this_workshop_meet_your_expectations_:
+    '#type': webform_radios_other
+    '#title': 'Did this training meet your expectations?'
+    '#options':
+      'Yes': 'Yes'
+    '#other__type': textarea
+    '#other__option_label': 'No'
+    '#other__title': 'Please tell us why (optional)'
+    '#other__placeholder': 'Enter feedback...'
+    '#required': true
+  do_you_recommend_this_class_:
+    '#type': webform_radios_other
+    '#title': 'Should this training be offered next year?'
+    '#help': 'Would you recommend this training to someone else in your role?'
+    '#options':
+      'Yes': 'Yes'
+    '#other__type': textarea
+    '#other__option_label': 'No'
+    '#other__title': 'Please tell us why (optional)'
+    '#other__placeholder': 'Enter your feedback...'
+    '#required': true
+  did_the_instructor_s_communicate_the_subject_matter_clearly_:
+    '#type': webform_radios_other
+    '#title': 'Did the instructor(s) communicate the subject-matter clearly?'
+    '#options':
+      'Yes': 'Yes'
+    '#other__type': textarea
+    '#other__option_label': 'No'
+    '#other__title': 'Please tell us why (optional)'
+    '#other__placeholder': 'Enter your feedback...'
+    '#required': true
+  was_the_depth_of_content_appropriate_for_the_subject_matter_:
+    '#type': radios
+    '#title': 'Was the depth of content appropriate for the subject-matter?'
+    '#options':
+      'It was too deep; there was too much material': 'It was too deep; there was too much material'
+      'It was just right': 'It was just right'
+      'It wasn''t deep enough; I still have questions': 'It wasn''t deep enough; I still have questions'
+    '#required': true
+  was_the_pace_of_instruction_appropriate_for_the_subject_matter_:
+    '#type': radios
+    '#title': 'Was the pace of instruction appropriate for the subject-matter?'
+    '#options':
+      'No, it was too fast': 'No, it was too fast'
+      'Yes, it was just right': 'Yes, it was just right'
+      'No, it was too slow': 'No, it was too slow'
+    '#required': true
+  why_did_you_sign_up_for_this_workshop_:
+    '#type': textarea
+    '#title': 'Why did you sign up for this training?'
+  if_the_trainer_can_only_improve_this_workshop_in_one_area_where_:
+    '#type': textarea
+    '#title': 'If the trainer can only improve this training in one area, where should they focus?'
+    '#help': 'e.g., logistics, content, speakers, etc.'
+  anything_else_:
+    '#type': textarea
+    '#title': 'Any other feedback about this specific training?'
+  what_training_topics_do_you_want_to_attend_:
+    '#type': textarea
+    '#title': 'What training topics would you attend next year?'
+    '#help': 'If applicable, please&nbsp;include the experience level for each topic (beginner, intermediate, advanced).'
+    '#description': 'Intro to Drupal 8, Module Development, Theming, Project Mangement, etc.'
+  any_feedback_about_training_for_the_midcamp_organizers_:
+    '#type': textarea
+    '#title': 'Any other feedback about training for the MidCamp organizers?'
+    '#description': 'If you want to be contacted in response to your feedback, please leave your name and email address in this field along with any other notes.'
 css: ''
 javascript: ''
 settings:
@@ -27,9 +105,9 @@ settings:
   page_theme_name: ''
   form_title: both
   form_submit_once: false
-  form_exception_message: ''
   form_open_message: ''
   form_close_message: ''
+  form_exception_message: ''
   form_previous_submissions: true
   form_confidential: false
   form_confidential_message: ''
@@ -39,31 +117,36 @@ settings:
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
   form_prepopulate_source_entity_type: ''
-  form_reset: false
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
   form_disable_autocomplete: false
   form_novalidate: false
   form_disable_inline_errors: false
   form_required: false
-  form_unsaved: false
-  form_disable_back: false
-  form_submit_back: false
   form_autofocus: false
   form_details_toggle: false
+  form_reset: false
   form_access_denied: default
   form_access_denied_title: ''
   form_access_denied_message: ''
   form_access_denied_attributes: {  }
   form_file_limit: ''
+  form_attributes: {  }
   form_method: ''
   form_action: ''
-  form_attributes: {  }
   share: false
   share_node: false
   share_theme_name: ''
   share_title: true
   share_page_body_attributes: {  }
   submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
   submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
   submission_views: {  }
   submission_views_replace: {  }
   submission_user_columns: {  }
@@ -72,11 +155,6 @@ settings:
   submission_access_denied_title: ''
   submission_access_denied_message: ''
   submission_access_denied_attributes: {  }
-  submission_exception_message: ''
-  submission_locked_message: ''
-  submission_excluded_elements: {  }
-  submission_exclude_empty: false
-  submission_exclude_empty_checkbox: false
   previous_submission_message: ''
   previous_submissions_message: ''
   autofill: false
@@ -87,13 +165,13 @@ settings:
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_auto_forward: true
-  wizard_auto_forward_hide_next_button: false
-  wizard_keyboard: true
   wizard_start_label: ''
   wizard_preview_link: false
   wizard_confirmation: false
   wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
   wizard_track: ''
   wizard_prev_button_label: ''
   wizard_next_button_label: ''
@@ -116,9 +194,9 @@ settings:
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
   confirmation_type: page
+  confirmation_url: ''
   confirmation_title: Thanks!
   confirmation_message: 'We really appreciate you taking the time to leave feedback. We hope to see you next year!'
-  confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: false
   confirmation_back_label: ''
@@ -197,9 +275,9 @@ access:
 handlers:
   email_to_david:
     id: email
+    handler_id: email_to_david
     label: 'Email to David'
     notes: ''
-    handler_id: email_to_david
     status: true
     conditions: {  }
     weight: 0
@@ -208,13 +286,17 @@ handlers:
         - completed
       to_mail: david.needham+midcampfeedback@pantheon.io
       to_options: {  }
-      cc_mail: ''
-      cc_options: {  }
       bcc_mail: ''
       bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
       from_mail: _default
       from_options: {  }
       from_name: _default
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
       subject: _default
       body: _default
       excluded_elements: {  }
@@ -225,11 +307,7 @@ handlers:
       html: true
       attachments: false
       twig: false
-      debug: false
-      reply_to: ''
-      return_path: ''
-      sender_mail: ''
-      sender_name: ''
       theme_name: ''
       parameters: {  }
+      debug: false
 variants: {  }

--- a/conf/drupal/config/webform.webform.training_feedback_2019.yml
+++ b/conf/drupal/config/webform.webform.training_feedback_2019.yml
@@ -2,9 +2,9 @@ uuid: d65665c1-9306-4e83-847e-1440d2456422
 langcode: en
 status: open
 dependencies: {  }
+weight: 0
 open: null
 close: null
-weight: 0
 uid: 6
 template: false
 archive: false
@@ -12,7 +12,76 @@ id: training_feedback_2019
 title: 'Training Feedback 2019'
 description: 'A survey for students to tell us what they thought of a training.'
 category: ''
-elements: "markup:\n  '#type': webform_markup\n  '#markup': 'Thank you for helping your trainers and the MidCamp organizers improve the training experience!&nbsp;'\ndid_this_workshop_meet_your_expectations_:\n  '#type': webform_radios_other\n  '#title': 'Did this training meet your expectations?'\n  '#options':\n    'Yes': 'Yes'\n  '#other__type': textarea\n  '#other__option_label': 'No'\n  '#other__title': 'Please tell us why (optional)'\n  '#other__placeholder': 'Enter feedback...'\n  '#required': true\ndo_you_recommend_this_class_:\n  '#type': webform_radios_other\n  '#title': 'Should this training be offered next year?'\n  '#help': 'Would you recommend this training to someone else in your role?'\n  '#options':\n    'Yes': 'Yes'\n  '#other__type': textarea\n  '#other__option_label': 'No'\n  '#other__title': 'Please tell us why (optional)'\n  '#other__placeholder': 'Enter your feedback...'\n  '#required': true\ndid_the_instructor_s_communicate_the_subject_matter_clearly_:\n  '#type': webform_radios_other\n  '#title': 'Did the instructor(s) communicate the subject-matter clearly?'\n  '#options':\n    'Yes': 'Yes'\n  '#other__type': textarea\n  '#other__option_label': 'No'\n  '#other__title': 'Please tell us why (optional)'\n  '#other__placeholder': 'Enter your feedback...'\n  '#required': true\nwas_the_depth_of_content_appropriate_for_the_subject_matter_:\n  '#type': radios\n  '#title': 'Was the depth of content appropriate for the subject-matter?'\n  '#options':\n    'It was too deep; there was too much material': 'It was too deep; there was too much material'\n    'It was just right': 'It was just right'\n    'It wasn''t deep enough; I still have questions': 'It wasn''t deep enough; I still have questions'\n  '#required': true\nwas_the_pace_of_instruction_appropriate_for_the_subject_matter_:\n  '#type': radios\n  '#title': 'Was the pace of instruction appropriate for the subject-matter?'\n  '#options':\n    'No, it was too fast': 'No, it was too fast'\n    'Yes, it was just right': 'Yes, it was just right'\n    'No, it was too slow': 'No, it was too slow'\n  '#required': true\nwhy_did_you_sign_up_for_this_workshop_:\n  '#type': textarea\n  '#title': 'Why did you sign up for this training?'\nif_the_trainer_can_only_improve_this_workshop_in_one_area_where_:\n  '#type': textarea\n  '#title': 'If the trainer can only improve this training in one area, where should they focus?'\n  '#help': 'e.g., logistics, content, speakers, etc.'\nanything_else_:\n  '#type': textarea\n  '#title': 'Any other feedback about this specific training?'\nwhat_training_topics_do_you_want_to_attend_:\n  '#type': textarea\n  '#title': 'What training topics would you attend next year?'\n  '#help': 'If applicable, please&nbsp;include the experience level for each topic (beginner, intermediate, advanced).'\n  '#description': 'Intro to Drupal 8, Module Development, Theming, Project Mangement, etc.'\nany_feedback_about_training_for_the_midcamp_organizers_:\n  '#type': textarea\n  '#title': 'Any other feedback about training for the MidCamp organizers?'\n  '#description': 'If you want to be contacted in response to your feedback, please leave your name and email address in this field along with any other notes.'\n"
+elements: |
+  markup:
+    '#type': webform_markup
+    '#markup': 'Thank you for helping your trainers and the MidCamp organizers improve the training experience!&nbsp;'
+  did_this_workshop_meet_your_expectations_:
+    '#type': webform_radios_other
+    '#title': 'Did this training meet your expectations?'
+    '#options':
+      'Yes': 'Yes'
+    '#other__type': textarea
+    '#other__option_label': 'No'
+    '#other__title': 'Please tell us why (optional)'
+    '#other__placeholder': 'Enter feedback...'
+    '#required': true
+  do_you_recommend_this_class_:
+    '#type': webform_radios_other
+    '#title': 'Should this training be offered next year?'
+    '#help': 'Would you recommend this training to someone else in your role?'
+    '#options':
+      'Yes': 'Yes'
+    '#other__type': textarea
+    '#other__option_label': 'No'
+    '#other__title': 'Please tell us why (optional)'
+    '#other__placeholder': 'Enter your feedback...'
+    '#required': true
+  did_the_instructor_s_communicate_the_subject_matter_clearly_:
+    '#type': webform_radios_other
+    '#title': 'Did the instructor(s) communicate the subject-matter clearly?'
+    '#options':
+      'Yes': 'Yes'
+    '#other__type': textarea
+    '#other__option_label': 'No'
+    '#other__title': 'Please tell us why (optional)'
+    '#other__placeholder': 'Enter your feedback...'
+    '#required': true
+  was_the_depth_of_content_appropriate_for_the_subject_matter_:
+    '#type': radios
+    '#title': 'Was the depth of content appropriate for the subject-matter?'
+    '#options':
+      'It was too deep; there was too much material': 'It was too deep; there was too much material'
+      'It was just right': 'It was just right'
+      'It wasn''t deep enough; I still have questions': 'It wasn''t deep enough; I still have questions'
+    '#required': true
+  was_the_pace_of_instruction_appropriate_for_the_subject_matter_:
+    '#type': radios
+    '#title': 'Was the pace of instruction appropriate for the subject-matter?'
+    '#options':
+      'No, it was too fast': 'No, it was too fast'
+      'Yes, it was just right': 'Yes, it was just right'
+      'No, it was too slow': 'No, it was too slow'
+    '#required': true
+  why_did_you_sign_up_for_this_workshop_:
+    '#type': textarea
+    '#title': 'Why did you sign up for this training?'
+  if_the_trainer_can_only_improve_this_workshop_in_one_area_where_:
+    '#type': textarea
+    '#title': 'If the trainer can only improve this training in one area, where should they focus?'
+    '#help': 'e.g., logistics, content, speakers, etc.'
+  anything_else_:
+    '#type': textarea
+    '#title': 'Any other feedback about this specific training?'
+  what_training_topics_do_you_want_to_attend_:
+    '#type': textarea
+    '#title': 'What training topics would you attend next year?'
+    '#help': 'If applicable, please&nbsp;include the experience level for each topic (beginner, intermediate, advanced).'
+    '#description': 'Intro to Drupal 8, Module Development, Theming, Project Mangement, etc.'
+  any_feedback_about_training_for_the_midcamp_organizers_:
+    '#type': textarea
+    '#title': 'Any other feedback about training for the MidCamp organizers?'
+    '#description': 'If you want to be contacted in response to your feedback, please leave your name and email address in this field along with any other notes.'
 css: ''
 javascript: ''
 settings:
@@ -27,9 +96,9 @@ settings:
   page_theme_name: ''
   form_title: both
   form_submit_once: false
-  form_exception_message: ''
   form_open_message: ''
   form_close_message: ''
+  form_exception_message: ''
   form_previous_submissions: true
   form_confidential: false
   form_confidential_message: ''
@@ -39,31 +108,36 @@ settings:
   form_prepopulate_source_entity: false
   form_prepopulate_source_entity_required: false
   form_prepopulate_source_entity_type: ''
-  form_reset: false
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
   form_disable_autocomplete: false
   form_novalidate: false
   form_disable_inline_errors: false
   form_required: false
-  form_unsaved: false
-  form_disable_back: false
-  form_submit_back: false
   form_autofocus: false
   form_details_toggle: false
+  form_reset: false
   form_access_denied: default
   form_access_denied_title: ''
   form_access_denied_message: ''
   form_access_denied_attributes: {  }
   form_file_limit: ''
+  form_attributes: {  }
   form_method: ''
   form_action: ''
-  form_attributes: {  }
   share: false
   share_node: false
   share_theme_name: ''
   share_title: true
   share_page_body_attributes: {  }
   submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
   submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
   submission_views: {  }
   submission_views_replace: {  }
   submission_user_columns: {  }
@@ -72,11 +146,6 @@ settings:
   submission_access_denied_title: ''
   submission_access_denied_message: ''
   submission_access_denied_attributes: {  }
-  submission_exception_message: ''
-  submission_locked_message: ''
-  submission_excluded_elements: {  }
-  submission_exclude_empty: false
-  submission_exclude_empty_checkbox: false
   previous_submission_message: ''
   previous_submissions_message: ''
   autofill: false
@@ -87,13 +156,13 @@ settings:
   wizard_progress_percentage: false
   wizard_progress_link: false
   wizard_progress_states: false
-  wizard_auto_forward: true
-  wizard_auto_forward_hide_next_button: false
-  wizard_keyboard: true
   wizard_start_label: ''
   wizard_preview_link: false
   wizard_confirmation: false
   wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
   wizard_track: ''
   wizard_prev_button_label: ''
   wizard_next_button_label: ''
@@ -116,9 +185,9 @@ settings:
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
   confirmation_type: page
+  confirmation_url: ''
   confirmation_title: Thanks!
   confirmation_message: 'We really appreciate you taking the time to leave feedback. We hope to see you next year!'
-  confirmation_url: ''
   confirmation_attributes: {  }
   confirmation_back: false
   confirmation_back_label: ''
@@ -201,9 +270,9 @@ access:
 handlers:
   email_to_david:
     id: email
+    handler_id: email_to_david
     label: 'Email to David'
     notes: ''
-    handler_id: email_to_david
     status: true
     conditions: {  }
     weight: 0
@@ -212,13 +281,17 @@ handlers:
         - completed
       to_mail: david.needham+midcampfeedback@pantheon.io
       to_options: {  }
-      cc_mail: ''
-      cc_options: {  }
       bcc_mail: ''
       bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
       from_mail: _default
       from_options: {  }
       from_name: _default
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
       subject: _default
       body: _default
       excluded_elements: {  }
@@ -229,11 +302,7 @@ handlers:
       html: true
       attachments: false
       twig: false
-      debug: false
-      reply_to: ''
-      return_path: ''
-      sender_mail: ''
-      sender_name: ''
       theme_name: ''
       parameters: {  }
+      debug: false
 variants: {  }

--- a/conf/drupal/config/webform.webform_options.creditcard_codes.yml
+++ b/conf/drupal/config/webform.webform_options.creditcard_codes.yml
@@ -11,4 +11,8 @@ id: creditcard_codes
 label: 'Credit card codes'
 category: Payment
 likert: false
-options: "VI: 'Visa'\nMC: 'Mastercard'\nAE: 'American Express'\nDC: 'Discover'\n"
+options: |
+  VI: 'Visa'
+  MC: 'Mastercard'
+  AE: 'American Express'
+  DC: 'Discover'

--- a/conf/drupal/config/webform.webform_options.days.yml
+++ b/conf/drupal/config/webform.webform_options.days.yml
@@ -11,4 +11,11 @@ id: days
 label: Days
 category: 'Date and time'
 likert: false
-options: "Sunday: Sunday\nMonday: Monday\nTuesday: Tuesday\nWednesday: Wednesday\nThursday: Thursday\nFriday: Friday\nSaturday: Saturday\n"
+options: |
+  Sunday: Sunday
+  Monday: Monday
+  Tuesday: Tuesday
+  Wednesday: Wednesday
+  Thursday: Thursday
+  Friday: Friday
+  Saturday: Saturday

--- a/conf/drupal/config/webform.webform_options.education.yml
+++ b/conf/drupal/config/webform.webform_options.education.yml
@@ -11,4 +11,9 @@ id: education
 label: Education
 category: Demographic
 likert: false
-options: "High School: High School\nAssociate Degree: Associate Degree\nAssociate Degree: Associate Degree\nGraduate or Professional Degree: Graduate or Professional Degree\nSome College: Some College\n"
+options: |
+  High School: High School
+  Associate Degree: Associate Degree
+  Associate Degree: Associate Degree
+  Graduate or Professional Degree: Graduate or Professional Degree
+  Some College: Some College

--- a/conf/drupal/config/webform.webform_options.employment_status.yml
+++ b/conf/drupal/config/webform.webform_options.employment_status.yml
@@ -11,4 +11,9 @@ id: employment_status
 label: 'Employment status'
 category: Demographic
 likert: false
-options: "'Full Time': 'Full Time'\n'Part Time': 'Part Time'\n'Military': 'Military'\nUnemployed: Unemployed\nRetired: Retired\n"
+options: |
+  'Full Time': 'Full Time'
+  'Part Time': 'Part Time'
+  'Military': 'Military'
+  Unemployed: Unemployed
+  Retired: Retired

--- a/conf/drupal/config/webform.webform_options.ethnicity.yml
+++ b/conf/drupal/config/webform.webform_options.ethnicity.yml
@@ -11,4 +11,13 @@ id: ethnicity
 label: Ethnicity
 category: Demographic
 likert: false
-options: "Caucasian: Caucasian\nLatino/Hispanic: Latino/Hispanic\n'Middle Eastern': 'Middle Eastern'\nAfrican: African\nCaribbean: Caribbean\n'South Asian': 'South Asian'\n'East Asian': 'East Asian'\nMixed: Mixed\n'Prefer not to answer': 'Prefer not to answer'\n"
+options: |
+  Caucasian: Caucasian
+  Latino/Hispanic: Latino/Hispanic
+  'Middle Eastern': 'Middle Eastern'
+  African: African
+  Caribbean: Caribbean
+  'South Asian': 'South Asian'
+  'East Asian': 'East Asian'
+  Mixed: Mixed
+  'Prefer not to answer': 'Prefer not to answer'

--- a/conf/drupal/config/webform.webform_options.gender.yml
+++ b/conf/drupal/config/webform.webform_options.gender.yml
@@ -11,4 +11,8 @@ id: gender
 label: Gender
 category: Demographic
 likert: false
-options: "Male: Male\nFemale: Female\nTransgender: Transgender\n'Prefer not to answer': 'Prefer not to answer'\n"
+options: |
+  Male: Male
+  Female: Female
+  Transgender: Transgender
+  'Prefer not to answer': 'Prefer not to answer'

--- a/conf/drupal/config/webform.webform_options.industry.yml
+++ b/conf/drupal/config/webform.webform_options.industry.yml
@@ -11,4 +11,43 @@ id: industry
 label: Industry
 category: Demographic
 likert: false
-options: "Accounting/Finance: Accounting/Finance\nAdvertising/Public Relations: Advertising/Public Relations\nAerospace/Aviation: Aerospace/Aviation\nArts/Entertainment/Publishing: Arts/Entertainment/Publishing\nAutomotive: Automotive\nBanking/Mortgage: Banking/Mortgage\nBusiness Development: Business Development\nBusiness Opportunity: Business Opportunity\nClerical/Administrative: Clerical/Administrative\nConstruction/Facilities: Construction/Facilities\nConsumer Goods: Consumer Goods\nCustomer Service: Customer Service\nEducation/Training: Education/Training\nEnergy/Utilities: Energy/Utilities\nEngineering: Engineering\nGovernment/Military: Government/Military\nHealthcare: Healthcare\nHospitality/Travel: Hospitality/Travel\nHuman Resources: Human Resources\nInstallation/Maintenance: Installation/Maintenance\nInsurance: Insurance\nInternet: Internet\nLaw Enforcement/Security: Law Enforcement/Security\nLegal: Legal\nManagement/Executive: Management/Executive\nManufacturing/Operations: Manufacturing/Operations\nMarketing: Marketing\nNon-Profit/Volunteer: Non-Profit/Volunteer\nPharmaceutical/Biotech: Pharmaceutical/Biotech\nProfessional Services: Professional Services\nReal Estate: Real Estate\nRestaurant/Food Service: Restaurant/Food Service\nRetail: Retail\nSales: Sales\nScience/Research: Science/Research\nSkilled Labor: Skilled Labor\nTechnology: Technology\nTelecommunications: Telecommunications\nTransportation/Logistics: Transportation/Logistics\n"
+options: |
+  Accounting/Finance: Accounting/Finance
+  Advertising/Public Relations: Advertising/Public Relations
+  Aerospace/Aviation: Aerospace/Aviation
+  Arts/Entertainment/Publishing: Arts/Entertainment/Publishing
+  Automotive: Automotive
+  Banking/Mortgage: Banking/Mortgage
+  Business Development: Business Development
+  Business Opportunity: Business Opportunity
+  Clerical/Administrative: Clerical/Administrative
+  Construction/Facilities: Construction/Facilities
+  Consumer Goods: Consumer Goods
+  Customer Service: Customer Service
+  Education/Training: Education/Training
+  Energy/Utilities: Energy/Utilities
+  Engineering: Engineering
+  Government/Military: Government/Military
+  Healthcare: Healthcare
+  Hospitality/Travel: Hospitality/Travel
+  Human Resources: Human Resources
+  Installation/Maintenance: Installation/Maintenance
+  Insurance: Insurance
+  Internet: Internet
+  Law Enforcement/Security: Law Enforcement/Security
+  Legal: Legal
+  Management/Executive: Management/Executive
+  Manufacturing/Operations: Manufacturing/Operations
+  Marketing: Marketing
+  Non-Profit/Volunteer: Non-Profit/Volunteer
+  Pharmaceutical/Biotech: Pharmaceutical/Biotech
+  Professional Services: Professional Services
+  Real Estate: Real Estate
+  Restaurant/Food Service: Restaurant/Food Service
+  Retail: Retail
+  Sales: Sales
+  Science/Research: Science/Research
+  Skilled Labor: Skilled Labor
+  Technology: Technology
+  Telecommunications: Telecommunications
+  Transportation/Logistics: Transportation/Logistics

--- a/conf/drupal/config/webform.webform_options.likert_agreement.yml
+++ b/conf/drupal/config/webform.webform_options.likert_agreement.yml
@@ -11,4 +11,9 @@ id: likert_agreement
 label: 'Likert: Agreement'
 category: Likert
 likert: true
-options: "1: 'Much Worse'\n2: 'Somewhat Worse'\n3: 'About the Same'\n4: 'Somewhat Better'\n5: 'Much Better'\n"
+options: |
+  1: 'Much Worse'
+  2: 'Somewhat Worse'
+  3: 'About the Same'
+  4: 'Somewhat Better'
+  5: 'Much Better'

--- a/conf/drupal/config/webform.webform_options.likert_comparison.yml
+++ b/conf/drupal/config/webform.webform_options.likert_comparison.yml
@@ -11,4 +11,9 @@ id: likert_comparison
 label: 'Likert: Comparison'
 category: Likert
 likert: true
-options: "1: Strongly Disagree\n2: Disagree\n3: Neutral\n4: Agree\n5: Strongly Agree\n"
+options: |
+  1: Strongly Disagree
+  2: Disagree
+  3: Neutral
+  4: Agree
+  5: Strongly Agree

--- a/conf/drupal/config/webform.webform_options.likert_five_scale.yml
+++ b/conf/drupal/config/webform.webform_options.likert_five_scale.yml
@@ -11,4 +11,9 @@ id: likert_five_scale
 label: 'Likert: Five Scale'
 category: Likert
 likert: true
-options: "1: '1'\n2: '2'\n3: '3'\n4: '4'\n5: '5'\n"
+options: |
+  1: '1'
+  2: '2'
+  3: '3'
+  4: '4'
+  5: '5'

--- a/conf/drupal/config/webform.webform_options.likert_importance.yml
+++ b/conf/drupal/config/webform.webform_options.likert_importance.yml
@@ -11,4 +11,9 @@ id: likert_importance
 label: 'Likert: Importance'
 category: Likert
 likert: true
-options: "1: Not at all Important\n2: Somewhat Important\n3: Neutral\n4: Important\n5: Very Important\n"
+options: |
+  1: Not at all Important
+  2: Somewhat Important
+  3: Neutral
+  4: Important
+  5: Very Important

--- a/conf/drupal/config/webform.webform_options.likert_quality.yml
+++ b/conf/drupal/config/webform.webform_options.likert_quality.yml
@@ -11,4 +11,9 @@ id: likert_quality
 label: 'Likert: Quality'
 category: Likert
 likert: true
-options: "1: Poor\n2: Fair\n3: Good\n4: Very good\n5: Excellent\n"
+options: |
+  1: Poor
+  2: Fair
+  3: Good
+  4: Very good
+  5: Excellent

--- a/conf/drupal/config/webform.webform_options.likert_satisfaction.yml
+++ b/conf/drupal/config/webform.webform_options.likert_satisfaction.yml
@@ -11,4 +11,9 @@ id: likert_satisfaction
 label: 'Likert: Satisfaction'
 category: Likert
 likert: true
-options: "1: Very Unsatisfied\n2: Unsatisfied\n3: Neutral\n4: Satisfied\n5: Very Satisfied\n"
+options: |
+  1: Very Unsatisfied
+  2: Unsatisfied
+  3: Neutral
+  4: Satisfied
+  5: Very Satisfied

--- a/conf/drupal/config/webform.webform_options.likert_ten_scale.yml
+++ b/conf/drupal/config/webform.webform_options.likert_ten_scale.yml
@@ -11,4 +11,14 @@ id: likert_ten_scale
 label: 'Likert: Ten Scale'
 category: Likert
 likert: true
-options: "1: 1\n2: 2\n3: 3\n4: 4\n5: 5\n6: 6\n7: 7\n8: 8\n9: 9\n10: 10\n"
+options: |
+  1: 1
+  2: 2
+  3: 3
+  4: 4
+  5: 5
+  6: 6
+  7: 7
+  8: 8
+  9: 9
+  10: 10

--- a/conf/drupal/config/webform.webform_options.likert_would_you.yml
+++ b/conf/drupal/config/webform.webform_options.likert_would_you.yml
@@ -11,4 +11,9 @@ id: likert_would_you
 label: 'Likert: Would You'
 category: Likert
 likert: true
-options: "1: Definitely Not\n2: Probably Not\n3: Not Sure\n4: Probably\n5: Definitely\n"
+options: |
+  1: Definitely Not
+  2: Probably Not
+  3: Not Sure
+  4: Probably
+  5: Definitely

--- a/conf/drupal/config/webform.webform_options.marital_status.yml
+++ b/conf/drupal/config/webform.webform_options.marital_status.yml
@@ -11,4 +11,8 @@ id: marital_status
 label: 'Marital status'
 category: Demographic
 likert: false
-options: "Single: Single\nMarried: Married\nDivorced: Divorced\nWidowed: Widowed\n"
+options: |
+  Single: Single
+  Married: Married
+  Divorced: Divorced
+  Widowed: Widowed

--- a/conf/drupal/config/webform.webform_options.months.yml
+++ b/conf/drupal/config/webform.webform_options.months.yml
@@ -11,4 +11,16 @@ id: months
 label: Months
 category: 'Date and time'
 likert: false
-options: "January: January\nFebruary: February\nMarch: March\nApril: April\nMay: May\nJune: June\nJuly: July\nAugust: August\nSeptember: September\nOctober: October\nNovember: November\nDecember: December\n"
+options: |
+  January: January
+  February: February
+  March: March
+  April: April
+  May: May
+  June: June
+  July: July
+  August: August
+  September: September
+  October: October
+  November: November
+  December: December

--- a/conf/drupal/config/webform.webform_options.phone_types.yml
+++ b/conf/drupal/config/webform.webform_options.phone_types.yml
@@ -11,4 +11,7 @@ id: phone_types
 label: 'Phone type'
 category: Demographic
 likert: false
-options: "Home: Home\nOffice: Office\nCell: Cell\n"
+options: |
+  Home: Home
+  Office: Office
+  Cell: Cell

--- a/conf/drupal/config/webform.webform_options.relationship.yml
+++ b/conf/drupal/config/webform.webform_options.relationship.yml
@@ -11,4 +11,9 @@ id: relationship
 label: Relationship
 category: Demographic
 likert: false
-options: "Parent: Parent\n'Significant Other': 'Significant Other'\nSibling: Sibling\nChild: Child\nFriend: Friend\n"
+options: |
+  Parent: Parent
+  'Significant Other': 'Significant Other'
+  Sibling: Sibling
+  Child: Child
+  Friend: Friend

--- a/conf/drupal/config/webform.webform_options.size.yml
+++ b/conf/drupal/config/webform.webform_options.size.yml
@@ -11,4 +11,9 @@ id: size
 label: Size
 category: General
 likert: false
-options: "Extra Small: Extra Small\nSmall: Small\nMedium: Medium\nLarge: Large\nExtra Large: Extra Large\n"
+options: |
+  Extra Small: Extra Small
+  Small: Small
+  Medium: Medium
+  Large: Large
+  Extra Large: Extra Large

--- a/conf/drupal/config/webform.webform_options.state_codes.yml
+++ b/conf/drupal/config/webform.webform_options.state_codes.yml
@@ -11,4 +11,56 @@ id: state_codes
 label: 'State codes'
 category: Geographic
 likert: false
-options: "AL: Alabama\nAK: Alaska\nAZ: Arizona\nAR: Arkansas\nCA: California\nCO: Colorado\nCT: Connecticut\nDE: Delaware\nDC: 'District of Columbia'\nFL: Florida\nGA: Georgia\nGU: Guam\nHI: Hawaii\nID: Idaho\nIL: Illinois\nIN: Indiana\nIA: Iowa\nKS: Kansas\nKY: Kentucky\nLA: Louisiana\nME: Maine\nMD: Maryland\nMA: Massachusetts\nMI: Michigan\nMN: Minnesota\nMS: Mississippi\nMO: Missouri\nMT: Montana\nNE: Nebraska\nNV: Nevada\nNH: 'New Hampshire'\nNJ: 'New Jersey'\nNM: 'New Mexico'\nNY: 'New York'\nNC: 'North Carolina'\nND: 'North Dakota'\nOH: Ohio\nOK: Oklahoma\nOR: Oregon\nPA: Pennsylvania\nRI: 'Rhode Island'\nSC: 'South Carolina'\nSD: 'South Dakota'\nTN: Tennessee\nTX: Texas\nUT: Utah\nVT: Vermont\nVA: Virginia\nWA: Washington\nWV: 'West Virginia'\nWI: Wisconsin\nWY: Wyoming\n"
+options: |
+  AL: Alabama
+  AK: Alaska
+  AZ: Arizona
+  AR: Arkansas
+  CA: California
+  CO: Colorado
+  CT: Connecticut
+  DE: Delaware
+  DC: 'District of Columbia'
+  FL: Florida
+  GA: Georgia
+  GU: Guam
+  HI: Hawaii
+  ID: Idaho
+  IL: Illinois
+  IN: Indiana
+  IA: Iowa
+  KS: Kansas
+  KY: Kentucky
+  LA: Louisiana
+  ME: Maine
+  MD: Maryland
+  MA: Massachusetts
+  MI: Michigan
+  MN: Minnesota
+  MS: Mississippi
+  MO: Missouri
+  MT: Montana
+  NE: Nebraska
+  NV: Nevada
+  NH: 'New Hampshire'
+  NJ: 'New Jersey'
+  NM: 'New Mexico'
+  NY: 'New York'
+  NC: 'North Carolina'
+  ND: 'North Dakota'
+  OH: Ohio
+  OK: Oklahoma
+  OR: Oregon
+  PA: Pennsylvania
+  RI: 'Rhode Island'
+  SC: 'South Carolina'
+  SD: 'South Dakota'
+  TN: Tennessee
+  TX: Texas
+  UT: Utah
+  VT: Vermont
+  VA: Virginia
+  WA: Washington
+  WV: 'West Virginia'
+  WI: Wisconsin
+  WY: Wyoming

--- a/conf/drupal/config/webform.webform_options.state_names.yml
+++ b/conf/drupal/config/webform.webform_options.state_names.yml
@@ -11,4 +11,55 @@ id: state_names
 label: 'State names'
 category: Geographic
 likert: false
-options: "Alabama: Alabama\nAlaska: Alaska\nArizona: Arizona\nArkansas: Arkansas\nCalifornia: California\nColorado: Colorado\nConnecticut: Connecticut\nDelaware: Delaware\n'District of Columbia': 'District of Columbia'\nFlorida: Florida\nGeorgia: Georgia\nHawaii: Hawaii\nIdaho: Idaho\nIllinois: Illinois\nIndiana: Indiana\nIowa: Iowa\nKansas: Kansas\nKentucky: Kentucky\nLouisiana: Louisiana\nMaine: Maine\nMaryland: Maryland\nMassachusetts: Massachusetts\nMichigan: Michigan\nMinnesota: Minnesota\nMississippi: Mississippi\nMissouri: Missouri\nMontana: Montana\nNebraska: Nebraska\nNevada: Nevada\n'New Hampshire': 'New Hampshire'\n'New Jersey': 'New Jersey'\n'New Mexico': 'New Mexico'\n'New York': 'New York'\n'North Carolina': 'North Carolina'\n'North Dakota': 'North Dakota'\nOhio: Ohio\nOklahoma: Oklahoma\nOregon: Oregon\nPennsylvania: Pennsylvania\n'Rhode Island': 'Rhode Island'\n'South Carolina': 'South Carolina'\n'South Dakota': 'South Dakota'\nTennessee: Tennessee\nTexas: Texas\nUtah: Utah\nVermont: Vermont\nVirginia: Virginia\nWashington: Washington\n'West Virginia': 'West Virginia'\nWisconsin: Wisconsin\nWyoming: Wyoming\n"
+options: |
+  Alabama: Alabama
+  Alaska: Alaska
+  Arizona: Arizona
+  Arkansas: Arkansas
+  California: California
+  Colorado: Colorado
+  Connecticut: Connecticut
+  Delaware: Delaware
+  'District of Columbia': 'District of Columbia'
+  Florida: Florida
+  Georgia: Georgia
+  Hawaii: Hawaii
+  Idaho: Idaho
+  Illinois: Illinois
+  Indiana: Indiana
+  Iowa: Iowa
+  Kansas: Kansas
+  Kentucky: Kentucky
+  Louisiana: Louisiana
+  Maine: Maine
+  Maryland: Maryland
+  Massachusetts: Massachusetts
+  Michigan: Michigan
+  Minnesota: Minnesota
+  Mississippi: Mississippi
+  Missouri: Missouri
+  Montana: Montana
+  Nebraska: Nebraska
+  Nevada: Nevada
+  'New Hampshire': 'New Hampshire'
+  'New Jersey': 'New Jersey'
+  'New Mexico': 'New Mexico'
+  'New York': 'New York'
+  'North Carolina': 'North Carolina'
+  'North Dakota': 'North Dakota'
+  Ohio: Ohio
+  Oklahoma: Oklahoma
+  Oregon: Oregon
+  Pennsylvania: Pennsylvania
+  'Rhode Island': 'Rhode Island'
+  'South Carolina': 'South Carolina'
+  'South Dakota': 'South Dakota'
+  Tennessee: Tennessee
+  Texas: Texas
+  Utah: Utah
+  Vermont: Vermont
+  Virginia: Virginia
+  Washington: Washington
+  'West Virginia': 'West Virginia'
+  Wisconsin: Wisconsin
+  Wyoming: Wyoming

--- a/conf/drupal/config/webform.webform_options.state_province_codes.yml
+++ b/conf/drupal/config/webform.webform_options.state_province_codes.yml
@@ -11,4 +11,66 @@ id: state_province_codes
 label: 'State/Province codes'
 category: Geographic
 likert: false
-options: "AL: Alabama\nAK: Alaska\nAS: 'American Samoa'\nAZ: Arizona\nAR: Arkansas\nAE: 'Armed Forces (Canada, Europe, Africa, or Middle East)'\nAA: 'Armed Forces Americas'\nAP: 'Armed Forces Pacific'\nCA: California\nCO: Colorado\nCT: Connecticut\nDE: Delaware\nDC: 'District of Columbia'\nFM: 'Federate States of Micronesia'\nFL: Florida\nGA: Georgia\nGU: Guam\nHI: Hawaii\nID: Idaho\nIL: Illinois\nIN: Indiana\nIA: Iowa\nKS: Kansas\nKY: Kentucky\nLA: Louisiana\nME: Maine\nMH: 'Marshall Islands'\nMD: Maryland\nMA: Massachusetts\nMI: Michigan\nMN: Minnesota\nMS: Mississippi\nMO: Missouri\nMT: Montana\nNE: Nebraska\nNV: Nevada\nNH: 'New Hampshire'\nNJ: 'New Jersey'\nNM: 'New Mexico'\nNY: 'New York'\nNC: 'North Carolina'\nND: 'North Dakota'\nMP: 'Northern Mariana Islands'\nOH: Ohio\nOK: Oklahoma\nOR: Oregon\nPW: Palau\nPA: Pennsylvania\nPR: 'Puerto Rico'\nRI: 'Rhode Island'\nSC: 'South Carolina'\nSD: 'South Dakota'\nTN: Tennessee\nTX: Texas\nUT: Utah\nVT: Vermont\nVI: 'Virgin Islands'\nVA: Virginia\nWA: Washington\nWV: 'West Virginia'\nWI: Wisconsin\nWY: Wyoming\n"
+options: |
+  AL: Alabama
+  AK: Alaska
+  AS: 'American Samoa'
+  AZ: Arizona
+  AR: Arkansas
+  AE: 'Armed Forces (Canada, Europe, Africa, or Middle East)'
+  AA: 'Armed Forces Americas'
+  AP: 'Armed Forces Pacific'
+  CA: California
+  CO: Colorado
+  CT: Connecticut
+  DE: Delaware
+  DC: 'District of Columbia'
+  FM: 'Federate States of Micronesia'
+  FL: Florida
+  GA: Georgia
+  GU: Guam
+  HI: Hawaii
+  ID: Idaho
+  IL: Illinois
+  IN: Indiana
+  IA: Iowa
+  KS: Kansas
+  KY: Kentucky
+  LA: Louisiana
+  ME: Maine
+  MH: 'Marshall Islands'
+  MD: Maryland
+  MA: Massachusetts
+  MI: Michigan
+  MN: Minnesota
+  MS: Mississippi
+  MO: Missouri
+  MT: Montana
+  NE: Nebraska
+  NV: Nevada
+  NH: 'New Hampshire'
+  NJ: 'New Jersey'
+  NM: 'New Mexico'
+  NY: 'New York'
+  NC: 'North Carolina'
+  ND: 'North Dakota'
+  MP: 'Northern Mariana Islands'
+  OH: Ohio
+  OK: Oklahoma
+  OR: Oregon
+  PW: Palau
+  PA: Pennsylvania
+  PR: 'Puerto Rico'
+  RI: 'Rhode Island'
+  SC: 'South Carolina'
+  SD: 'South Dakota'
+  TN: Tennessee
+  TX: Texas
+  UT: Utah
+  VT: Vermont
+  VI: 'Virgin Islands'
+  VA: Virginia
+  WA: Washington
+  WV: 'West Virginia'
+  WI: Wisconsin
+  WY: Wyoming

--- a/conf/drupal/config/webform.webform_options.state_province_names.yml
+++ b/conf/drupal/config/webform.webform_options.state_province_names.yml
@@ -11,4 +11,66 @@ id: state_province_names
 label: 'State/Province names'
 category: Geographic
 likert: false
-options: "Alabama: Alabama\nAlaska: Alaska\n'American Samoa': 'American Samoa'\nArizona: Arizona\nArkansas: Arkansas\n'Armed Forces (Canada, Europe, Africa, or Middle East': 'Armed Forces (Canada, Europe, Africa, or Middle East'\n'Armed Forces Americas': 'Armed Forces Americas'\n'Armed Forces Pacific': 'Armed Forces Pacific'\nCalifornia: California\nColorado: Colorado\nConnecticut: Connecticut\nDelaware: Delaware\n'District of Columbia': 'District of Columbia'\n'Federate States of Micronesia': 'Federate States of Micronesia'\nFlorida: Florida\nGeorgia: Georgia\nGuam: Guam\nHawaii: Hawaii\nIdaho: Idaho\nIllinois: Illinois\nIndiana: Indiana\nIowa: Iowa\nKansas: Kansas\nKentucky: Kentucky\nLouisiana: Louisiana\nMaine: Maine\n'Marshall Islands': 'Marshall Islands'\nMaryland: Maryland\nMassachusetts: Massachusetts\nMichigan: Michigan\nMinnesota: Minnesota\nMississippi: Mississippi\nMissouri: Missouri\nMontana: Montana\nNebraska: Nebraska\nNevada: Nevada\n'New Hampshire': 'New Hampshire'\n'New Jersey': 'New Jersey'\n'New Mexico': 'New Mexico'\n'New York': 'New York'\n'North Carolina': 'North Carolina'\n'North Dakota': 'North Dakota'\n'Northern Mariana Islands': 'Northern Mariana Islands'\nOhio: Ohio\nOklahoma: Oklahoma\nOregon: Oregon\nPalau: Palau\nPennsylvania: Pennsylvania\n'Puerto Rico': 'Puerto Rico'\n'Rhode Island': 'Rhode Island'\n'South Carolina': 'South Carolina'\n'South Dakota': 'South Dakota'\nTennessee: Tennessee\nTexas: Texas\nUtah: Utah\nVermont: Vermont\n'Virgin Islands': 'Virgin Islands'\nVirginia: Virginia\nWashington: Washington\n'West Virginia': 'West Virginia'\nWisconsin: Wisconsin\nWyoming: Wyoming\n"
+options: |
+  Alabama: Alabama
+  Alaska: Alaska
+  'American Samoa': 'American Samoa'
+  Arizona: Arizona
+  Arkansas: Arkansas
+  'Armed Forces (Canada, Europe, Africa, or Middle East': 'Armed Forces (Canada, Europe, Africa, or Middle East'
+  'Armed Forces Americas': 'Armed Forces Americas'
+  'Armed Forces Pacific': 'Armed Forces Pacific'
+  California: California
+  Colorado: Colorado
+  Connecticut: Connecticut
+  Delaware: Delaware
+  'District of Columbia': 'District of Columbia'
+  'Federate States of Micronesia': 'Federate States of Micronesia'
+  Florida: Florida
+  Georgia: Georgia
+  Guam: Guam
+  Hawaii: Hawaii
+  Idaho: Idaho
+  Illinois: Illinois
+  Indiana: Indiana
+  Iowa: Iowa
+  Kansas: Kansas
+  Kentucky: Kentucky
+  Louisiana: Louisiana
+  Maine: Maine
+  'Marshall Islands': 'Marshall Islands'
+  Maryland: Maryland
+  Massachusetts: Massachusetts
+  Michigan: Michigan
+  Minnesota: Minnesota
+  Mississippi: Mississippi
+  Missouri: Missouri
+  Montana: Montana
+  Nebraska: Nebraska
+  Nevada: Nevada
+  'New Hampshire': 'New Hampshire'
+  'New Jersey': 'New Jersey'
+  'New Mexico': 'New Mexico'
+  'New York': 'New York'
+  'North Carolina': 'North Carolina'
+  'North Dakota': 'North Dakota'
+  'Northern Mariana Islands': 'Northern Mariana Islands'
+  Ohio: Ohio
+  Oklahoma: Oklahoma
+  Oregon: Oregon
+  Palau: Palau
+  Pennsylvania: Pennsylvania
+  'Puerto Rico': 'Puerto Rico'
+  'Rhode Island': 'Rhode Island'
+  'South Carolina': 'South Carolina'
+  'South Dakota': 'South Dakota'
+  Tennessee: Tennessee
+  Texas: Texas
+  Utah: Utah
+  Vermont: Vermont
+  'Virgin Islands': 'Virgin Islands'
+  Virginia: Virginia
+  Washington: Washington
+  'West Virginia': 'West Virginia'
+  Wisconsin: Wisconsin
+  Wyoming: Wyoming

--- a/conf/drupal/config/webform.webform_options.titles.yml
+++ b/conf/drupal/config/webform.webform_options.titles.yml
@@ -11,4 +11,9 @@ id: titles
 label: Titles
 category: Demographic
 likert: false
-options: "Miss: Miss\nMs: Ms\nMr: Mr\nMrs: Mrs\nDr: Dr\n"
+options: |
+  Miss: Miss
+  Ms: Ms
+  Mr: Mr
+  Mrs: Mrs
+  Dr: Dr

--- a/conf/drupal/config/webform.webform_options.yes_no.yml
+++ b/conf/drupal/config/webform.webform_options.yes_no.yml
@@ -11,4 +11,6 @@ id: yes_no
 label: Yes/No
 category: General
 likert: false
-options: "Yes: Yes\nNo: No\n"
+options: |
+  Yes: Yes
+  No: No

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,1 @@
+/README.md

--- a/web/.htaccess
+++ b/web/.htaccess
@@ -116,13 +116,13 @@ AddEncoding gzip svgz
   # RewriteBase /
 
   # Redirect common PHP files to their new locations.
-  RewriteCond %{REQUEST_URI} ^(.*)?/(install.php) [OR]
-  RewriteCond %{REQUEST_URI} ^(.*)?/(rebuild.php)
+  RewriteCond %{REQUEST_URI} ^(.*)?/(install\.php) [OR]
+  RewriteCond %{REQUEST_URI} ^(.*)?/(rebuild\.php)
   RewriteCond %{REQUEST_URI} !core
   RewriteRule ^ %1/core/%2 [L,QSA,R=301]
 
   # Rewrite install.php during installation to see if mod_rewrite is working
-  RewriteRule ^core/install.php core/install.php?rewrite=ok [QSA,L]
+  RewriteRule ^core/install\.php core/install.php?rewrite=ok [QSA,L]
 
   # Pass all requests not referring directly to files in the filesystem to
   # index.php.
@@ -138,11 +138,11 @@ AddEncoding gzip svgz
   # Allow access to PHP files in /core (like authorize.php or install.php):
   RewriteCond %{REQUEST_URI} !/core/[^/]*\.php$
   # Allow access to test-specific PHP files:
-  RewriteCond %{REQUEST_URI} !/core/modules/system/tests/https?.php
+  RewriteCond %{REQUEST_URI} !/core/modules/system/tests/https?\.php
   # Allow access to Statistics module's custom front controller.
   # Copy and adapt this rule to directly execute PHP files in contributed or
   # custom modules or to run another PHP application in the same directory.
-  RewriteCond %{REQUEST_URI} !/core/modules/statistics/statistics.php$
+  RewriteCond %{REQUEST_URI} !/core/modules/statistics/statistics\.php$
   # Deny access to any other PHP files that do not match the rules above.
   # Specifically, disallow autoload.php from being served directly.
   RewriteRule "^(.+/.*|autoload)\.php($|/)" - [F]

--- a/web/modules/custom/midcamp_utility/midcamp_utility.module
+++ b/web/modules/custom/midcamp_utility/midcamp_utility.module
@@ -48,7 +48,7 @@ function midcamp_utility_views_pre_view(ViewExecutable $view, $display_id, array
       $current_uri = \Drupal::request()->getRequestUri();
       $parts = explode('/', $current_uri);
       // Get the term ID from the path
-      $term_path = \Drupal::service('path.alias_manager')->getPathByAlias('/' . $parts[1]);
+      $term_path = \Drupal::service('path_alias.manager')->getPathByAlias('/' . $parts[1]);
       $term_args = explode('/', $term_path);
 
       // If we've found a taxonomy term path pass the term ID.

--- a/web/robots.txt
+++ b/web/robots.txt
@@ -45,17 +45,17 @@ Disallow: /comment/reply/
 Disallow: /filter/tips
 Disallow: /node/add/
 Disallow: /search/
-Disallow: /user/register/
-Disallow: /user/password/
-Disallow: /user/login/
-Disallow: /user/logout/
+Disallow: /user/register
+Disallow: /user/password
+Disallow: /user/login
+Disallow: /user/logout
 # Paths (no clean URLs)
 Disallow: /index.php/admin/
 Disallow: /index.php/comment/reply/
 Disallow: /index.php/filter/tips
 Disallow: /index.php/node/add/
 Disallow: /index.php/search/
-Disallow: /index.php/user/password/
-Disallow: /index.php/user/register/
-Disallow: /index.php/user/login/
-Disallow: /index.php/user/logout/
+Disallow: /index.php/user/password
+Disallow: /index.php/user/register
+Disallow: /index.php/user/login
+Disallow: /index.php/user/logout

--- a/web/sites/example.settings.local.php
+++ b/web/sites/example.settings.local.php
@@ -1,6 +1,6 @@
 <?php
 
-// @codingStandardsIgnoreFile
+// phpcs:ignoreFile
 
 /**
  * @file

--- a/web/sites/example.sites.php
+++ b/web/sites/example.sites.php
@@ -1,6 +1,6 @@
 <?php
 
-// @codingStandardsIgnoreFile
+// phpcs:ignoreFile
 
 /**
  * @file

--- a/web/update.php
+++ b/web/update.php
@@ -16,7 +16,6 @@ $autoloader = require_once 'autoload.php';
 // Disable garbage collection during test runs. Under certain circumstances the
 // update path will create so many objects that garbage collection causes
 // segmentation faults.
-require_once 'core/includes/bootstrap.inc';
 if (drupal_valid_test_ua()) {
   gc_collect_cycles();
   gc_disable();

--- a/web/web.config
+++ b/web/web.config
@@ -33,18 +33,6 @@
             <add input="{REQUEST_FILENAME}" matchType="IsFile" negate="true" />
           </conditions>
         </rule>
-     <!-- If running on a PHP version affected by httpoxy vulnerability
-      uncomment the following rule to mitigate it's impact. To make this
-      rule work, you will also need to add HTTP_PROXY to the allowed server
-      variables manually in IIS. See https://www.drupal.org/node/2783079.
-        <rule name="Erase HTTP_PROXY" patternSyntax="Wildcard">
-          <match url="*.*" />
-          <serverVariables>
-            <set name="HTTP_PROXY" value="" />
-          </serverVariables>
-          <action type="None" />
-        </rule>
-    -->
     <!-- To redirect all users to access the site WITH the 'www.' prefix,
      http://example.com/foo will be redirected to http://www.example.com/foo)
      adapt and uncomment the following:   -->


### PR DESCRIPTION
# Description

- Effectively removes `"spress/spress"`, a dependency of [MidCamp/Hatter](https://github.com/MidCamp/Hatter) incompatible with Drupal 9's TWIG version
- Upgrades Redirect module for D9 support
- Adds `drupal/core-recommended` package
- Updates Drupal Core to version 9.3
- Updates all config for Drupal Core's new config key ordering
- Updates Drush
- Updates Drupal Extension
- Removes Drupal Console

# Test instructions

1. Install updated dependencies with `lando composer install`
2. Perform database updates via `lando drush updb -y`
3. Browse the site and confirm it still works