### PR TITLE
Stop building solr to snuff the warnings since we're not using it

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,16 +89,16 @@ services:
 
 
 
-
-  solr:
-    image: amazeeio/solr:6.6-drupal
-    labels:
-      lagoon.type: solr
-      lando.type: lagoon-solr
-    ports:
-      - "8983" # exposes the port 8983 with a random local port, find it with `docker-compose port solr 8983`
-    environment:
-      << : *default-environment
+  # We're not using solr at the moment, so let's just save the bits.
+  # solr:
+  #   image: amazeeio/solr:6.6-drupal
+  #   labels:
+  #     lagoon.type: solr
+  #     lando.type: lagoon-solr
+  #   ports:
+  #     - "8983" # exposes the port 8983 with a random local port, find it with `docker-compose port solr 8983`
+  #   environment:
+  #     << : *default-environment
 
 
   varnish:


### PR DESCRIPTION
Amazee builds are throwing a warning:

```
>> Lagoon detected deprecated images during the build
  This indicates that an image you're using in the build has been flagged as deprecated.
  You should stop using these images as soon as possible.
  If the deprecated image has a suggested replacement, it will be mentioned in the warning.
  Please visit https://docs.lagoon.sh/deprecated-images for more information.

>> The image (or an image used in the build for) amazeeio/solr:6.6-drupal has been deprecated, marked endoflife
  A suggested replacement image is uselagoon/solr-9-drupal
```

we're not using solr at the moment (afaik, unless there's some dark magic involved that doesn't use search_api), so just commenting out the image for now.