### PR TITLE
Allow rendering referenced users without elevated permissions

### DIFF
--- a/conf/drupal/config/core.entity_view_display.node.summit.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.summit.default.yml
@@ -28,7 +28,7 @@ content:
     weight: 1
     region: content
   field_people:
-    type: entity_reference_entity_view
+    type: midcamp_utility_bypass_access_entity_reference
     label: above
     settings:
       view_mode: compact

--- a/conf/drupal/config/core.entity_view_display.node.topic.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.topic.default.yml
@@ -69,7 +69,7 @@ content:
     weight: 9
     region: content
   field_people:
-    type: entity_reference_entity_view
+    type: midcamp_utility_bypass_access_entity_reference
     label: above
     settings:
       view_mode: compact

--- a/conf/drupal/config/core.entity_view_display.node.topic.full.yml
+++ b/conf/drupal/config/core.entity_view_display.node.topic.full.yml
@@ -111,7 +111,7 @@ content:
     weight: 9
     region: content
   field_people:
-    type: entity_reference_entity_view
+    type: midcamp_utility_bypass_access_entity_reference
     label: above
     settings:
       view_mode: compact

--- a/conf/drupal/config/core.entity_view_display.node.training.default.yml
+++ b/conf/drupal/config/core.entity_view_display.node.training.default.yml
@@ -30,7 +30,7 @@ content:
     weight: 1
     region: content
   field_people:
-    type: entity_reference_entity_view
+    type: midcamp_utility_bypass_access_entity_reference
     label: above
     settings:
       view_mode: compact

--- a/web/modules/custom/midcamp_utility/src/Plugin/Field/FieldFormatter/BypassAccessEntityReferenceFormatter.php
+++ b/web/modules/custom/midcamp_utility/src/Plugin/Field/FieldFormatter/BypassAccessEntityReferenceFormatter.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\midcamp_utility\Plugin\Field\FieldFormatter;
+
+use Drupal\Core\Entity\TranslatableInterface;
+use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
+use Drupal\Core\Field\Plugin\Field\FieldFormatter\EntityReferenceEntityFormatter;
+
+/**
+ * Plugin implementation of the 'entity reference rendered entity' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "midcamp_utility_bypass_access_entity_reference",
+ *   label = @Translation("Rendered entity (bypass access)"),
+ *   description = @Translation("Display the referenced entities rendered by entity_view() without access checks."),
+ *   field_types = {
+ *     "entity_reference"
+ *   }
+ * )
+ */
+final class BypassAccessEntityReferenceFormatter extends EntityReferenceEntityFormatter {
+
+  protected function getEntitiesToView(EntityReferenceFieldItemListInterface $items, $langcode) {
+    $entities = [];
+
+    foreach ($items as $delta => $item) {
+      // Ignore items where no entity could be loaded in prepareView().
+      if (!empty($item->_loaded)) {
+        $entity = $item->entity;
+
+        // Set the entity in the correct language for display.
+        if ($entity instanceof TranslatableInterface) {
+          $entity = \Drupal::service('entity.repository')->getTranslationFromContext($entity, $langcode);
+        }
+
+        $entity->_referringItem = $items[$delta];
+        $entities[$delta] = $entity;
+      }
+    }
+
+    return $entities;
+  }
+
+}


### PR DESCRIPTION
I couldn't get the site to install using `drush si --existing-config`. So I manually updated a few entity view displays to use the formatter. I could not manually test.
