### PR TITLE
Feature/speaker prep

### DIFF
--- a/.ddev/.env.example
+++ b/.ddev/.env.example
@@ -1,0 +1,6 @@
+# Rename this file to .env and get the keys from 1Password
+# to test RECAPTCHA locally. `ddev start` to get them in the env.
+RECAPTCHA_SITE_KEY="in1Password"
+RECAPTCHA_SECRET_KEY="in1Password"
+RECAPTCHA_V3_SITE_KEY="in1Password"
+RECAPTCHA_V3_SECRET_KEY="in1Password"

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ styleguide/*.sass-cache/
 styleguide/source/code/css/*.css
 /.editorconfig
 /.gitattributes
+
+# Ignore Mac stuff
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Ignore Drupal settings and files
 settings.php
+settings.local.php
 services.yml
 services.local.yml
 !conf/drupal/settings.php
@@ -38,6 +39,3 @@ styleguide/*.sass-cache/
 styleguide/source/code/css/*.css
 /.editorconfig
 /.gitattributes
-
-# Ignore Mac stuff
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ services.local.yml
 !conf/drupal/services.yml
 web/sites/*/files
 web/sites/sites.php
+.ddev/.env
 
 # Ignore virtual environment and artifacts
 .vagrant/

--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,7 @@
         "drupal/quick_node_clone": "^1.16",
         "drupal/r4032login": "^2.1",
         "drupal/recaptcha": "^3.0",
+        "drupal/recaptcha_v3": "^2.0",
         "drupal/redirect": "^1.7",
         "drupal/scheduler": "^1.3",
         "drupal/simple_sitemap": "^3.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eaa00c9fbfec9673ad82e552e8d1749d",
