### PR TITLE
Initial ddev config

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,0 +1,276 @@
+name: midcamp
+type: drupal9
+docroot: web
+php_version: "7.4"
+webserver_type: nginx-fpm
+xdebug_enabled: false
+additional_hostnames: []
+additional_fqdns: []
+database:
+    type: mariadb
+    version: "10.4"
+use_dns_when_possible: true
+composer_version: "2"
+web_environment:
+    - LAGOON_ENVIRONMENT=midcamp-org-production
+    - LAGOON_PROJECT=midcamp-org
+
+# Key features of DDEV's config.yaml:
+
+# name: <projectname> # Name of the project, automatically provides
+#   http://projectname.ddev.site and https://projectname.ddev.site
+
+# type: <projecttype>  # drupal6/7/8, backdrop, typo3, wordpress, php
+
+# docroot: <relative_path> # Relative path to the directory containing index.php.
+
+# php_version: "8.1"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"
+
+# You can explicitly specify the webimage but this
+# is not recommended, as the images are often closely tied to DDEV's' behavior,
+# so this can break upgrades.
+
+# webimage: <docker_image>  # nginx/php docker image.
+
+# database:
+#   type: <dbtype> # mysql, mariadb, postgres
+#   version: <version> # database version, like "10.4" or "8.0"
+#   MariaDB versions can be 5.5-10.8 and 10.11, MySQL versions can be 5.5-8.0
+#   PostgreSQL versions can be 9-16.
+
+# router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)
+# router_https_port: <port> # Port for https (defaults to global configuration, usually 443)
+
+# xdebug_enabled: false  # Set to true to enable Xdebug and "ddev start" or "ddev restart"
+# Note that for most people the commands
+# "ddev xdebug" to enable Xdebug and "ddev xdebug off" to disable it work better,
+# as leaving Xdebug enabled all the time is a big performance hit.
+
+# xhprof_enabled: false  # Set to true to enable Xhprof and "ddev start" or "ddev restart"
+# Note that for most people the commands
+# "ddev xhprof" to enable Xhprof and "ddev xhprof off" to disable it work better,
+# as leaving Xhprof enabled all the time is a big performance hit.
+
+# webserver_type: nginx-fpm, apache-fpm, or nginx-gunicorn
+
+# timezone: Europe/Berlin
+# This is the timezone used in the containers and by PHP;
+# it can be set to any valid timezone,
+# see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+# For example Europe/Dublin or MST7MDT
+
+# composer_root: <relative_path>
+# Relative path to the Composer root directory from the project root. This is
+# the directory which contains the composer.json and where all Composer related
+# commands are executed.
+
+# composer_version: "2"
+# You can set it to "" or "2" (default) for Composer v2 or "1" for Composer v1
+# to use the latest major version available at the time your container is built.
+# It is also possible to use each other Composer version channel. This includes:
+#   - 2.2 (latest Composer LTS version)
+#   - stable
+#   - preview
+#   - snapshot
+# Alternatively, an explicit Composer version may be specified, for example "2.2.18".
+# To reinstall Composer after the image was built, run "ddev debug refresh".
+
+# nodejs_version: "18"
+# change from the default system Node.js version to another supported version, like 16, 18, 20.
+# Note that you can use 'ddev nvm' or nvm inside the web container to provide nearly any
+# Node.js version, including v6, etc.
+# You only need to configure this if you are not using nvm and you want to use a major
+# version that is not the default.
+
+# additional_hostnames:
+#  - somename
+#  - someothername
+# would provide http and https URLs for "somename.ddev.site"
+# and "someothername.ddev.site".
+
+# additional_fqdns:
+#  - example.com
+#  - sub1.example.com
+# would provide http and https URLs for "example.com" and "sub1.example.com"
+# Please take care with this because it can cause great confusion.
+
+# upload_dirs: "custom/upload/dir"
+#
+# upload_dirs:
+#   - custom/upload/dir
+#   - ../private
+#
+# would set the destination paths for ddev import-files to <docroot>/custom/upload/dir
+# When Mutagen is enabled this path is bind-mounted so that all the files
+# in the upload_dirs don't have to be synced into Mutagen.
+
+# disable_upload_dirs_warning: false
+# If true, turns off the normal warning that says
+# "You have Mutagen enabled and your 'php' project type doesn't have upload_dirs set"
+
+# ddev_version_constraint: ""
+# Example:
+# ddev_version_constraint: ">= 1.22.4"
+# This will enforce that the running ddev version is within this constraint.
+# See https://github.com/Masterminds/semver#checking-version-constraints for
+# supported constraint formats
+
+# working_dir:
+#   web: /var/www/html
+#   db: /home
+# would set the default working directory for the web and db services.
+# These values specify the destination directory for ddev ssh and the
+# directory in which commands passed into ddev exec are run.
+
+# omit_containers: [db, ddev-ssh-agent]
+# Currently only these containers are supported. Some containers can also be
+# omitted globally in the ~/.ddev/global_config.yaml. Note that if you omit
+# the "db" container, several standard features of DDEV that access the
+# database container will be unusable. In the global configuration it is also
+# possible to omit ddev-router, but not here.
+
+# performance_mode: "global"
+# DDEV offers performance optimization strategies to improve the filesystem
+# performance depending on your host system. Should be configured globally.
+#
+# If set, will override the global config. Possible values are:
+#   - "global":  uses the value from the global config.
+#   - "none":    disables performance optimization for this project.
+#   - "mutagen": enables Mutagen for this project.
+#   - "nfs":     enables NFS for this project.
+#
+# See https://ddev.readthedocs.io/en/latest/users/install/performance/#nfs
+# See https://ddev.readthedocs.io/en/latest/users/install/performance/#mutagen
+
+# fail_on_hook_fail: False
+# Decide whether 'ddev start' should be interrupted by a failing hook
+
+# host_https_port: "59002"
+# The host port binding for https can be explicitly specified. It is
+# dynamic unless otherwise specified.
+# This is not used by most people, most people use the *router* instead
+# of the localhost port.
+
+# host_webserver_port: "59001"
+# The host port binding for the ddev-webserver can be explicitly specified. It is
+# dynamic unless otherwise specified.
+# This is not used by most people, most people use the *router* instead
+# of the localhost port.
+
+# host_db_port: "59002"
+# The host port binding for the ddev-dbserver can be explicitly specified. It is dynamic
+# unless explicitly specified.
+
+# mailpit_http_port: "8025"
+# mailpit_https_port: "8026"
+# The Mailpit ports can be changed from the default 8025 and 8026
+
+# host_mailpit_port: "8025"
+# The mailpit port is not normally bound on the host at all, instead being routed
+# through ddev-router, but it can be bound directly to localhost if specified here.
+
+# webimage_extra_packages: [php7.4-tidy, php-bcmath]
+# Extra Debian packages that are needed in the webimage can be added here
+
+# dbimage_extra_packages: [telnet,netcat]
+# Extra Debian packages that are needed in the dbimage can be added here
+
+# use_dns_when_possible: true
+# If the host has internet access and the domain configured can
+# successfully be looked up, DNS will be used for hostname resolution
+# instead of editing /etc/hosts
+# Defaults to true
+
+# project_tld: ddev.site
+# The top-level domain used for project URLs
+# The default "ddev.site" allows DNS lookup via a wildcard
+# If you prefer you can change this to "ddev.local" to preserve
+# pre-v1.9 behavior.
+
+# ngrok_args: --basic-auth username:pass1234
+# Provide extra flags to the "ngrok http" command, see
+# https://ngrok.com/docs/ngrok-agent/config or run "ngrok http -h"
+
+# disable_settings_management: false
+# If true, DDEV will not create CMS-specific settings files like
+# Drupal's settings.php/settings.ddev.php or TYPO3's AdditionalConfiguration.php
+# In this case the user must provide all such settings.
+
+# You can inject environment variables into the web container with:
+# web_environment:
+# - SOMEENV=somevalue
+# - SOMEOTHERENV=someothervalue
+
+# no_project_mount: false
+# (Experimental) If true, DDEV will not mount the project into the web container;
+# the user is responsible for mounting it manually or via a script.
+# This is to enable experimentation with alternate file mounting strategies.
+# For advanced users only!
+
+# bind_all_interfaces: false
+# If true, host ports will be bound on all network interfaces,
+# not the localhost interface only. This means that ports
+# will be available on the local network if the host firewall
+# allows it.
+
+# default_container_timeout: 120
+# The default time that DDEV waits for all containers to become ready can be increased from
+# the default 120. This helps in importing huge databases, for example.
+
+#web_extra_exposed_ports:
+#- name: nodejs
+#  container_port: 3000
+#  http_port: 2999
+#  https_port: 3000
+#- name: something
+#  container_port: 4000
+#  https_port: 4000
+#  http_port: 3999
+# Allows a set of extra ports to be exposed via ddev-router
+# Fill in all three fields even if you don’t intend to use the https_port!
+# If you don’t add https_port, then it defaults to 0 and ddev-router will fail to start.
+#
+# The port behavior on the ddev-webserver must be arranged separately, for example
+# using web_extra_daemons.
+# For example, with a web app on port 3000 inside the container, this config would
+# expose that web app on https://<project>.ddev.site:9999 and http://<project>.ddev.site:9998
+# web_extra_exposed_ports:
+#  - name: myapp
+#    container_port: 3000
+#    http_port: 9998
+#    https_port: 9999
+
+#web_extra_daemons:
+#- name: "http-1"
+#  command: "/var/www/html/node_modules/.bin/http-server -p 3000"
+#  directory: /var/www/html
+#- name: "http-2"
+#  command: "/var/www/html/node_modules/.bin/http-server /var/www/html/sub -p 3000"
+#  directory: /var/www/html
+
+# override_config: false
+# By default, config.*.yaml files are *merged* into the configuration
+# But this means that some things can't be overridden
+# For example, if you have 'use_dns_when_possible: true'' you can't override it with a merge
+# and you can't erase existing hooks or all environment variables.
+# However, with "override_config: true" in a particular config.*.yaml file,
+# 'use_dns_when_possible: false' can override the existing values, and
+# hooks:
+#   post-start: []
+# or
+# web_environment: []
+# or
+# additional_hostnames: []
+# can have their intended affect. 'override_config' affects only behavior of the
+# config.*.yaml file it exists in.
+
+# Many DDEV commands can be extended to run tasks before or after the
+# DDEV command is executed, for example "post-start", "post-import-db",
+# "pre-composer", "post-composer"
+# See https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/ for more
+# information on the commands that can be extended and the tasks you can define
+# for them. Example:
+#hooks:
+# post-import-db:
+#   - exec: drush cr
+#   - exec: drush updb

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -12,7 +12,7 @@ database:
 use_dns_when_possible: true
 composer_version: "2"
 web_environment:
-    - LAGOON_ENVIRONMENT=midcamp-org-production
+    - LAGOON_ENVIRONMENT=production
     - LAGOON_PROJECT=midcamp-org
 
 # Key features of DDEV's config.yaml:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,6 @@
 # DDEV Gitpod config via https://github.com/shaal/ddev-gitpod/blob/main/.gitpod.yml
+image: drupalpod/drupalpod-gitpod-base:20230922
+
 tasks:
   - init: |
       ddev start -y

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,51 @@
+# DDEV Gitpod config via https://github.com/shaal/ddev-gitpod/blob/main/.gitpod.yml
+tasks:
+  - init: |
+      ddev start -y
+      ddev composer install
+    command: |
+      ddev start -y
+      gp ports await 8080 && gp preview $(gp url 8080)
+
+# VScode xdebug extension
+vscode:
+  extensions:
+    # PHP extensions.
+    - felixfbecker.php-debug
+    - wongjn.php-sniffer
+    - neilbrayfield.php-docblocker
+    - bmewburn.vscode-intelephense-client
+    - andrewdavidblum.drupal-smart-snippets
+
+    # Twig extensions.
+    - mblode.twig-language-2
+
+    # Bash extensions.
+    - timonwong.shellcheck
+    - rogalmic.bash-debug
+
+ports:
+  # Used by ddev - local db clients
+  - port: 3306
+    onOpen: ignore
+  # Used by projector
+  - port: 6942
+    onOpen: ignore
+  # Used by MailHog
+  - port: 8027
+    onOpen: ignore
+  # Used by phpMyAdmin
+  - port: 8036
+    onOpen: ignore
+  # Direct-connect ddev-webserver port that is the main port
+  - port: 8080
+    onOpen: ignore
+  # Ignore host https port
+  - port: 8443
+    onOpen: ignore
+  # xdebug port
+  - port: 9003
+    onOpen: ignore
+  # projector port
+  - port: 9999
+    onOpen: open-browser