+    "content-hash": "519c20c025619a30a30ff9604c91d4b8",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2812,6 +2812,60 @@
             "support": {
                 "source": "https://git.drupal.org/project/recaptcha.git",
                 "issues": "https://www.drupal.org/project/issues/recaptcha"
+            }
+        },
+        {
+            "name": "drupal/recaptcha_v3",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/recaptcha_v3.git",
+                "reference": "2.0.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/recaptcha_v3-2.0.1.zip",
+                "reference": "2.0.1",
+                "shasum": "f2226e4227d146df17d584b5307316da182f4e2a"
+            },
+            "require": {
+                "drupal/captcha": "*",
+                "drupal/core": "^9.5 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.1",
+                    "datestamp": "1692375692",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "B-Prod",
+                    "homepage": "https://www.drupal.org/user/407852"
+                },
+                {
+                    "name": "dench0",
+                    "homepage": "https://www.drupal.org/user/896504"
+                },
+                {
+                    "name": "majid.ali",
+                    "homepage": "https://www.drupal.org/user/1271330"
+                }
+            ],
+            "description": "The reCaptcha V3 module provides integration with Google reCaptcha V3 and CAPTCHA module.",
+            "homepage": "https://www.drupal.org/project/recaptcha_v3",
+            "support": {
+                "source": "https://git.drupalcode.org/project/recaptcha_v3",
+                "error": "require.drupal/captcha : invalid version constraint (Could not parse version constraint ^2.0': Invalid version string \"^2.0'\")"
             }
         },
         {

--- a/conf/drupal/config/block.block.hatter_addajobbutton.yml
+++ b/conf/drupal/config/block.block.hatter_addajobbutton.yml
@@ -13,7 +13,7 @@ dependencies:
 id: hatter_addajobbutton
 theme: hatter
 region: content
-weight: -14
+weight: -16
 provider: null
 plugin: 'block_content:de1557a6-167f-41a3-945d-05e977e71f1c'
 settings:

--- a/conf/drupal/config/block.block.hatter_content.yml
+++ b/conf/drupal/config/block.block.hatter_content.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_content
 theme: hatter
 region: content
-weight: -12
+weight: -14
 provider: null
 plugin: system_main_block
 settings:

--- a/conf/drupal/config/block.block.hatter_eventlabelblock.yml
+++ b/conf/drupal/config/block.block.hatter_eventlabelblock.yml
@@ -10,7 +10,7 @@ dependencies:
 id: hatter_eventlabelblock
 theme: hatter
 region: content
-weight: -21
+weight: -23
 provider: null
 plugin: event_label_block
 settings:

--- a/conf/drupal/config/block.block.hatter_help.yml
+++ b/conf/drupal/config/block.block.hatter_help.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_help
 theme: hatter
 region: content
-weight: -24
+weight: -26
 provider: null
 plugin: help_block
 settings:

--- a/conf/drupal/config/block.block.hatter_local_actions.yml
+++ b/conf/drupal/config/block.block.hatter_local_actions.yml
@@ -9,7 +9,7 @@ _core:
 id: hatter_local_actions
 theme: hatter
 region: content
-weight: -13
+weight: -15
 provider: null
 plugin: local_actions_block
 settings:

--- a/conf/drupal/config/block.block.hatter_messages.yml
+++ b/conf/drupal/config/block.block.hatter_messages.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_messages
 theme: hatter
 region: content
-weight: -23
+weight: -25
 provider: null
 plugin: system_messages_block
 settings:

--- a/conf/drupal/config/block.block.hatter_midcamp2019.yml
+++ b/conf/drupal/config/block.block.hatter_midcamp2019.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_midcamp2019
 theme: hatter
 region: content
-weight: -25
+weight: -27
 provider: null
 plugin: 'block_content:718a2f09-3a75-462a-9c04-3e21f78a81bb'
 settings:

--- a/conf/drupal/config/block.block.hatter_page_title.yml
+++ b/conf/drupal/config/block.block.hatter_page_title.yml
@@ -11,7 +11,7 @@ _core:
 id: hatter_page_title
 theme: hatter
 region: content
-weight: -15
+weight: -17
 provider: null
 plugin: page_title_block
 settings:

--- a/conf/drupal/config/block.block.hatter_tabs.yml
+++ b/conf/drupal/config/block.block.hatter_tabs.yml
@@ -7,7 +7,7 @@ dependencies:
 id: hatter_tabs
 theme: hatter
 region: content
-weight: -22
+weight: -24
 provider: null
 plugin: local_tasks_block
 settings:

--- a/conf/drupal/config/block.block.hatter_training_feedback_form.yml
+++ b/conf/drupal/config/block.block.hatter_training_feedback_form.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_training_feedback_form
 theme: hatter
 region: content
-weight: 2
+weight: -1
 provider: null
 plugin: webform_block
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__attendees_block_2.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__attendees_block_2.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_views_block__attendees_block_2
 theme: hatter
 region: content
-weight: 7
+weight: 4
 provider: null
 plugin: 'views_block:attendees-block_2'
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__event_news_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_news_block_1.yml
@@ -11,7 +11,7 @@ dependencies:
 id: hatter_views_block__event_news_block_1
 theme: hatter
 region: content
-weight: -10
+weight: 9
 provider: null
 plugin: 'views_block:event_news-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_10.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_10.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_views_block__event_sponsors_block_10
 theme: hatter
 region: content
-weight: -4
+weight: -7
 provider: null
 plugin: 'views_block:event_sponsors-block_10'
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_11.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_11.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_views_block__event_sponsors_block_11
 theme: hatter
 region: content
-weight: -3
+weight: -6
 provider: null
 plugin: 'views_block:event_sponsors-block_11'
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_2.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_2.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_views_block__event_sponsors_block_2
 theme: hatter
 region: content
-weight: -6
+weight: -9
 provider: null
 plugin: 'views_block:event_sponsors-block_2'
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_3.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_3.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_views_block__event_sponsors_block_3
 theme: hatter
 region: content
-weight: -5
+weight: -8
 provider: null
 plugin: 'views_block:event_sponsors-block_3'
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_4.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_4.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_views_block__event_sponsors_block_4
 theme: hatter
 region: content
-weight: -9
+weight: -12
 provider: null
 plugin: 'views_block:event_sponsors-block_4'
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_5.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_5.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_views_block__event_sponsors_block_5
 theme: hatter
 region: content
-weight: -7
+weight: -10
 provider: null
 plugin: 'views_block:event_sponsors-block_5'
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_6.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_6.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_views_block__event_sponsors_block_6
 theme: hatter
 region: content
-weight: 6
+weight: 3
 provider: null
 plugin: 'views_block:event_sponsors-block_6'
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_7.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_7.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_views_block__event_sponsors_block_7
 theme: hatter
 region: content
-weight: 10
+weight: 8
 provider: null
 plugin: 'views_block:event_sponsors-block_7'
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_8.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_8.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_views_block__event_sponsors_block_8
 theme: hatter
 region: content
-weight: 5
+weight: 2
 provider: null
 plugin: 'views_block:event_sponsors-block_8'
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_9.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_sponsors_block_9.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_views_block__event_sponsors_block_9
 theme: hatter
 region: content
-weight: -8
+weight: -11
 provider: null
 plugin: 'views_block:event_sponsors-block_9'
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__event_venue_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_venue_block_1.yml
@@ -28,4 +28,4 @@ visibility:
     id: request_path
     negate: false
     context_mapping: {  }
-    pages: "/2018*\r\n/2023*"
+    pages: "/2018*\r\n/2023*\r\n/2024*"

--- a/conf/drupal/config/block.block.hatter_views_block__event_venue_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__event_venue_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_views_block__event_venue_block_1
 theme: hatter
 region: featured_bottom_first
-weight: 0
+weight: -27
 provider: null
 plugin: 'views_block:event_venue-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__jobs_board_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__jobs_board_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_views_block__jobs_board_block_1
 theme: hatter
 region: content
-weight: 3
+weight: 0
 provider: null
 plugin: 'views_block:jobs_board-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__speakers_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__speakers_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_views_block__speakers_block_1
 theme: hatter
 region: content
-weight: 0
+weight: -3
 provider: null
 plugin: 'views_block:speakers-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__summits_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__summits_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_views_block__summits_block_1
 theme: hatter
 region: content
-weight: 4
+weight: 1
 provider: null
 plugin: 'views_block:summits-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_views_block__training_block_1.yml
+++ b/conf/drupal/config/block.block.hatter_views_block__training_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_views_block__training_block_1
 theme: hatter
 region: content
-weight: 1
+weight: -2
 provider: null
 plugin: 'views_block:training-block_1'
 settings:

--- a/conf/drupal/config/block.block.hatter_webform.yml
+++ b/conf/drupal/config/block.block.hatter_webform.yml
@@ -12,7 +12,7 @@ dependencies:
 id: hatter_webform
 theme: hatter
 region: content
-weight: -2
+weight: -5
 provider: null
 plugin: webform_block
 settings:

--- a/conf/drupal/config/block.block.midcamp2021_2.yml
+++ b/conf/drupal/config/block.block.midcamp2021_2.yml
@@ -12,7 +12,7 @@ dependencies:
 id: midcamp2021_2
 theme: hatter
 region: content
-weight: 9
+weight: 7
 provider: null
 plugin: 'block_content:a54a0659-0ed4-46e8-afe3-55cdd97cd855'
 settings:

--- a/conf/drupal/config/block.block.midcamp2023fridayschedulenav.yml
+++ b/conf/drupal/config/block.block.midcamp2023fridayschedulenav.yml
@@ -12,7 +12,7 @@ dependencies:
 id: midcamp2023fridayschedulenav
 theme: hatter
 region: content
-weight: -16
+weight: -18
 provider: null
 plugin: 'block_content:1c8daa11-b2ca-45da-80ac-fd1fcf5a2c2a'
 settings:

--- a/conf/drupal/config/block.block.midcamp2023hybridschedulenav.yml
+++ b/conf/drupal/config/block.block.midcamp2023hybridschedulenav.yml
@@ -12,7 +12,7 @@ dependencies:
 id: midcamp2023hybridschedulenav
 theme: hatter
 region: content
-weight: -19
+weight: -21
 provider: null
 plugin: 'block_content:0cc50f48-a353-480d-adf3-688c49ca882e'
 settings:

--- a/conf/drupal/config/block.block.midcamp2023schedulenav.yml
+++ b/conf/drupal/config/block.block.midcamp2023schedulenav.yml
@@ -13,7 +13,7 @@ dependencies:
 id: midcamp2023schedulenav
 theme: hatter
 region: content
-weight: -20
+weight: -22
 provider: null
 plugin: 'block_content:e066b47a-a80d-432a-8edd-6c60b28b7c95'
 settings:

--- a/conf/drupal/config/block.block.midcamp2023survey.yml
+++ b/conf/drupal/config/block.block.midcamp2023survey.yml
@@ -12,7 +12,7 @@ dependencies:
 id: midcamp2023survey
 theme: hatter
 region: content
-weight: -26
+weight: 5
 provider: null
 plugin: 'block_content:1b4a7d99-7564-406a-ab3e-5cea2f34683a'
 settings:

--- a/conf/drupal/config/block.block.midcamp2023thursdayschedulenav.yml
+++ b/conf/drupal/config/block.block.midcamp2023thursdayschedulenav.yml
@@ -12,7 +12,7 @@ dependencies:
 id: midcamp2023thursdayschedulenav
 theme: hatter
 region: content
-weight: -17
+weight: -19
 provider: null
 plugin: 'block_content:8fda6051-e288-4faf-8315-99e9cad4903a'
 settings:

--- a/conf/drupal/config/block.block.midcamp2023wednesdayschedulenav.yml
+++ b/conf/drupal/config/block.block.midcamp2023wednesdayschedulenav.yml
@@ -12,7 +12,7 @@ dependencies:
 id: midcamp2023wednesdayschedulenav
 theme: hatter
 region: content
-weight: -18
+weight: -20
 provider: null
 plugin: 'block_content:daf73e2b-f395-4c62-8e60-15afec11e174'
 settings:

--- a/conf/drupal/config/block.block.midcamp2024navigation.yml
+++ b/conf/drupal/config/block.block.midcamp2024navigation.yml
@@ -25,5 +25,5 @@ settings:
 visibility:
   request_path:
     id: request_path
-    negate: true
-    pages: "/2018*\r\n/2019*\r\n/2020*\r\n/2021*\r\n/2023*"
+    negate: false
+    pages: "/2024/*\r\n/2024"

--- a/conf/drupal/config/block.block.views_block__live_sessions_block_1_2.yml
+++ b/conf/drupal/config/block.block.views_block__live_sessions_block_1_2.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__live_sessions_block_1_2
 theme: hatter
 region: content
-weight: 8
+weight: 6
 provider: null
 plugin: 'views_block:live_sessions-block_1'
 settings:

--- a/conf/drupal/config/block.block.views_block__schedule_2023_short_url.yml
+++ b/conf/drupal/config/block.block.views_block__schedule_2023_short_url.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__schedule_2023_short_url
 theme: hatter
 region: content
-weight: -11
+weight: -13
 provider: null
 plugin: 'views_block:schedule_2023-short_url'
 settings:

--- a/conf/drupal/config/block.block.webform.yml
+++ b/conf/drupal/config/block.block.webform.yml
@@ -12,7 +12,7 @@ dependencies:
 id: webform
 theme: hatter
 region: content
-weight: -1
+weight: -4
 provider: null
 plugin: webform_block
 settings:

--- a/conf/drupal/config/captcha.captcha_point.node_topic_form.yml
+++ b/conf/drupal/config/captcha.captcha_point.node_topic_form.yml
@@ -1,6 +1,6 @@
 uuid: 284415b5-c134-4496-8e09-72a2400fc8ba
 langcode: en
-status: false
+status: true
 dependencies: {  }
 formId: node_topic_form
 captchaType: default

--- a/conf/drupal/config/captcha.captcha_point.user_login_form.yml
+++ b/conf/drupal/config/captcha.captcha_point.user_login_form.yml
@@ -1,6 +1,6 @@
 uuid: fd62e165-b692-4686-b488-33313dadc3a1
 langcode: en
-status: true
+status: false
 dependencies: {  }
 _core:
   default_config_hash: crLwyc9uwZ8Bv8lpMLIOEQYHOxW_mS49jaDf_95-o4I

--- a/conf/drupal/config/captcha.captcha_point.user_login_form.yml
+++ b/conf/drupal/config/captcha.captcha_point.user_login_form.yml
@@ -1,6 +1,6 @@
 uuid: fd62e165-b692-4686-b488-33313dadc3a1
 langcode: en
-status: false
+status: true
 dependencies: {  }
 _core:
   default_config_hash: crLwyc9uwZ8Bv8lpMLIOEQYHOxW_mS49jaDf_95-o4I

--- a/conf/drupal/config/captcha.captcha_point.user_register_form.yml
+++ b/conf/drupal/config/captcha.captcha_point.user_register_form.yml
@@ -5,5 +5,5 @@ dependencies: {  }
 _core:
   default_config_hash: O11nB9Assnic6AhIuaeK_CQdh_zO0udxABDnUZJupis
 formId: user_register_form
-captchaType: recaptcha/reCAPTCHA
+captchaType: default
 label: 'User register form'

--- a/conf/drupal/config/captcha.settings.yml
+++ b/conf/drupal/config/captcha.settings.yml
@@ -1,7 +1,7 @@
 _core:
   default_config_hash: _UaIWu0_ZD3lUs97wlFC2Koi-o7Bex69Xr9q36nJtkY
 enabled_default: 0
-default_challenge: recaptcha/reCAPTCHA
+default_challenge: recaptcha_v3/v3_with_fallback
 description: 'This question is for testing whether or not you are a human visitor and to prevent automated spam submissions.'
 administration_mode: false
 allow_on_admin_pages: false

--- a/conf/drupal/config/core.entity_view_display.taxonomy_term.event.default.yml
+++ b/conf/drupal/config/core.entity_view_display.taxonomy_term.event.default.yml
@@ -14,9 +14,6 @@ dependencies:
     - field.field.taxonomy_term.event.field_tito_slug
     - taxonomy.vocabulary.event
   module:
-    - datetime_range
-    - image
-    - link
     - text
 id: taxonomy_term.event.default
 targetEntityType: taxonomy_term
@@ -30,63 +27,13 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
-  field_banner_cta_anonymous:
-    type: link
-    label: above
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
-    third_party_settings: {  }
-    weight: 4
-    region: content
-  field_banner_cta_authenticated:
-    type: link
-    label: above
-    settings:
-      trim_length: 80
-      url_only: false
-      url_plain: false
-      rel: ''
-      target: ''
-    third_party_settings: {  }
-    weight: 5
-    region: content
-  field_date:
-    type: daterange_default
-    label: above
-    settings:
-      timezone_override: ''
-      format_type: long
-      separator: '-'
-    third_party_settings: {  }
-    weight: 2
-    region: content
-  field_date_has_time:
-    type: boolean
-    label: above
-    settings:
-      format: default
-      format_custom_false: ''
-      format_custom_true: ''
-    third_party_settings: {  }
-    weight: 3
-    region: content
-  field_image:
-    type: image
-    label: above
-    settings:
-      image_link: ''
-      image_style: ''
-      image_loading:
-        attribute: lazy
-    third_party_settings: {  }
-    weight: 1
-    region: content
 hidden:
+  field_banner_cta_anonymous: true
+  field_banner_cta_authenticated: true
+  field_date: true
+  field_date_has_time: true
   field_event_id: true
   field_event_status: true
+  field_image: true
   field_social_media: true
   field_tito_slug: true

--- a/conf/drupal/config/core.extension.yml
+++ b/conf/drupal/config/core.extension.yml
@@ -68,6 +68,7 @@ module:
   r4032login: 0
   rdf: 0
   recaptcha: 0
+  recaptcha_v3: 0
   redirect: 0
   scheduler: 0
   search: 0

--- a/conf/drupal/config/node.type.venue.yml
+++ b/conf/drupal/config/node.type.venue.yml
@@ -8,8 +8,8 @@ dependencies:
 third_party_settings:
   menu_ui:
     available_menus:
-      - midcamp-2023-navigation
-    parent: 'midcamp-2023-navigation:'
+      - midcamp-2024-navigation
+    parent: 'midcamp-2024-navigation:'
   scheduler:
     expand_fieldset: when_required
     fields_display_mode: vertical_tab

--- a/conf/drupal/config/recaptcha.settings.yml
+++ b/conf/drupal/config/recaptcha.settings.yml
@@ -1,5 +1,7 @@
 _core:
   default_config_hash: eKR4FfUD7Cp3bXamsCz6GAxh0PCLIZNMa65y2kChIh0
+site_key: 6Ldwbj0UAAAAABC0HLdWEfh6-9yjq_6_sg-Mtadd
+secret_key: 6Ldwbj0UAAAAAAtoEeqb_dyysasQJ-KYAOaAGQqu
 verify_hostname: false
 use_globally: false
 widget:

--- a/conf/drupal/config/recaptcha.settings.yml
+++ b/conf/drupal/config/recaptcha.settings.yml
@@ -1,7 +1,7 @@
 _core:
   default_config_hash: eKR4FfUD7Cp3bXamsCz6GAxh0PCLIZNMa65y2kChIh0
-site_key: 6Ldwbj0UAAAAABC0HLdWEfh6-9yjq_6_sg-Mtadd
-secret_key: 6Ldwbj0UAAAAAAtoEeqb_dyysasQJ-KYAOaAGQqu
+site_key: 'in environment variables'
+secret_key: 'in environment variables'
 verify_hostname: false
 use_globally: false
 widget:

--- a/conf/drupal/config/recaptcha_v3.recaptcha_v3_action.v3_with_fallback.yml
+++ b/conf/drupal/config/recaptcha_v3.recaptcha_v3_action.v3_with_fallback.yml
@@ -1,0 +1,8 @@
+uuid: 7d9c2bd1-81b7-40cb-b104-629631cbf524
+langcode: en
+status: true
+dependencies: {  }
+id: v3_with_fallback
+label: 'v3 with fallback'
+threshold: 0.5
+challenge: recaptcha/reCAPTCHA

--- a/conf/drupal/config/recaptcha_v3.settings.yml
+++ b/conf/drupal/config/recaptcha_v3.settings.yml
@@ -1,8 +1,8 @@
 _core:
   default_config_hash: ae8AQLsAFXvfcLPmE4YUBcxThAqf7psqRTHzhccslls
-site_key: 6LetCxUpAAAAAJLcJycGGF5OrCRUpZpe2i6zcfPA
-secret_key: 6LetCxUpAAAAAGFwzsE024dUtM7Cv9GlyJyw4qWo
-hide_badge: false
+site_key: 'in environment variables'
+secret_key: 'in environment variables'
+hide_badge: true
 verify_hostname: true
 default_challenge: recaptcha/reCAPTCHA
 error_message: 'Antibot verification failed.'

--- a/conf/drupal/config/recaptcha_v3.settings.yml
+++ b/conf/drupal/config/recaptcha_v3.settings.yml
@@ -1,0 +1,10 @@
+_core:
+  default_config_hash: ae8AQLsAFXvfcLPmE4YUBcxThAqf7psqRTHzhccslls
+site_key: 6LetCxUpAAAAAJLcJycGGF5OrCRUpZpe2i6zcfPA
+secret_key: 6LetCxUpAAAAAGFwzsE024dUtM7Cv9GlyJyw4qWo
+hide_badge: false
+verify_hostname: true
+default_challenge: recaptcha/reCAPTCHA
+error_message: 'Antibot verification failed.'
+cacheable: false
+library_use_recaptcha_net: false

--- a/conf/drupal/config/user.settings.yml
+++ b/conf/drupal/config/user.settings.yml
@@ -12,7 +12,7 @@ notify:
   register_admin_created: true
   register_no_approval_required: true
   register_pending_approval: true
-register: admin_only
+register: visitors
 cancel_method: user_cancel_block_unpublish
 password_reset_timeout: 86400
 password_strength: true

--- a/web/sites/default/all.settings.php
+++ b/web/sites/default/all.settings.php
@@ -16,3 +16,13 @@ $settings['file_private_path'] = 'sites/default/files/private';
 if (getenv('MAILCHIMP_API_KEY')) {
   $config['mailchimp.settings']['api_key'] = getenv('MAILCHIMP_API_KEY');
 }
+
+if (getenv('RECAPTCHA_SITE_KEY') && getenv('RECAPTCHA_SECRET_KEY')){
+  $config['recaptcha.settings']['site_key'] = getenv('RECAPTCHA_SITE_KEY');
+  $config['recaptcha.settings']['secret_key'] = getenv('RECAPTCHA_SECRET_KEY');
+}
+
+if (getenv('RECAPTCHA_V3_SITE_KEY') && getenv('RECAPTCHA_V3_SECRET_KEY')) {
+  $config['recaptcha_v3.settings']['site_key'] = getenv('RECAPTCHA_V3_SITE_KEY');
+  $config['recaptcha_v3.settings']['secret_key'] = getenv('RECAPTCHA_V3_SECRET_KEY');
+}

--- a/web/sites/development.services.yml
+++ b/web/sites/development.services.yml
@@ -4,6 +4,8 @@
 # 'example.settings.local.php' file, which sits next to this file.
 parameters:
   http.response.debug_cacheability_headers: true
+  twig.config:
+    debug: true
 services:
   cache.backend.null:
     class: Drupal\Core\Cache\NullBackendFactory

--- a/web/themes/custom/hatter/hatter.theme
+++ b/web/themes/custom/hatter/hatter.theme
@@ -172,6 +172,20 @@ function hatter_preprocess_block(&$variables) {
       $site_config = \Drupal::config('system.site');
       $variables['site_slogan'] = $site_config->get('slogan');
       break;
+    case 'system_branding_block':
+      $term = \Drupal::routeMatch()->getParameter('taxonomy_term');
+      if ($term instanceof \Drupal\taxonomy\Entity\Term) {
+        if ($variables['user']->isAnonymous()) {
+          $variables['button']['title'] = $term->field_banner_cta_anonymous->__get('title');
+          $variables['button']['uri'] = $term->field_banner_cta_anonymous->__get('uri');
+        }
+        else {
+          $variables['button']['title'] = $term->field_banner_cta_authenticated->__get('title');
+          $variables['button']['uri'] = $term->field_banner_cta_authenticated->__get('uri');
+        }
+
+      }
+      break;
   }
 }
 

--- a/web/themes/custom/hatter/templates/block/block--system-branding-block.html.twig
+++ b/web/themes/custom/hatter/templates/block/block--system-branding-block.html.twig
@@ -29,6 +29,9 @@
           <h2 class="event__subtitle">{{ site_slogan }}</h2>
           {# <a href="/submit-session" class="event__button button--primary">Submit a Session</a> #}
           {# <a href="https://mid.camp/tickets/" class="event__button button--primary">Register</a> #}
+          {% if button.title and button.uri %}
+            {{ link(button.title, button.uri, create_attribute({'class': ['event__button', 'button--primary']})) }}
+          {% endif %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Add all the recaptchas
  - Prob not good storing the API keys in config in the public repo, but they're here now... permissions are restricted to our domains, so... 🤷 ?
- Wire up the buttons!!!
  - to test: 
    - add an anon/auth button on terms/2024
    - PROFIT!
- Enable the term description field to work so that we don't need a block there
  - to test: 
    - Add some stuff in the term/description
    - See it on the homepage

Log in and then check https://nginx.feature-speaker-prep.midcamp-org.us2.amazee.io/admin/config/people/captcha/examples to see both CAPTCHAs are working with the environment variables!