--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -75,3 +75,15 @@ environments:
         schedule: "2 * * * *"
         command: drush cron
         service: cli
+
+lagoon-sync:
+  mariadb:
+    config:
+      hostname: "${MARIADB_HOST:-mariadb}"
+      username: "${MARIADB_USERNAME:-drupal}"
+      password: "${MARIADB_PASSWORD:-drupal}"
+      port: "${MARIADB_PORT:-3306}"
+      database: "${MARIADB_DATABASE:-drupal}"
+  files:
+    config:
+      sync-directory: "web/sites/default/files"

--- a/README.md
+++ b/README.md
@@ -1,28 +1,54 @@
 # MidCamp
 
-## The Drupal 8 website for midcamp.org
+## The Drupal website for midcamp.org
 [![CircleCI](https://circleci.com/gh/MidCamp/midcamp.svg?style=shield)](https://circleci.com/gh/MidCamp/midcamp)
 [![Code Climate](https://codeclimate.com/github/MidCamp/midcamp/badges/gpa.svg)](https://codeclimate.com/github/MidCamp/midcamp)
 
-## Prerequisites
+## Getting access
+
+Ensure you have an Amazee account with your [SSH keys loaded](http://dashboard.amazeeio.cloud/settings).  If not reach out on the [MidCamp Slack](https://mid.camp/slack) in `#website-amazeeio`.
+
+## DDEV-mode
+
+### Prerequisites
+
+- [DDEV](https://ddev.readthedocs.io/en/latest/users/install/)
+
+### Getting started
+
+Refer to [DDEV's documentation](https://ddev.readthedocs.io/en/latest/) for detailed information on configuration, customization and troubleshooting.
+
+1. Start your local environment with `ddev start`
+1. Run `ddev auth ssh` to load your ssh keys.
+1. Import your local database and files via:
+    1. `ddev pull lagoon`
+    1. Skip files/db with `--skip-files` or `--skip-db`
+
+## GitPod-mode
+
+- [Add your SSH keys to GitPod (maybe)](https://github.com/gitpod-io/gitpod/issues/666)
+- [Rock and roll](https://gitpod.io/?autostart=true#https://github.com/MidCamp/midcamp)
+
+## Lando-mode
+
+### Prerequisites
 
 - Lando (tested and working with version [`v3.0.23`](https://github.com/lando/lando/releases/tag/v3.0.23))
 
-##  Getting started
+###  Getting started
 
 Refer to [Lando's documentation](https://docs.lando.dev/) for detailed information on configuration, customization and troubleshooting.
 
 1. Start your local environment with `lando start`
-1. Ensure you have an Amazee account with your SSH keys loaded.  If not reach out on the [Amazee Rocket Chat](https://amazeeio.rocket.chat/group/midcamp).
 1. Import your local database and files via:
     1. `lando get-db`
     1. `lando get-files`
 
-## Working with Lando
+### Working with Lando
 
 Some common Lando commands to be aware of:
 
-- `lando start` statrs your application
+- `lando start` starts your application
 - `lando stop` stops your application
 - `lando poweroff` stops Lando and any Lando apps currently running
 - `lando restart` restarts your application

--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ Refer to [DDEV's documentation](https://ddev.readthedocs.io/en/latest/) for deta
 
 ## GitPod-mode
 
-- [Add your SSH keys to GitPod (maybe)](https://github.com/gitpod-io/gitpod/issues/666)
+`.gitpod.yml` adds support for developing in a fully web-based environment called [GitPod](https://gitpod.io). GitPod doesn't have a great solution for forwarding ssh keys yet, so in order to be able to pull from Amazee you have two options:
+
+1. [Add your existing SSH keys to GitPod (if you trust them)]https://github.com/gitpod-io/gitpod/issues/666#issuecomment-534124994)
+1. [Generate a new key pod and give it to Amazee](https://docs.lagoon.sh/using-lagoon-advanced/ssh/) - you'll have to do this on every new instance, but Amazee will recognize new keys basically instantaneously, so it isn't too bad.
+
 - [Rock and roll](https://gitpod.io/?autostart=true#https://github.com/MidCamp/midcamp)
 
 ## Lando-mode
@@ -68,6 +72,16 @@ When beginning work on a task, start a new branch:
 `git checkout -b feature/my-great-work`
 
 Amazee [workflows](https://lagoon.readthedocs.io/en/latest/using_lagoon/workflows/) will build a new environment for every branch that begins with `feature/` when it's pushed to GitHub. In order to access the environment for the branch above, visit https://nginx-midcamp-org-feature-my-great-work.us.amazee.io/. Databases for that environment are synced from Amazee dev, and it takes a few minutes after Circle completes for the install to complete.
+
+### Deploying
+
+To deploy a feature:
+
+- merge your feature branch into `master`,
+- (optional but plz) give it a few minutes to sync, then test your work on https://dev.midcamp.org/
+- merge `master` to `production`.
+
+See `deploy_tasks` in `.amazeeio.yml` for what happens after deploy (`updb`, `cim`, and more!)
 
 ## How do I Drupal?
 

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -157,3 +157,9 @@ if (file_exists(__DIR__ . '/settings.local.php')) {
 if (file_exists(__DIR__ . '/services.local.yml')) {
   $settings['container_yamls'][] = __DIR__ . '/services.local.yml';
 }
+
+// Automatically generated include for settings managed by ddev.
+$ddev_settings = dirname(__FILE__) . '/settings.ddev.php';
+if (getenv('IS_DDEV_PROJECT') == 'true' && is_readable($ddev_settings)) {
+  require $ddev_settings;
+}


### PR DESCRIPTION
Getting started... here's how I got here:

- https://ddev.readthedocs.io/en/latest/users/install/ddev-installation/#gitpod option 1
- change php version to 7.4
- ddev start
- ddev composer install
- got drupal install!
- https://ddev.readthedocs.io/en/latest/users/providers/lagoon/?h=lagoon
- ddev config --web-environment-add="LAGOON_PROJECT=midcamp-org,LAGOON_ENVIRONMENT=production
- ddev start
- a whole bunch of ssh stuff to add a key to gitpod
- ddev pull lando ~fails~ success!

`ddev pull lagoon` is failing. Asked about it here:

https://discord.com/channels/664580571770388500/1130647712942014604/1173466093646532619